### PR TITLE
Add SC Tests/Fixtures and some SC changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,36 @@
-# Config file for automatic testing at travis-ci.org
+dist: trusty
+sudo: true
+language: generic
 
-language: python
-python:
-  - 3.6
 
-# Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -r requirements.txt
+jobs:
+  include:
+    - language: python
+      if: type = pull_request
+      python: '3.5'
+      env:
+        - TEST_TYPE=core-contracts
+        - SOLC_URL='https://github.com/ethereum/solidity/releases/download/v0.4.19/solc-static-linux'
+        - SOLC_VERSION='v0.4.19'
 
-# Command to run tests, e.g. python setup.py test
-script: true
+      cache:
+        pip: true
+        directories:
+          - $HOME/.cache/pip
+
+      before_install:
+            - mkdir -p $HOME/.bin
+            - export PATH=$PATH:$HOME/.bin
+            - ./.travis/download_solc.sh
+
+      install:
+        - pip install -U pip wheel coveralls "coverage<4.4"
+        - pip install pytest-travis-fold
+        - pip install flake8
+        - pip install -r requirements.txt
+
+      before_script:
+        - flake8 raiden_contracts/
+
+      script:
+        - coverage run --source raiden_contracts/ -m py.test --populus-project 'contracts/' -k-needs_xorg --travis-fold=always -vvvvvvvvs $TEST_TYPE

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
       if: type = pull_request
       python: '3.5'
       env:
-        - TEST_TYPE=core-contracts
+        - TEST_TYPE=contracts
         - SOLC_URL='https://github.com/ethereum/solidity/releases/download/v0.4.19/solc-static-linux'
         - SOLC_VERSION='v0.4.19'
 
@@ -33,4 +33,4 @@ jobs:
         - flake8 raiden_contracts/
 
       script:
-        - coverage run --source raiden_contracts/ -m py.test --populus-project 'contracts/' -k-needs_xorg --travis-fold=always -vvvvvvvvs $TEST_TYPE
+        - coverage run --source raiden_contracts/ -m py.test --populus-project '.' -k-needs_xorg --travis-fold=always -vvvvvvvvs $TEST_TYPE

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
       if: type = pull_request
       python: '3.5'
       env:
-        - TEST_TYPE=contracts
+        - TEST_TYPE=raiden_contracts
         - SOLC_URL='https://github.com/ethereum/solidity/releases/download/v0.4.19/solc-static-linux'
         - SOLC_VERSION='v0.4.19'
 
@@ -33,4 +33,4 @@ jobs:
         - flake8 raiden_contracts/
 
       script:
-        - coverage run --source raiden_contracts/ -m py.test --populus-project '.' -k-needs_xorg --travis-fold=always -vvvvvvvvs $TEST_TYPE
+        - coverage run --source raiden_contracts/ -m py.test --travis-fold=always $TEST_TYPE

--- a/.travis/download_solc.sh
+++ b/.travis/download_solc.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -o xtrace
+
+set -e
+
+fail() {
+    if [[ $- == *i* ]]; then
+       red=`tput setaf 1`
+       reset=`tput sgr0`
+
+       echo "${red}==> ${@}${reset}"
+    fi
+    exit 1
+}
+
+info() {
+    if [[ $- == *i* ]]; then
+        blue=`tput setaf 4`
+        reset=`tput sgr0`
+
+        echo "${blue}${@}${reset}"
+    fi
+}
+
+success() {
+    if [[ $- == *i* ]]; then
+        green=`tput setaf 2`
+        reset=`tput sgr0`
+        echo "${green}${@}${reset}"
+    fi
+
+}
+
+warn() {
+    if [[ $- == *i* ]]; then
+        yellow=`tput setaf 3`
+        reset=`tput sgr0`
+
+        echo "${yellow}${@}${reset}"
+    fi
+}
+
+[ -z "${SOLC_URL}" ] && fail 'missing SOLC_URL'
+[ -z "${SOLC_VERSION}" ] && fail 'missing SOLC_VERSION'
+
+if [ ! -x $HOME/.bin/solc-${SOLC_VERSION} ]; then
+    mkdir -p $HOME/.bin
+
+    curl -L $SOLC_URL > $HOME/.bin/solc-${SOLC_VERSION}
+    chmod 775 $HOME/.bin/solc-${SOLC_VERSION}
+
+    success "solc ${SOLC_VERSION} installed"
+else
+    info 'using cached solc'
+fi
+
+# always recreate the symlink since we dont know if it's pointing to a different
+# version
+[ -h $HOME/.bin/solc ] && unlink $HOME/.bin/solc
+ln -s $HOME/.bin/solc-${SOLC_VERSION} $HOME/.bin/solc

--- a/README.md
+++ b/README.md
@@ -18,19 +18,23 @@ pip install -r requirements.txt
 
 ## Deployment on a testnet
 
+! You need to have the compiled contract data first. You can run `populus compile` for that.
+
 ```
 # Following calls are equivalent
 
 python -m deploy
 
-python -m deploy.deploy_testnet \
-       --chain ropsten \
+python -m deploy \
+       --rpc-provider http://127.0.0.1:8545 \
+       --json build/contracts.json
        --owner 0x5601Ea8445A5d96EEeBF89A67C4199FbB7a43Fbb \
+       --wait 300 \
        --token-name CustomToken --token-symbol TKN \
        --supply 10000000 --token-decimals 18
 
 # Provide a custom deployed token
-python -m deploy.deploy_testnet --token-address <TOKEN_ADDRESS>
+python -m deploy --token-address <TOKEN_ADDRESS>
 
 ```
 
@@ -42,7 +46,7 @@ populus compile
 # tests
 pytest
 pytest -p no:warnings -s
-pytest tests/test_token_network.py -p no:warnings -s
+pytest raiden_contracts/tests/test_token_network.py -p no:warnings -s
 
 # Recommended for speed:
 pip install pytest-xdist==1.17.1

--- a/contracts/SecretRegistry.sol
+++ b/contracts/SecretRegistry.sol
@@ -9,8 +9,7 @@ contract SecretRegistry {
     string constant public contract_version = "0.3._";
 
     // Secret => block number at which the secret was revealed
-    // uint64 is sufficient to represent 8774136260326 years with blocks of 15s.
-    mapping(bytes32 => uint64) public secret_to_block;
+    mapping(bytes32 => uint256) public secret_to_block;
 
     /*
      *  Events
@@ -22,7 +21,7 @@ contract SecretRegistry {
         if (secret_to_block[secret] > 0) {
             return false;
         }
-        secret_to_block[secret] = uint64(block.number);
+        secret_to_block[secret] = block.number;
         SecretRevealed(secret);
         return true;
     }

--- a/contracts/TokenNetwork.sol
+++ b/contracts/TokenNetwork.sol
@@ -581,8 +581,7 @@ contract TokenNetwork is Utils {
 
     }*/
 
-    function getChannelInfo(
-        uint256 channel_identifier)
+    function getChannelInfo(uint256 channel_identifier)
         view
         external
         returns (uint256, address, uint256)

--- a/contracts/TokenNetwork.sol
+++ b/contracts/TokenNetwork.sol
@@ -191,7 +191,8 @@ contract TokenNetwork is Utils {
     /// Can be called by anyone.
     /// @param channel_identifier The channel identifier - mapping key used for `channels`
     /// @param participant Channel participant who's deposit is being set.
-    /// @param total_deposit Idempotent function which sets the total amount of tokens that the participant will have as a deposit.
+    /// @param total_deposit Idempotent function which sets the total amount of
+    /// tokens that the participant will have as a deposit.
     function setDeposit(
         uint256 channel_identifier,
         address participant,
@@ -222,7 +223,8 @@ contract TokenNetwork is Utils {
     }
 
     /// @notice Close a channel between two parties that was used bidirectionally.
-    /// Only a participant may close the channel, providing a balance proof signed by its partner. Callable only once.
+    /// Only a participant may close the channel, providing a balance proof
+    /// signed by its partner. Callable only once.
     /// @param channel_identifier The channel identifier - mapping key used for `channels`
     /// @param nonce Strictly monotonic value used to order transfers.
     /// @param transferred_amount Total amount of tokens transferred by the channel partner
@@ -409,7 +411,8 @@ contract TokenNetwork is Utils {
         TransferUpdated(channel_identifier, closing_participant);
     }
 
-    /// @notice Registers the lock secret in the SecretRegistry contract. Unlocks a pending transfer and increases the partner's transferred amount
+    /// @notice Registers the lock secret in the SecretRegistry contract.
+    /// Unlocks a pending transfer and increases the partner's transferred amount
     /// with the transfer value. A lock can be unlocked only once per participant.
     // Anyone can call unlock a transfer on behalf of a channel participant.
     /// @param channel_identifier The channel identifier - mapping key used for `channels`.

--- a/contracts/TokenNetworksRegistry.sol
+++ b/contracts/TokenNetworksRegistry.sol
@@ -4,7 +4,7 @@ import "./Utils.sol";
 import "./Token.sol";
 import "./TokenNetwork.sol";
 
-contract TokenNetworkRegistry is Utils {
+contract TokenNetworksRegistry is Utils {
 
     /*
      *  Data structures
@@ -12,6 +12,7 @@ contract TokenNetworkRegistry is Utils {
 
     string constant public contract_version = "0.3._";
     address public secret_registry_address;
+    uint256 public chain_id;
 
     // Token address => TokenNetwork address
     mapping(address => address) public token_to_token_networks;
@@ -20,16 +21,18 @@ contract TokenNetworkRegistry is Utils {
      *  Events
      */
 
-    event TokenNetworkCreated(address token_address, address token_network_address);
+    event TokenNetworkRegistered(address token_address, address token_network_address);
 
     /*
      *  Constructor
      */
 
-    function TokenNetworkRegistry(address _secret_registry_address) public {
+    function TokenNetworksRegistry(address _secret_registry_address, uint256 _chain_id) public {
+        require(_chain_id > 0);
         require(_secret_registry_address != 0x0);
         require(contractExists(_secret_registry_address));
         secret_registry_address = _secret_registry_address;
+        chain_id = _chain_id;
     }
 
     /*
@@ -45,9 +48,10 @@ contract TokenNetworkRegistry is Utils {
 
         // Token contract checks are in the corresponding TokenNetwork contract
 
-        token_network_address = new TokenNetwork(_token_address, secret_registry_address);
+        token_network_address = new TokenNetwork(_token_address, secret_registry_address, chain_id);
+
         token_to_token_networks[_token_address] = token_network_address;
-        TokenNetworkCreated(_token_address, token_network_address);
+        TokenNetworkRegistered(_token_address, token_network_address);
 
         return token_network_address;
     }

--- a/contracts/TokenNetworksRegistry.sol
+++ b/contracts/TokenNetworksRegistry.sol
@@ -21,7 +21,7 @@ contract TokenNetworksRegistry is Utils {
      *  Events
      */
 
-    event TokenNetworkRegistered(address token_address, address token_network_address);
+    event TokenNetworkCreated(address token_address, address token_network_address);
 
     /*
      *  Constructor
@@ -51,7 +51,7 @@ contract TokenNetworksRegistry is Utils {
         token_network_address = new TokenNetwork(_token_address, secret_registry_address, chain_id);
 
         token_to_token_networks[_token_address] = token_network_address;
-        TokenNetworkRegistered(_token_address, token_network_address);
+        TokenNetworkCreated(_token_address, token_network_address);
 
         return token_network_address;
     }

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -1,22 +1,28 @@
 '''
-A simple Python script to deploy contracts.
+A simple Python script to deploy compiled contracts.
 '''
 import click
-from populus import Project
+import json
+from web3 import Web3, HTTPProvider
 from eth_utils import (
     is_address,
     to_checksum_address,
 )
-from utils.utils import (
+from raiden_contracts.utils.utils import (
     check_succesful_tx
 )
 
 
 @click.command()
 @click.option(
-    '--chain',
-    default='ropsten',
-    help='Chain to deploy on: kovan | ropsten | rinkeby | tester | privtest'
+    '--rpc-provider',
+    default="http://127.0.0.1:8545",
+    help='Address of the Ethereum RPC provider'
+)
+@click.option(
+    '--json',
+    default="build/contracts.json",
+    help='Path to compiled contracts data'
 )
 @click.option(
     '--owner',
@@ -46,10 +52,19 @@ from utils.utils import (
     '--token-address',
     help='Already deployed token address.'
 )
+@click.option(
+    '--wait',
+    default=300,
+    help='Token contract number of decimals.'
+)
+@click.option(
+    '--gas-price',
+    default=0,
+    help='Token contract number of decimals.'
+)
 def main(**kwargs):
-    project = Project()
-
-    chain_name = kwargs['chain']
+    rpc_provider = kwargs['rpc_provider']
+    json_file = kwargs['json']
     owner = kwargs['owner']
     supply = kwargs['supply']
     token_name = kwargs['token_name']
@@ -57,53 +72,69 @@ def main(**kwargs):
     token_symbol = kwargs['token_symbol']
     token_address = kwargs['token_address']
     supply *= 10**(token_decimals)
-    txn_wait = 300
+    txn_wait = kwargs['wait']
+    gas_price = kwargs['gas_price']
 
-    print('''Make sure {} chain is running, you can connect to it and it is synced,
-          or you'll get timeout'''.format(chain_name))
+    print('''Make sure chain is running, you can connect to it and it is synced,
+          or you'll get timeout''')
 
+    web3 = Web3(HTTPProvider(rpc_provider, request_kwargs={'timeout': 60}))
+    print('Web3 provider is', web3.providers[0])
 
-    with project.get_chain(chain_name) as chain:
-        web3 = chain.web3
-        print('Web3 provider is', web3.providers[0])
+    owner = owner or web3.eth.accounts[0]
+    assert owner and is_address(owner), 'Invalid owner provided.'
+    owner = to_checksum_address(owner)
+    print('Owner is', owner)
+    assert web3.eth.getBalance(owner) > 0, 'Account with insuficient funds.'
 
-        owner = owner or web3.eth.accounts[0]
-        assert owner and is_address(owner), 'Invalid owner provided.'
-        owner = to_checksum_address(owner)
-        print('Owner is', owner)
-        assert web3.eth.getBalance(owner) > 0, 'Account with insuficient funds.'
+    transaction={'from': owner}
+    if gas_price == 0:
+        transaction['gasPrice'] = gas_price
 
-        def deploy_contract(contract_name, args=[]):
-            contract = chain.provider.get_contract_factory(contract_name)
-            txhash = contract.deploy(
-                args=args,
-                transaction={'from': owner}
-            )
-            receipt = check_succesful_tx(chain.web3, txhash, txn_wait)
-            return receipt['contractAddress']
-
-        token = chain.provider.get_contract_factory('CustomToken')
+    with open(json_file) as json_data:
+        contracts_compiled_data = json.load(json_data)
 
         if not token_address:
-            txhash = token.deploy(
-                args=[supply, token_decimals, token_name, token_symbol],
-                transaction={'from': owner}
-            )
-            receipt = check_succesful_tx(chain.web3, txhash, txn_wait)
-            token_address = receipt['contractAddress']
+            token_address = deploy_contract(web3, contracts_compiled_data, 'CustomToken', transaction, txn_wait, [supply, token_decimals, token_name, token_symbol])
 
         assert token_address and is_address(token_address)
         token_address = to_checksum_address(token_address)
-        print(token_name, 'address is', token_address)
 
-        secret_registry_address = deploy_contract('SecretRegistry')
-        print('SecretRegistry address:', secret_registry_address)
+        secret_registry_address = deploy_contract(web3, contracts_compiled_data, 'SecretRegistry', transaction, txn_wait)
 
-        token_network_registry_address = deploy_contract('TokenNetworkRegistry', [secret_registry_address])
-        print('TokenNetworkRegistry address:', token_network_registry_address)
+        token_network_registry_address = deploy_contract(web3, contracts_compiled_data, 'TokenNetworksRegistry', transaction, txn_wait, [secret_registry_address, int(web3.version.network)])
 
-        token_network_address = deploy_contract('TokenNetwork', [token_address, secret_registry_address])
-        print('TokenNetwork address:', token_network_address)
+        token_network_registry = instantiate_contract(web3, contracts_compiled_data, 'TokenNetworksRegistry', token_network_registry_address)
+
+        txhash = token_network_registry.transact(transaction).createERC20TokenNetwork(token_address)
+        receipt = check_succesful_tx(web3, txhash, txn_wait)
+
+        print('TokenNetwork address: {0}. Gas used: {1}'.format(
+            token_network_registry.call().token_to_token_networks(token_address),
+            receipt['gasUsed'])
+        )
+
+
+def instantiate_contract(web3, contracts_compiled_data, contract_name, contract_address):
+    contract_interface = contracts_compiled_data[contract_name]
+
+    contract = web3.eth.contract(abi=contract_interface['abi'], bytecode=contract_interface['bytecode'], address=contract_address)
+
+    return contract
+
+def deploy_contract(web3, contracts_compiled_data, contract_name, transaction, txn_wait=200, args=[]):
+    contract_interface = contracts_compiled_data[contract_name]
+
+    # Instantiate and deploy contract
+    contract = web3.eth.contract(abi=contract_interface['abi'], bytecode=contract_interface['bytecode'])
+
+    # Get transaction hash from deployed contract
+    txhash = contract.deploy(transaction=transaction, args=args)
+
+    # Get tx receipt to get contract address
+    receipt = check_succesful_tx(web3, txhash, txn_wait)
+    print('{0} address: {1}. Gas used: {2}'.format(contract_name, receipt['contractAddress'], receipt['gasUsed']))
+    return receipt['contractAddress']
 
 
 if __name__ == '__main__':

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -16,12 +16,12 @@ from raiden_contracts.utils.utils import (
 @click.command()
 @click.option(
     '--rpc-provider',
-    default="http://127.0.0.1:8545",
+    default='http://127.0.0.1:8545',
     help='Address of the Ethereum RPC provider'
 )
 @click.option(
     '--json',
-    default="build/contracts.json",
+    default='build/contracts.json',
     help='Path to compiled contracts data'
 )
 @click.option(
@@ -87,7 +87,7 @@ def main(**kwargs):
     print('Owner is', owner)
     assert web3.eth.getBalance(owner) > 0, 'Account with insuficient funds.'
 
-    transaction={'from': owner}
+    transaction = {'from': owner}
     if gas_price == 0:
         transaction['gasPrice'] = gas_price
 
@@ -95,18 +95,45 @@ def main(**kwargs):
         contracts_compiled_data = json.load(json_data)
 
         if not token_address:
-            token_address = deploy_contract(web3, contracts_compiled_data, 'CustomToken', transaction, txn_wait, [supply, token_decimals, token_name, token_symbol])
+            token_address = deploy_contract(
+                web3,
+                contracts_compiled_data,
+                'CustomToken',
+                transaction,
+                txn_wait,
+                [supply, token_decimals, token_name, token_symbol]
+            )
 
         assert token_address and is_address(token_address)
         token_address = to_checksum_address(token_address)
 
-        secret_registry_address = deploy_contract(web3, contracts_compiled_data, 'SecretRegistry', transaction, txn_wait)
+        secret_registry_address = deploy_contract(
+            web3,
+            contracts_compiled_data,
+            'SecretRegistry',
+            transaction,
+            txn_wait
+        )
 
-        token_network_registry_address = deploy_contract(web3, contracts_compiled_data, 'TokenNetworksRegistry', transaction, txn_wait, [secret_registry_address, int(web3.version.network)])
+        token_network_registry_address = deploy_contract(
+            web3,
+            contracts_compiled_data,
+            'TokenNetworksRegistry',
+            transaction,
+            txn_wait,
+            [secret_registry_address, int(web3.version.network)]
+        )
 
-        token_network_registry = instantiate_contract(web3, contracts_compiled_data, 'TokenNetworksRegistry', token_network_registry_address)
+        token_network_registry = instantiate_contract(
+            web3,
+            contracts_compiled_data,
+            'TokenNetworksRegistry',
+            token_network_registry_address
+        )
 
-        txhash = token_network_registry.transact(transaction).createERC20TokenNetwork(token_address)
+        txhash = token_network_registry.transact(transaction).createERC20TokenNetwork(
+            token_address
+        )
         receipt = check_succesful_tx(web3, txhash, txn_wait)
 
         print('TokenNetwork address: {0}. Gas used: {1}'.format(
@@ -118,22 +145,41 @@ def main(**kwargs):
 def instantiate_contract(web3, contracts_compiled_data, contract_name, contract_address):
     contract_interface = contracts_compiled_data[contract_name]
 
-    contract = web3.eth.contract(abi=contract_interface['abi'], bytecode=contract_interface['bytecode'], address=contract_address)
+    contract = web3.eth.contract(
+        abi=contract_interface['abi'],
+        bytecode=contract_interface['bytecode'],
+        address=contract_address
+    )
 
     return contract
 
-def deploy_contract(web3, contracts_compiled_data, contract_name, transaction, txn_wait=200, args=[]):
+
+def deploy_contract(
+        web3,
+        contracts_compiled_data,
+        contract_name,
+        transaction,
+        txn_wait=200,
+        args=[]
+):
     contract_interface = contracts_compiled_data[contract_name]
 
     # Instantiate and deploy contract
-    contract = web3.eth.contract(abi=contract_interface['abi'], bytecode=contract_interface['bytecode'])
+    contract = web3.eth.contract(
+        abi=contract_interface['abi'],
+        bytecode=contract_interface['bytecode']
+    )
 
     # Get transaction hash from deployed contract
     txhash = contract.deploy(transaction=transaction, args=args)
 
     # Get tx receipt to get contract address
     receipt = check_succesful_tx(web3, txhash, txn_wait)
-    print('{0} address: {1}. Gas used: {2}'.format(contract_name, receipt['contractAddress'], receipt['gasUsed']))
+    print('{0} address: {1}. Gas used: {2}'.format(
+        contract_name,
+        receipt['contractAddress'],
+        receipt['gasUsed'])
+    )
     return receipt['contractAddress']
 
 

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -1,6 +1,6 @@
-'''
+"""
 A simple Python script to deploy compiled contracts.
-'''
+"""
 import click
 import json
 from web3 import Web3, HTTPProvider

--- a/raiden_contracts/tests/conftest.py
+++ b/raiden_contracts/tests/conftest.py
@@ -1,1 +1,1 @@
-from .fixtures import * # flake8: noqa
+from .fixtures import *  # flake8: noqa

--- a/raiden_contracts/tests/fixtures/__init__.py
+++ b/raiden_contracts/tests/fixtures/__init__.py
@@ -5,3 +5,4 @@ from .utils import *
 from .secret_registry import *
 from .token_network_registry import *
 from .token_network import *
+from .channel import *

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -1,8 +1,8 @@
 import pytest
 from raiden_contracts.utils.config import C_TOKEN_NETWORK, SETTLE_TIMEOUT_MIN
-from raiden_contracts.utils.sign import *
-from .token_network import *
-from .secret_registry import *
+from raiden_contracts.utils.sign import sign_balance_proof
+from .token_network import *  # flake8: noqa
+from .secret_registry import *  # flake8: noqa
 
 
 @pytest.fixture()
@@ -10,9 +10,9 @@ def create_channel(token_network):
     def get(A, B, settle_timeout=SETTLE_TIMEOUT_MIN):
         token_network.transact().openChannel(A, B, settle_timeout)
         channel_identifier = token_network.call().last_channel_index()
-        assert token_network.call().getChannelInfo(channel_identifier)[0] ==  settle_timeout
-        assert token_network.call().getChannelParticipantInfo(channel_identifier, A)[0] == True
-        assert token_network.call().getChannelParticipantInfo(channel_identifier, B)[0] == True
+        assert token_network.call().getChannelInfo(channel_identifier)[0] == settle_timeout
+        assert token_network.call().getChannelParticipantInfo(channel_identifier, A)[0] is True
+        assert token_network.call().getChannelParticipantInfo(channel_identifier, B)[0] is True
         return channel_identifier
     return get
 
@@ -29,14 +29,25 @@ def channel_deposit(token_network, custom_token):
 
         custom_token.transact({'from': participant}).approve(token_network.address, deposit)
 
-        txn_hash = token_network.transact({'from': participant}).setDeposit(channel_identifier, participant, deposit)
+        txn_hash = token_network.transact({'from': participant}).setDeposit(
+            channel_identifier,
+            participant,
+            deposit
+        )
         return txn_hash
     return get
 
 
 @pytest.fixture()
 def create_balance_proof(token_network, get_private_key):
-    def get(channel_identifier, participant, transferred_amount=0, nonce=0, locksroot=None, additional_hash=None):
+    def get(
+            channel_identifier,
+            participant,
+            transferred_amount=0,
+            nonce=0,
+            locksroot=None,
+            additional_hash=None
+    ):
         private_key = get_private_key(participant)
         locksroot = locksroot or b'\x00' * 32
         additional_hash = additional_hash or b'\x00' * 32
@@ -51,5 +62,12 @@ def create_balance_proof(token_network, get_private_key):
             locksroot,
             additional_hash
         )
-        return (channel_identifier, nonce, transferred_amount, locksroot, additional_hash, signature)
+        return (
+            channel_identifier,
+            nonce,
+            transferred_amount,
+            locksroot,
+            additional_hash,
+            signature
+        )
     return get

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -1,0 +1,55 @@
+import pytest
+from raiden_contracts.utils.config import C_TOKEN_NETWORK, SETTLE_TIMEOUT_MIN
+from raiden_contracts.utils.sign import *
+from .token_network import *
+from .secret_registry import *
+
+
+@pytest.fixture()
+def create_channel(token_network):
+    def get(A, B, settle_timeout=SETTLE_TIMEOUT_MIN):
+        token_network.transact().openChannel(A, B, settle_timeout)
+        channel_identifier = token_network.call().last_channel_index()
+        assert token_network.call().getChannelInfo(channel_identifier)[0] ==  settle_timeout
+        assert token_network.call().getChannelParticipantInfo(channel_identifier, A)[0] == True
+        assert token_network.call().getChannelParticipantInfo(channel_identifier, B)[0] == True
+        return channel_identifier
+    return get
+
+
+@pytest.fixture()
+def channel_deposit(token_network, custom_token):
+    def get(channel_identifier, participant, deposit=None):
+        balance = custom_token.call().balanceOf(participant)
+        deposit = deposit or balance
+
+        while balance < deposit:
+            custom_token.transact({'from': participant, 'value': 10 ** 18}).mint()
+            balance = custom_token.call().balanceOf(participant)
+
+        custom_token.transact({'from': participant}).approve(token_network.address, deposit)
+
+        txn_hash = token_network.transact({'from': participant}).setDeposit(channel_identifier, participant, deposit)
+        return txn_hash
+    return get
+
+
+@pytest.fixture()
+def create_balance_proof(token_network, get_private_key):
+    def get(channel_identifier, participant, transferred_amount=0, nonce=0, locksroot=None, additional_hash=None):
+        private_key = get_private_key(participant)
+        locksroot = locksroot or b'\x00' * 32
+        additional_hash = additional_hash or b'\x00' * 32
+
+        signature = sign_balance_proof(
+            private_key,
+            channel_identifier,
+            token_network.address,
+            int(token_network.call().chain_id()),
+            nonce,
+            transferred_amount,
+            locksroot,
+            additional_hash
+        )
+        return (channel_identifier, nonce, transferred_amount, locksroot, additional_hash, signature)
+    return get

--- a/raiden_contracts/tests/fixtures/config.py
+++ b/raiden_contracts/tests/fixtures/config.py
@@ -1,0 +1,15 @@
+raiden_contracts_version = '0.3.0'
+MAX_UINT256 = 2 ** 256 - 1
+MAX_UINT192 = 2 ** 192 - 1
+MAX_UINT32 = 2 ** 32 - 1
+fake_address = '0x03432'
+empty_address = '0x0000000000000000000000000000000000000000'
+passphrase = '0'
+
+
+def fake_hex(size, fill='00'):
+    return '0x' + ''.join([fill for i in range(0, size)])
+
+
+def fake_bytes(size, fill='00'):
+    return bytearray.fromhex(fake_hex(size, fill)[2:])

--- a/raiden_contracts/tests/fixtures/secret_registry.py
+++ b/raiden_contracts/tests/fixtures/secret_registry.py
@@ -14,9 +14,3 @@ def get_secret_registry(chain, create_contract):
 @pytest.fixture()
 def secret_registry(get_secret_registry):
     return get_secret_registry([])
-
-
-def check_secret_revealed(secret):
-    def get(event):
-        assert event['args']['secret'] == secret
-    return get

--- a/raiden_contracts/tests/fixtures/token.py
+++ b/raiden_contracts/tests/fixtures/token.py
@@ -1,10 +1,10 @@
 import pytest
 from raiden_contracts.utils.config import C_HUMAN_STANDARD_TOKEN, C_CUSTOM_TOKEN
-from .utils import *
+from .utils import *  # flake8: noqa
 
 token_args = [
     (10 ** 26, 18, 'CustomToken', 'TKN'),
-    (10 ** 26, 0, 'CustomToken', 'TKN')
+    # (10 ** 26, 0, 'CustomToken', 'TKN')
 ]
 
 

--- a/raiden_contracts/tests/fixtures/token.py
+++ b/raiden_contracts/tests/fixtures/token.py
@@ -1,5 +1,6 @@
 import pytest
 from raiden_contracts.utils.config import C_HUMAN_STANDARD_TOKEN, C_CUSTOM_TOKEN
+from .utils import *
 
 token_args = [
     (10 ** 26, 18, 'CustomToken', 'TKN'),

--- a/raiden_contracts/tests/fixtures/token_network.py
+++ b/raiden_contracts/tests/fixtures/token_network.py
@@ -12,5 +12,61 @@ def get_token_network(chain, create_contract):
 
 
 @pytest.fixture()
-def token_network(get_token_network, custom_token, secret_registry):
-    return get_token_network([custom_token.address, secret_registry.address])
+def token_network(chain, token_network_registry, custom_token, secret_registry):
+    token_network_address = token_network_registry.call().createERC20TokenNetwork(custom_token.address)
+    token_network_registry.transact().createERC20TokenNetwork(custom_token.address)
+
+    TokenNetwork = chain.provider.get_contract_factory(C_TOKEN_NETWORK)
+    token_network = chain.web3.eth.contract(address=token_network_address, ContractFactoryClass=TokenNetwork)
+
+    return token_network
+
+
+@pytest.fixture()
+def token_network_external(chain, get_token_network, custom_token, secret_registry):
+    return get_token_network([custom_token.address, secret_registry.address, int(chain.web3.version.network)])
+
+
+def check_channel_opened(channel_identifier, participant1, participant2, settle_timeout):
+    def get(event):
+        assert event['args']['channel_identifier'] == channel_identifier
+        assert event['args']['participant1'] == participant1
+        assert event['args']['participant2'] == participant2
+        assert event['args']['settle_timeout'] == settle_timeout
+    return get
+
+
+def check_new_deposit(channel_identifier, participant, deposit):
+    def get(event):
+        assert event['args']['channel_identifier'] == channel_identifier
+        assert event['args']['participant'] == participant
+        assert event['args']['deposit'] == deposit
+    return get
+
+
+def check_channel_closed(channel_identifier, closing_address):
+    def get(event):
+        assert event['args']['channel_identifier'] == channel_identifier
+        assert event['args']['closing_address'] == closing_address
+    return get
+
+
+def check_channel_unlocked(channel_identifier, payer_participant, transferred_amount):
+    def get(event):
+        assert event['args']['channel_identifier'] == channel_identifier
+        assert event['args']['payer_participant'] == payer_participant
+        assert event['args']['transferred_amount'] == transferred_amount
+    return get
+
+
+def check_transfer_updated(channel_identifier, closing_participant):
+    def get(event):
+        assert event['args']['channel_identifier'] == channel_identifier
+        assert event['args']['closing_participant'] == closing_participant
+    return get
+
+
+def check_channel_settled(channel_identifier):
+    def get(event):
+        assert event['args']['channel_identifier'] == channel_identifier
+    return get

--- a/raiden_contracts/tests/fixtures/token_network.py
+++ b/raiden_contracts/tests/fixtures/token_network.py
@@ -13,60 +13,24 @@ def get_token_network(chain, create_contract):
 
 @pytest.fixture()
 def token_network(chain, token_network_registry, custom_token, secret_registry):
-    token_network_address = token_network_registry.call().createERC20TokenNetwork(custom_token.address)
+    token_network_address = token_network_registry.call().createERC20TokenNetwork(
+        custom_token.address
+    )
     token_network_registry.transact().createERC20TokenNetwork(custom_token.address)
 
     TokenNetwork = chain.provider.get_contract_factory(C_TOKEN_NETWORK)
-    token_network = chain.web3.eth.contract(address=token_network_address, ContractFactoryClass=TokenNetwork)
+    token_network = chain.web3.eth.contract(
+        address=token_network_address,
+        ContractFactoryClass=TokenNetwork
+    )
 
     return token_network
 
 
 @pytest.fixture()
 def token_network_external(chain, get_token_network, custom_token, secret_registry):
-    return get_token_network([custom_token.address, secret_registry.address, int(chain.web3.version.network)])
-
-
-def check_channel_opened(channel_identifier, participant1, participant2, settle_timeout):
-    def get(event):
-        assert event['args']['channel_identifier'] == channel_identifier
-        assert event['args']['participant1'] == participant1
-        assert event['args']['participant2'] == participant2
-        assert event['args']['settle_timeout'] == settle_timeout
-    return get
-
-
-def check_new_deposit(channel_identifier, participant, deposit):
-    def get(event):
-        assert event['args']['channel_identifier'] == channel_identifier
-        assert event['args']['participant'] == participant
-        assert event['args']['deposit'] == deposit
-    return get
-
-
-def check_channel_closed(channel_identifier, closing_address):
-    def get(event):
-        assert event['args']['channel_identifier'] == channel_identifier
-        assert event['args']['closing_address'] == closing_address
-    return get
-
-
-def check_channel_unlocked(channel_identifier, payer_participant, transferred_amount):
-    def get(event):
-        assert event['args']['channel_identifier'] == channel_identifier
-        assert event['args']['payer_participant'] == payer_participant
-        assert event['args']['transferred_amount'] == transferred_amount
-    return get
-
-
-def check_transfer_updated(channel_identifier, closing_participant):
-    def get(event):
-        assert event['args']['channel_identifier'] == channel_identifier
-        assert event['args']['closing_participant'] == closing_participant
-    return get
-
-
-def check_channel_settled(channel_identifier):
-    def get(event):
-        assert event['args']['channel_identifier'] == channel_identifier
-    return get
+    return get_token_network([
+        custom_token.address,
+        secret_registry.address,
+        int(chain.web3.version.network)
+    ])

--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -1,5 +1,7 @@
 import pytest
 from raiden_contracts.utils.config import C_TOKEN_NETWORK_REGISTRY
+from .utils import *
+
 
 @pytest.fixture()
 def get_token_network_registry(chain, create_contract):
@@ -11,8 +13,8 @@ def get_token_network_registry(chain, create_contract):
 
 
 @pytest.fixture()
-def token_network_registry(get_token_network_registry, secret_registry):
-    return get_token_network_registry([secret_registry.address])
+def token_network_registry(chain, get_token_network_registry, secret_registry):
+    return get_token_network_registry([secret_registry.address, int(chain.web3.version.network)])
 
 
 def check_token_network_created(token_address, token_network_address):

--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -1,6 +1,6 @@
 import pytest
 from raiden_contracts.utils.config import C_TOKEN_NETWORK_REGISTRY
-from .utils import *
+from .utils import *  # flake8: noqa
 
 
 @pytest.fixture()
@@ -15,10 +15,3 @@ def get_token_network_registry(chain, create_contract):
 @pytest.fixture()
 def token_network_registry(chain, get_token_network_registry, secret_registry):
     return get_token_network_registry([secret_registry.address, int(chain.web3.version.network)])
-
-
-def check_token_network_created(token_address, token_network_address):
-    def get(event):
-        assert event['args']['token_address'] == token_address
-        assert event['args']['token_network_address'] == token_network_address
-    return get

--- a/raiden_contracts/tests/fixtures/utils.py
+++ b/raiden_contracts/tests/fixtures/utils.py
@@ -1,24 +1,7 @@
 import pytest
 from raiden_contracts.utils.logs import LogHandler
 from ethereum import tester
-
-print_the_logs = False
-
-raiden_contracts_version = '0.3.0'
-MAX_UINT256 = 2 ** 256 - 1
-MAX_UINT192 = 2 ** 192 - 1
-MAX_UINT32 = 2 ** 32 - 1
-fake_address = '0x03432'
-empty_address = '0x0000000000000000000000000000000000000000'
-passphrase = '0'
-
-
-def fake_hex(size, fill='00'):
-    return '0x' + ''.join([fill for i in range(0, size)])
-
-
-def fake_bytes(size, fill='00'):
-    return bytearray.fromhex(fake_hex(size, fill)[2:])
+from .config import passphrase
 
 
 @pytest.fixture()

--- a/raiden_contracts/tests/fixtures/utils.py
+++ b/raiden_contracts/tests/fixtures/utils.py
@@ -1,5 +1,6 @@
 import pytest
 from raiden_contracts.utils.logs import LogHandler
+from ethereum import tester
 
 print_the_logs = False
 
@@ -12,12 +13,12 @@ empty_address = '0x0000000000000000000000000000000000000000'
 passphrase = '0'
 
 
-def fake_hex(size):
-    return '0x' + ''.join(['02' for i in range(0, size)])
+def fake_hex(size, fill='00'):
+    return '0x' + ''.join([fill for i in range(0, size)])
 
 
-def fake_bytes(size):
-    return bytearray.fromhex(fake_hex(size)[2:])
+def fake_bytes(size, fill='00'):
+    return bytearray.fromhex(fake_hex(size, fill)[2:])
 
 
 @pytest.fixture()
@@ -59,6 +60,14 @@ def create_accounts(web3):
             web3.personal.unlockAccount(new_account, passphrase)
             new_accounts.append(new_account)
         return new_accounts
+    return get
+
+
+@pytest.fixture
+def get_private_key(web3):
+    def get(account_address):
+        index = web3.eth.accounts.index(account_address)
+        return getattr(tester, 'k' + str(index))
     return get
 
 

--- a/raiden_contracts/tests/test_channel_close.py
+++ b/raiden_contracts/tests/test_channel_close.py
@@ -1,0 +1,46 @@
+import pytest
+from ethereum import tester
+from raiden_contracts.utils.config import C_TOKEN_NETWORK, E_CHANNEL_CLOSED
+from .fixtures.utils import *
+from .fixtures.token_network_registry import *
+from .fixtures.token_network import *
+from .fixtures.channel import *
+from .fixtures.token import *
+
+
+# TODO: test transferred_amount > deposit - this works now!!!!
+def test_close_channel_fail_small_deposit():
+    pass
+
+
+# TODO: test event argument when a delegate closes
+def test_close_channel_event_delegate():
+    pass
+
+
+def test_close_channel_event_no_offchain_transfers(get_accounts, token_network, create_channel, create_balance_proof, event_handler):
+    ev_handler = event_handler(token_network)
+    (A, B) = get_accounts(2)
+
+    channel_identifier = create_channel(A, B)
+    balance_proof = create_balance_proof(channel_identifier, B, 0, 0)
+
+    txn_hash = token_network.transact({'from': A}).closeChannel(*balance_proof)
+
+    ev_handler.add(txn_hash, E_CHANNEL_CLOSED, check_channel_closed(channel_identifier, A))
+    ev_handler.check()
+
+
+def test_close_channel_event(get_accounts, token_network, create_channel, channel_deposit, create_balance_proof, event_handler):
+    ev_handler = event_handler(token_network)
+    (A, B) = get_accounts(2)
+    deposit_A = 10
+
+    channel_identifier = create_channel(A, B)
+    channel_deposit(channel_identifier, A, deposit_A)
+    balance_proof = create_balance_proof(channel_identifier, B, 5, 3)
+
+    txn_hash = token_network.transact({'from': A}).closeChannel(*balance_proof)
+
+    ev_handler.add(txn_hash, E_CHANNEL_CLOSED, check_channel_closed(channel_identifier, A))
+    ev_handler.check()

--- a/raiden_contracts/tests/test_channel_close.py
+++ b/raiden_contracts/tests/test_channel_close.py
@@ -1,11 +1,5 @@
-import pytest
-from ethereum import tester
-from raiden_contracts.utils.config import C_TOKEN_NETWORK, E_CHANNEL_CLOSED
-from .fixtures.utils import *
-from .fixtures.token_network_registry import *
-from .fixtures.token_network import *
-from .fixtures.channel import *
-from .fixtures.token import *
+from raiden_contracts.utils.config import E_CHANNEL_CLOSED
+from .utils import check_channel_closed
 
 
 # TODO: test transferred_amount > deposit - this works now!!!!
@@ -18,7 +12,13 @@ def test_close_channel_event_delegate():
     pass
 
 
-def test_close_channel_event_no_offchain_transfers(get_accounts, token_network, create_channel, create_balance_proof, event_handler):
+def test_close_channel_event_no_offchain_transfers(
+        get_accounts,
+        token_network,
+        create_channel,
+        create_balance_proof,
+        event_handler
+):
     ev_handler = event_handler(token_network)
     (A, B) = get_accounts(2)
 
@@ -31,7 +31,14 @@ def test_close_channel_event_no_offchain_transfers(get_accounts, token_network, 
     ev_handler.check()
 
 
-def test_close_channel_event(get_accounts, token_network, create_channel, channel_deposit, create_balance_proof, event_handler):
+def test_close_channel_event(
+        get_accounts,
+        token_network,
+        create_channel,
+        channel_deposit,
+        create_balance_proof,
+        event_handler
+):
     ev_handler = event_handler(token_network)
     (A, B) = get_accounts(2)
     deposit_A = 10

--- a/raiden_contracts/tests/test_channel_deposit.py
+++ b/raiden_contracts/tests/test_channel_deposit.py
@@ -1,0 +1,25 @@
+import pytest
+from ethereum import tester
+from raiden_contracts.utils.config import C_TOKEN_NETWORK, E_CHANNEL_NEW_DEPOSIT
+from .fixtures.utils import *
+from .fixtures.token_network_registry import *
+from .fixtures.token_network import *
+from .fixtures.channel import *
+from .fixtures.token import *
+
+
+def test_deposit_channel_event(get_accounts, token_network, create_channel, channel_deposit, event_handler):
+    ev_handler = event_handler(token_network)
+    (A, B) = get_accounts(2)
+    deposit_A = 10
+    deposit_B = 15
+
+    channel_identifier = create_channel(A, B)
+
+    txn_hash = channel_deposit(channel_identifier, A, deposit_A)
+    ev_handler.add(txn_hash, E_CHANNEL_NEW_DEPOSIT, check_new_deposit(channel_identifier, A, deposit_A))
+
+    txn_hash = channel_deposit(channel_identifier, B, deposit_B)
+    ev_handler.add(txn_hash, E_CHANNEL_NEW_DEPOSIT, check_new_deposit(channel_identifier, B, deposit_B))
+
+    ev_handler.check()

--- a/raiden_contracts/tests/test_channel_deposit.py
+++ b/raiden_contracts/tests/test_channel_deposit.py
@@ -1,14 +1,14 @@
-import pytest
-from ethereum import tester
-from raiden_contracts.utils.config import C_TOKEN_NETWORK, E_CHANNEL_NEW_DEPOSIT
-from .fixtures.utils import *
-from .fixtures.token_network_registry import *
-from .fixtures.token_network import *
-from .fixtures.channel import *
-from .fixtures.token import *
+from raiden_contracts.utils.config import E_CHANNEL_NEW_DEPOSIT
+from .utils import check_new_deposit
 
 
-def test_deposit_channel_event(get_accounts, token_network, create_channel, channel_deposit, event_handler):
+def test_deposit_channel_event(
+        get_accounts,
+        token_network,
+        create_channel,
+        channel_deposit,
+        event_handler
+):
     ev_handler = event_handler(token_network)
     (A, B) = get_accounts(2)
     deposit_A = 10
@@ -17,9 +17,17 @@ def test_deposit_channel_event(get_accounts, token_network, create_channel, chan
     channel_identifier = create_channel(A, B)
 
     txn_hash = channel_deposit(channel_identifier, A, deposit_A)
-    ev_handler.add(txn_hash, E_CHANNEL_NEW_DEPOSIT, check_new_deposit(channel_identifier, A, deposit_A))
+    ev_handler.add(
+        txn_hash,
+        E_CHANNEL_NEW_DEPOSIT,
+        check_new_deposit(channel_identifier, A, deposit_A)
+    )
 
     txn_hash = channel_deposit(channel_identifier, B, deposit_B)
-    ev_handler.add(txn_hash, E_CHANNEL_NEW_DEPOSIT, check_new_deposit(channel_identifier, B, deposit_B))
+    ev_handler.add(
+        txn_hash,
+        E_CHANNEL_NEW_DEPOSIT,
+        check_new_deposit(channel_identifier, B, deposit_B)
+    )
 
     ev_handler.check()

--- a/raiden_contracts/tests/test_channel_open.py
+++ b/raiden_contracts/tests/test_channel_open.py
@@ -1,11 +1,16 @@
 import pytest
 from ethereum import tester
-from raiden_contracts.utils.config import C_TOKEN_NETWORK, E_CHANNEL_OPENED, SETTLE_TIMEOUT_MIN, SETTLE_TIMEOUT_MAX
-from .fixtures.utils import *
-from .fixtures.token_network_registry import *
-from .fixtures.token_network import *
-from .fixtures.token import *
-from .fixtures.secret_registry import *
+from raiden_contracts.utils.config import (
+    E_CHANNEL_OPENED,
+    SETTLE_TIMEOUT_MIN,
+    SETTLE_TIMEOUT_MAX
+)
+from .utils import check_channel_opened
+from .fixtures.config import (
+    empty_address,
+    fake_address,
+    fake_bytes
+)
 
 
 def test_open_channel_call(token_network, get_accounts):
@@ -64,14 +69,14 @@ def test_open_channel_state(token_network, get_accounts):
     assert channel[2] == 0
 
     A_state = token_network.call().getChannelParticipantInfo(1, A)
-    assert A_state[0] == True
+    assert A_state[0] is True
     assert A_state[1] == 0
     assert A_state[2] == 0
     assert A_state[3] == 0
     assert A_state[4] == fake_bytes(32)
 
     B_state = token_network.call().getChannelParticipantInfo(1, B)
-    assert B_state[0] == True
+    assert B_state[0] is True
     assert B_state[1] == 0
     assert B_state[2] == 0
     assert B_state[3] == 0

--- a/raiden_contracts/tests/test_channel_open.py
+++ b/raiden_contracts/tests/test_channel_open.py
@@ -1,28 +1,88 @@
+import pytest
 from ethereum import tester
-from raiden_contracts.utils.config import C_TOKEN_NETWORK, E_CHANNEL_OPENED
+from raiden_contracts.utils.config import C_TOKEN_NETWORK, E_CHANNEL_OPENED, SETTLE_TIMEOUT_MIN, SETTLE_TIMEOUT_MAX
+from .fixtures.utils import *
+from .fixtures.token_network_registry import *
+from .fixtures.token_network import *
+from .fixtures.token import *
+from .fixtures.secret_registry import *
 
 
 def test_open_channel_call(token_network, get_accounts):
-    pass
-
-
-def test_open_channel_state():
-    pass
-
-
-def test_open_channel_last_index():
-    pass
-
-
-def test_open_channel_fail_existent():
-    pass
-
-
-def test_open_channel_event():
-    pass
-
-
-def test_print_gas_cost(token_network, get_accounts, print_gas):
     (A, B) = get_accounts(2)
-    txn_hash = token_network.transact().openChannel(A, B, 7)
-    print_gas(txn_hash, 'openChannel')
+    settle_timeout = SETTLE_TIMEOUT_MIN + 10
+    with pytest.raises(TypeError):
+        token_network.transact().openChannel(A, B, -3)
+    with pytest.raises(TypeError):
+        token_network.transact().openChannel(0x0, B, settle_timeout)
+    with pytest.raises(TypeError):
+        token_network.transact().openChannel('', B, settle_timeout)
+    with pytest.raises(TypeError):
+        token_network.transact().openChannel(fake_address, B, settle_timeout)
+    with pytest.raises(TypeError):
+        token_network.transact().openChannel(A, 0x0, settle_timeout)
+    with pytest.raises(TypeError):
+        token_network.transact().openChannel(A, '', settle_timeout)
+    with pytest.raises(TypeError):
+        token_network.transact().openChannel(A, fake_address, settle_timeout)
+
+    with pytest.raises(tester.TransactionFailed):
+        token_network.transact().openChannel(empty_address, B, settle_timeout)
+    with pytest.raises(tester.TransactionFailed):
+        token_network.transact().openChannel(A, empty_address, settle_timeout)
+
+    # Cannot open a channel between 2 participants with the same address
+    with pytest.raises(tester.TransactionFailed):
+        token_network.transact().openChannel(A, A, settle_timeout)
+
+    with pytest.raises(tester.TransactionFailed):
+        token_network.transact().openChannel(A, B, SETTLE_TIMEOUT_MIN - 1)
+    with pytest.raises(tester.TransactionFailed):
+        token_network.transact().openChannel(A, B, SETTLE_TIMEOUT_MAX + 1)
+
+
+def test_open_channel_index(token_network, get_accounts):
+    (A, B, C, D) = get_accounts(4)
+    settle_timeout = SETTLE_TIMEOUT_MIN + 10
+
+    assert token_network.call().last_channel_index() == 0
+
+    for i in range(1, 10):
+        token_network.transact().openChannel(A, B, settle_timeout)
+        assert token_network.call().last_channel_index() == i
+
+
+def test_open_channel_state(token_network, get_accounts):
+    (A, B) = get_accounts(2)
+    settle_timeout = SETTLE_TIMEOUT_MIN + 10
+
+    token_network.transact().openChannel(A, B, settle_timeout)
+
+    channel = token_network.call().getChannelInfo(1)
+    assert channel[0] == settle_timeout
+    assert channel[1] == empty_address
+    assert channel[2] == 0
+
+    A_state = token_network.call().getChannelParticipantInfo(1, A)
+    assert A_state[0] == True
+    assert A_state[1] == 0
+    assert A_state[2] == 0
+    assert A_state[3] == 0
+    assert A_state[4] == fake_bytes(32)
+
+    B_state = token_network.call().getChannelParticipantInfo(1, B)
+    assert B_state[0] == True
+    assert B_state[1] == 0
+    assert B_state[2] == 0
+    assert B_state[3] == 0
+    assert B_state[4] == fake_bytes(32)
+
+
+def test_open_channel_event(get_accounts, token_network, event_handler):
+    ev_handler = event_handler(token_network)
+    (A, B) = get_accounts(2)
+
+    txn_hash = token_network.transact().openChannel(A, B, SETTLE_TIMEOUT_MIN)
+
+    ev_handler.add(txn_hash, E_CHANNEL_OPENED, check_channel_opened(1, A, B, SETTLE_TIMEOUT_MIN))
+    ev_handler.check()

--- a/raiden_contracts/tests/test_channel_update_transfer.py
+++ b/raiden_contracts/tests/test_channel_update_transfer.py
@@ -1,0 +1,47 @@
+import pytest
+from ethereum import tester
+from raiden_contracts.utils.config import C_TOKEN_NETWORK, E_TRANSFER_UPDATED
+from .fixtures.utils import *
+from .fixtures.token_network_registry import *
+from .fixtures.token_network import *
+from .fixtures.channel import *
+from .fixtures.token import *
+
+
+# TODO: test transferred_amount > deposit - this works now!!!!
+def test_update_channel_fail_small_deposit():
+    pass
+
+
+def test_update_channel_event_no_offchain_transfers(get_accounts, token_network, create_channel, create_balance_proof, event_handler):
+    ev_handler = event_handler(token_network)
+    (A, B) = get_accounts(2)
+
+    channel_identifier = create_channel(A, B)
+    balance_proof_A = create_balance_proof(channel_identifier, B, 0, 0)
+    balance_proof_B = create_balance_proof(channel_identifier, A, 0, 0)
+
+    token_network.transact({'from': A}).closeChannel(*balance_proof_A)
+    txn_hash = token_network.transact({'from': B}).updateTransfer(*balance_proof_B)
+
+    ev_handler.add(txn_hash, E_TRANSFER_UPDATED, check_transfer_updated(channel_identifier, A))
+    ev_handler.check()
+
+
+def test_update_channel_event(get_accounts, token_network, create_channel, channel_deposit, create_balance_proof, event_handler):
+    ev_handler = event_handler(token_network)
+    (A, B) = get_accounts(2)
+    deposit_A = 10
+    deposit_B = 10
+
+    channel_identifier = create_channel(A, B)
+    channel_deposit(channel_identifier, A, deposit_A)
+    channel_deposit(channel_identifier, B, deposit_B)
+    balance_proof_A = create_balance_proof(channel_identifier, B, 5, 3)
+    balance_proof_B = create_balance_proof(channel_identifier, A, 2, 1)
+
+    token_network.transact({'from': A}).closeChannel(*balance_proof_A)
+    txn_hash = token_network.transact({'from': B}).updateTransfer(*balance_proof_B)
+
+    ev_handler.add(txn_hash, E_TRANSFER_UPDATED, check_transfer_updated(channel_identifier, A))
+    ev_handler.check()

--- a/raiden_contracts/tests/test_channel_update_transfer.py
+++ b/raiden_contracts/tests/test_channel_update_transfer.py
@@ -1,11 +1,5 @@
-import pytest
-from ethereum import tester
-from raiden_contracts.utils.config import C_TOKEN_NETWORK, E_TRANSFER_UPDATED
-from .fixtures.utils import *
-from .fixtures.token_network_registry import *
-from .fixtures.token_network import *
-from .fixtures.channel import *
-from .fixtures.token import *
+from raiden_contracts.utils.config import E_TRANSFER_UPDATED
+from .utils import check_transfer_updated
 
 
 # TODO: test transferred_amount > deposit - this works now!!!!
@@ -13,7 +7,13 @@ def test_update_channel_fail_small_deposit():
     pass
 
 
-def test_update_channel_event_no_offchain_transfers(get_accounts, token_network, create_channel, create_balance_proof, event_handler):
+def test_update_channel_event_no_offchain_transfers(
+        get_accounts,
+        token_network,
+        create_channel,
+        create_balance_proof,
+        event_handler
+):
     ev_handler = event_handler(token_network)
     (A, B) = get_accounts(2)
 
@@ -28,7 +28,14 @@ def test_update_channel_event_no_offchain_transfers(get_accounts, token_network,
     ev_handler.check()
 
 
-def test_update_channel_event(get_accounts, token_network, create_channel, channel_deposit, create_balance_proof, event_handler):
+def test_update_channel_event(
+        get_accounts,
+        token_network,
+        create_channel,
+        channel_deposit,
+        create_balance_proof,
+        event_handler
+):
     ev_handler = event_handler(token_network)
     (A, B) = get_accounts(2)
     deposit_A = 10

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -1,20 +1,30 @@
-import pytest
 from ethereum import tester
-from raiden_contracts.utils.config import *
-from raiden_contracts.utils.sign import *
-from .fixtures import *
+from raiden_contracts.utils.config import (
+    C_TOKEN_NETWORK_REGISTRY,
+    C_TOKEN_NETWORK,
+    C_SECRET_REGISTRY
+)
+from raiden_contracts.utils.sign import sign_balance_proof
 
 
 def test_token_network_registry(chain, token_network_registry, custom_token, print_gas):
     TokenNetworkRegistry = chain.provider.get_contract_factory(C_TOKEN_NETWORK_REGISTRY)
-    deploy_txn_hash = TokenNetworkRegistry.deploy(args=[custom_token.address, int(chain.web3.version.network)])
+    deploy_txn_hash = TokenNetworkRegistry.deploy(
+        args=[custom_token.address, int(chain.web3.version.network)]
+    )
     print_gas(deploy_txn_hash, C_TOKEN_NETWORK_REGISTRY + ' DEPLOYMENT')
 
     txn_hash = token_network_registry.transact().createERC20TokenNetwork(custom_token.address)
     print_gas(txn_hash, C_TOKEN_NETWORK_REGISTRY + '.createERC20TokenNetwork')
 
 
-def test_token_network_deployment(chain, print_gas, custom_token, secret_registry, token_network_registry):
+def test_token_network_deployment(
+        chain,
+        print_gas,
+        custom_token,
+        secret_registry,
+        token_network_registry
+):
     TokenNetwork = chain.provider.get_contract_factory(C_TOKEN_NETWORK)
     deploy_txn_hash = TokenNetwork.deploy(args=[
         custom_token.address,
@@ -25,7 +35,13 @@ def test_token_network_deployment(chain, print_gas, custom_token, secret_registr
     print_gas(deploy_txn_hash, C_TOKEN_NETWORK + ' DEPLOYMENT')
 
 
-def test_token_network_create(chain, print_gas, custom_token, secret_registry, token_network_registry):
+def test_token_network_create(
+        chain,
+        print_gas,
+        custom_token,
+        secret_registry,
+        token_network_registry
+):
     txn_hash = token_network_registry.transact().createERC20TokenNetwork(custom_token.address)
 
     print_gas(txn_hash, C_TOKEN_NETWORK_REGISTRY + ' createERC20TokenNetwork')

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -7,21 +7,28 @@ from .fixtures import *
 
 def test_token_network_registry(chain, token_network_registry, custom_token, print_gas):
     TokenNetworkRegistry = chain.provider.get_contract_factory(C_TOKEN_NETWORK_REGISTRY)
-    deploy_txn_hash = TokenNetworkRegistry.deploy(args=[custom_token.address])
+    deploy_txn_hash = TokenNetworkRegistry.deploy(args=[custom_token.address, int(chain.web3.version.network)])
     print_gas(deploy_txn_hash, C_TOKEN_NETWORK_REGISTRY + ' DEPLOYMENT')
 
     txn_hash = token_network_registry.transact().createERC20TokenNetwork(custom_token.address)
     print_gas(txn_hash, C_TOKEN_NETWORK_REGISTRY + '.createERC20TokenNetwork')
 
 
-def test_token_network_deployment(chain, print_gas, custom_token, secret_registry):
+def test_token_network_deployment(chain, print_gas, custom_token, secret_registry, token_network_registry):
     TokenNetwork = chain.provider.get_contract_factory(C_TOKEN_NETWORK)
     deploy_txn_hash = TokenNetwork.deploy(args=[
         custom_token.address,
-        secret_registry.address
+        secret_registry.address,
+        int(chain.web3.version.network)
     ])
 
     print_gas(deploy_txn_hash, C_TOKEN_NETWORK + ' DEPLOYMENT')
+
+
+def test_token_network_create(chain, print_gas, custom_token, secret_registry, token_network_registry):
+    txn_hash = token_network_registry.transact().createERC20TokenNetwork(custom_token.address)
+
+    print_gas(txn_hash, C_TOKEN_NETWORK_REGISTRY + ' createERC20TokenNetwork')
 
 
 def test_secret_registry(secret_registry, print_gas):
@@ -30,8 +37,9 @@ def test_secret_registry(secret_registry, print_gas):
     print_gas(txn_hash, C_SECRET_REGISTRY + '.registerSecret')
 
 
-def test_channel_deposit(web3, token_network, custom_token, get_accounts, print_gas):
+def test_channel_cycle(web3, token_network, custom_token, get_accounts, print_gas):
     (A, B) = get_accounts(2)
+    chain_id = int(web3.version.network)
 
     custom_token.transact({'from': A, 'value': 10 ** 18}).mint()
     custom_token.transact({'from': B, 'value': 10 ** 18}).mint()
@@ -56,6 +64,7 @@ def test_channel_deposit(web3, token_network, custom_token, get_accounts, print_
         tester.k3,
         1,
         token_network.address,
+        chain_id,
         nonce,
         transferred_amount,
         locksroot,
@@ -80,6 +89,7 @@ def test_channel_deposit(web3, token_network, custom_token, get_accounts, print_
         tester.k2,
         1,
         token_network.address,
+        chain_id,
         nonce,
         transferred_amount,
         locksroot,

--- a/raiden_contracts/tests/test_secret_registry.py
+++ b/raiden_contracts/tests/test_secret_registry.py
@@ -66,9 +66,3 @@ def test_events(secret_registry, event_handler):
 
     ev_handler.add(txn_hash, E_SECRET_REVEALED, check_secret_revealed(secret))
     ev_handler.check()
-
-
-def test_print_gas_cost(secret_registry, print_gas):
-    secret = b'secretsecretsecretsecretsecretse'
-    txn_hash = secret_registry.transact().registerSecret(secret)
-    print_gas(txn_hash, C_SECRET_REGISTRY + '.registerSecret')

--- a/raiden_contracts/tests/test_secret_registry.py
+++ b/raiden_contracts/tests/test_secret_registry.py
@@ -1,6 +1,7 @@
 import pytest
-from raiden_contracts.utils.config import C_SECRET_REGISTRY, E_SECRET_REVEALED
-from .fixtures import raiden_contracts_version, fake_hex, check_secret_revealed
+from raiden_contracts.utils.config import E_SECRET_REVEALED
+from .utils import check_secret_revealed
+from .fixtures.config import fake_hex, raiden_contracts_version
 
 
 def test_version(secret_registry):

--- a/raiden_contracts/tests/test_token_network.py
+++ b/raiden_contracts/tests/test_token_network.py
@@ -1,61 +1,65 @@
 import pytest
 from ethereum import tester
 from raiden_contracts.utils.config import C_TOKEN_NETWORK
-from .fixtures import raiden_contracts_version, fake_address, empty_address
+from .fixtures.utils import *
+from .fixtures.token_network import *
+from .fixtures.token_network_registry import *
+from .fixtures.token import *
+from .fixtures.secret_registry import *
 
 
 def test_version(token_network):
     assert token_network.call().contract_version()[:2] == raiden_contracts_version[:2]
 
 
-def test_constructor_call(get_token_network, custom_token, secret_registry, get_accounts):
+def test_constructor_call(chain, get_token_network, custom_token, secret_registry, get_accounts):
     A = get_accounts(1)[0]
+    chain_id = int(chain.web3.version.network)
     with pytest.raises(TypeError):
         get_token_network([])
     with pytest.raises(TypeError):
-        get_token_network([3, secret_registry.address])
+        get_token_network([3, secret_registry.address, chain_id])
     with pytest.raises(TypeError):
-        get_token_network([0, secret_registry.address])
+        get_token_network([0, secret_registry.address, chain_id])
     with pytest.raises(TypeError):
-        get_token_network(['', secret_registry.address])
+        get_token_network(['', secret_registry.address, chain_id])
     with pytest.raises(TypeError):
-        get_token_network([fake_address, secret_registry.address])
+        get_token_network([fake_address, secret_registry.address, chain_id])
     with pytest.raises(TypeError):
-        get_token_network([custom_token.address, 3])
+        get_token_network([custom_token.address, 3, chain_id])
     with pytest.raises(TypeError):
-        get_token_network([custom_token.address, 0])
+        get_token_network([custom_token.address, 0, chain_id])
     with pytest.raises(TypeError):
-        get_token_network([custom_token.address, ''])
+        get_token_network([custom_token.address, '', chain_id])
     with pytest.raises(TypeError):
-        get_token_network([custom_token.address, fake_address])
+        get_token_network([custom_token.address, fake_address, chain_id])
+    with pytest.raises(TypeError):
+        get_token_network([custom_token.address, secret_registry.address, ''])
+    with pytest.raises(TypeError):
+        get_token_network([custom_token.address, secret_registry.address, -3])
 
     with pytest.raises(tester.TransactionFailed):
-        get_token_network([empty_address, secret_registry.address])
+        get_token_network([empty_address, secret_registry.address, chain_id])
     with pytest.raises(tester.TransactionFailed):
-        get_token_network([A, secret_registry.address])
+        get_token_network([A, secret_registry.address, chain_id])
     with pytest.raises(tester.TransactionFailed):
-        get_token_network([secret_registry.address, secret_registry.address])
+        get_token_network([secret_registry.address, secret_registry.address, chain_id])
 
     with pytest.raises(tester.TransactionFailed):
-        get_token_network([custom_token.address, empty_address])
+        get_token_network([custom_token.address, empty_address, chain_id])
     with pytest.raises(tester.TransactionFailed):
-        get_token_network([custom_token.address, A])
+        get_token_network([custom_token.address, A, chain_id])
 
-    token_network = get_token_network([custom_token.address, secret_registry.address])
-    assert token_network is not None
+    with pytest.raises(tester.TransactionFailed):
+        get_token_network([custom_token.address, secret_registry.address, 0])
+
+    token_network = get_token_network([custom_token.address, secret_registry.address, chain_id])
 
 
-def test_constructor(get_token_network, custom_token, secret_registry):
-    token_network = get_token_network([custom_token.address, secret_registry.address])
+def test_constructor_not_registered(custom_token, secret_registry, token_network_registry, token_network_external):
+    token_network = token_network_external
     assert token_network.call().token() == custom_token.address
     assert token_network.call().secret_registry() == secret_registry.address
+    assert token_network.call().chain_id() == token_network_registry.call().chain_id()
 
-
-def test_print_gas_cost(chain, print_gas, custom_token, secret_registry):
-    TokenNetwork = chain.provider.get_contract_factory(C_TOKEN_NETWORK)
-    deploy_txn_hash = TokenNetwork.deploy(args=[
-        custom_token.address,
-        secret_registry.address
-    ])
-
-    print_gas(deploy_txn_hash, C_TOKEN_NETWORK + ' DEPLOYMENT')
+    assert token_network_registry.call().token_to_token_networks(custom_token.address) == empty_address

--- a/raiden_contracts/tests/test_token_network.py
+++ b/raiden_contracts/tests/test_token_network.py
@@ -1,11 +1,10 @@
 import pytest
 from ethereum import tester
-from raiden_contracts.utils.config import C_TOKEN_NETWORK
-from .fixtures.utils import *
-from .fixtures.token_network import *
-from .fixtures.token_network_registry import *
-from .fixtures.token import *
-from .fixtures.secret_registry import *
+from .fixtures.config import (
+    raiden_contracts_version,
+    empty_address,
+    fake_address
+)
 
 
 def test_version(token_network):
@@ -53,13 +52,20 @@ def test_constructor_call(chain, get_token_network, custom_token, secret_registr
     with pytest.raises(tester.TransactionFailed):
         get_token_network([custom_token.address, secret_registry.address, 0])
 
-    token_network = get_token_network([custom_token.address, secret_registry.address, chain_id])
+    get_token_network([custom_token.address, secret_registry.address, chain_id])
 
 
-def test_constructor_not_registered(custom_token, secret_registry, token_network_registry, token_network_external):
+def test_constructor_not_registered(
+        custom_token,
+        secret_registry,
+        token_network_registry,
+        token_network_external
+):
     token_network = token_network_external
     assert token_network.call().token() == custom_token.address
     assert token_network.call().secret_registry() == secret_registry.address
     assert token_network.call().chain_id() == token_network_registry.call().chain_id()
 
-    assert token_network_registry.call().token_to_token_networks(custom_token.address) == empty_address
+    assert token_network_registry.call().token_to_token_networks(
+        custom_token.address
+    ) == empty_address

--- a/raiden_contracts/tests/test_token_network_registry.py
+++ b/raiden_contracts/tests/test_token_network_registry.py
@@ -11,26 +11,43 @@ def test_version(token_network_registry):
     assert token_network_registry.call().contract_version()[:2] == raiden_contracts_version[:2]
 
 
-def test_constructor(get_token_network_registry, secret_registry, get_accounts):
+def test_constructor_call(chain, get_token_network_registry, secret_registry, get_accounts):
     A = get_accounts(1)[0]
+    chain_id = int(chain.web3.version.network)
     with pytest.raises(TypeError):
         get_token_network_registry([])
     with pytest.raises(TypeError):
-        get_token_network_registry([3])
+        get_token_network_registry([3, chain_id])
     with pytest.raises(TypeError):
-        get_token_network_registry([0])
+        get_token_network_registry([0, chain_id])
     with pytest.raises(TypeError):
-        get_token_network_registry([''])
+        get_token_network_registry(['', chain_id])
     with pytest.raises(TypeError):
-        get_token_network_registry([fake_address])
+        get_token_network_registry([fake_address, chain_id])
+    with pytest.raises(TypeError):
+        get_token_network_registry([secret_registry.address, ''])
+    with pytest.raises(TypeError):
+        get_token_network_registry([secret_registry.address, '1'])
+    with pytest.raises(TypeError):
+        get_token_network_registry([secret_registry.address, -3])
 
     with pytest.raises(tester.TransactionFailed):
-        get_token_network_registry([empty_address])
+        get_token_network_registry([empty_address, chain_id])
     with pytest.raises(tester.TransactionFailed):
-        get_token_network_registry([A])
+        get_token_network_registry([A, chain_id])
 
-    registry = get_token_network_registry([secret_registry.address])
+    with pytest.raises(tester.TransactionFailed):
+        get_token_network_registry([secret_registry.address, 0])
+
+    registry = get_token_network_registry([secret_registry.address, chain_id])
+
+
+def test_constructor_call(chain, get_token_network_registry, secret_registry):
+    chain_id = int(chain.web3.version.network)
+
+    registry = get_token_network_registry([secret_registry.address, chain_id])
     assert secret_registry.address == registry.call().secret_registry_address()
+    assert chain_id == registry.call().chain_id()
 
 
 def test_create_erc20_token_network_call(token_network_registry, custom_token, get_accounts):
@@ -58,6 +75,9 @@ def test_create_erc20_token_network_call(token_network_registry, custom_token, g
 
 
 def test_create_erc20_token_network(chain, web3, token_network_registry, custom_token):
+    assert token_network_registry.call().token_to_token_networks(
+        custom_token.address) == empty_address
+
     new_token_network = token_network_registry.call().createERC20TokenNetwork(custom_token.address)
 
     token_network_registry.transact().createERC20TokenNetwork(custom_token.address)
@@ -71,6 +91,7 @@ def test_create_erc20_token_network(chain, web3, token_network_registry, custom_
     token_network = web3.eth.contract(address=new_token_network, ContractFactoryClass=TokenNetwork)
     assert token_network.call().token() == custom_token.address
     assert token_network.call().secret_registry() == token_network_registry.call().secret_registry_address()
+    assert token_network.call().chain_id() == token_network_registry.call().chain_id()
 
 
 def test_events(token_network_registry, custom_token, event_handler):
@@ -82,12 +103,3 @@ def test_events(token_network_registry, custom_token, event_handler):
 
     ev_handler.add(txn_hash, E_TOKEN_NETWORK_CREATED, check_token_network_created(custom_token.address, new_token_network))
     ev_handler.check()
-
-
-def test_print_gas_cost(chain, token_network_registry, custom_token, print_gas):
-    TokenNetworkRegistry = chain.provider.get_contract_factory(C_TOKEN_NETWORK_REGISTRY)
-    deploy_txn_hash = TokenNetworkRegistry.deploy(args=[custom_token.address])
-    print_gas(deploy_txn_hash, C_TOKEN_NETWORK_REGISTRY + ' DEPLOYMENT')
-
-    txn_hash = token_network_registry.transact().createERC20TokenNetwork(custom_token.address)
-    print_gas(txn_hash, C_TOKEN_NETWORK_REGISTRY + '.createERC20TokenNetwork')

--- a/raiden_contracts/tests/utils.py
+++ b/raiden_contracts/tests/utils.py
@@ -1,0 +1,56 @@
+def check_secret_revealed(secret):
+    def get(event):
+        assert event['args']['secret'] == secret
+    return get
+
+
+def check_token_network_created(token_address, token_network_address):
+    def get(event):
+        assert event['args']['token_address'] == token_address
+        assert event['args']['token_network_address'] == token_network_address
+    return get
+
+
+def check_channel_opened(channel_identifier, participant1, participant2, settle_timeout):
+    def get(event):
+        assert event['args']['channel_identifier'] == channel_identifier
+        assert event['args']['participant1'] == participant1
+        assert event['args']['participant2'] == participant2
+        assert event['args']['settle_timeout'] == settle_timeout
+    return get
+
+
+def check_new_deposit(channel_identifier, participant, deposit):
+    def get(event):
+        assert event['args']['channel_identifier'] == channel_identifier
+        assert event['args']['participant'] == participant
+        assert event['args']['deposit'] == deposit
+    return get
+
+
+def check_channel_closed(channel_identifier, closing_address):
+    def get(event):
+        assert event['args']['channel_identifier'] == channel_identifier
+        assert event['args']['closing_address'] == closing_address
+    return get
+
+
+def check_channel_unlocked(channel_identifier, payer_participant, transferred_amount):
+    def get(event):
+        assert event['args']['channel_identifier'] == channel_identifier
+        assert event['args']['payer_participant'] == payer_participant
+        assert event['args']['transferred_amount'] == transferred_amount
+    return get
+
+
+def check_transfer_updated(channel_identifier, closing_participant):
+    def get(event):
+        assert event['args']['channel_identifier'] == channel_identifier
+        assert event['args']['closing_participant'] == closing_participant
+    return get
+
+
+def check_channel_settled(channel_identifier):
+    def get(event):
+        assert event['args']['channel_identifier'] == channel_identifier
+    return get

--- a/raiden_contracts/utils/config.py
+++ b/raiden_contracts/utils/config.py
@@ -1,5 +1,5 @@
 C_SECRET_REGISTRY = 'SecretRegistry'
-C_TOKEN_NETWORK_REGISTRY = 'TokenNetworkRegistry'
+C_TOKEN_NETWORK_REGISTRY = 'TokenNetworksRegistry'
 C_TOKEN_NETWORK = 'TokenNetwork'
 C_HUMAN_STANDARD_TOKEN = 'HumanStandardToken'
 C_CUSTOM_TOKEN = 'CustomToken'
@@ -10,5 +10,8 @@ E_CHANNEL_CLOSED = 'ChannelClosed'
 E_CHANNEL_UNLOCKED = 'ChannelUnlocked'
 E_TRANSFER_UPDATED = 'TransferUpdated'
 E_CHANNEL_SETTLED = 'ChannelSettled'
-E_TOKEN_NETWORK_CREATED = 'TokenNetworkCreated'
+E_TOKEN_NETWORK_CREATED = 'TokenNetworkRegistered'
 E_SECRET_REVEALED = 'SecretRevealed'
+
+SETTLE_TIMEOUT_MIN = 6
+SETTLE_TIMEOUT_MAX = 2700000

--- a/raiden_contracts/utils/config.py
+++ b/raiden_contracts/utils/config.py
@@ -10,7 +10,7 @@ E_CHANNEL_CLOSED = 'ChannelClosed'
 E_CHANNEL_UNLOCKED = 'ChannelUnlocked'
 E_TRANSFER_UPDATED = 'TransferUpdated'
 E_CHANNEL_SETTLED = 'ChannelSettled'
-E_TOKEN_NETWORK_CREATED = 'TokenNetworkRegistered'
+E_TOKEN_NETWORK_CREATED = 'TokenNetworkCreated'
 E_SECRET_REVEALED = 'SecretRevealed'
 
 SETTLE_TIMEOUT_MIN = 6

--- a/raiden_contracts/utils/logs.py
+++ b/raiden_contracts/utils/logs.py
@@ -63,12 +63,13 @@ class LogHandler:
             with Timeout(seconds) as timeout:
                 while len(list(self.event_waiting.keys())):
                     timeout.sleep(2)
-        except:
+        except Exception as e:
+            print(e)
             message = 'NO EVENTS WERE TRIGGERED FOR: ' + str(self.event_waiting)
             if len(self.event_unkown) > 0:
                 message += '\n UNKOWN EVENTS: ' + str(self.event_unkown)
 
-            # FIXME Events triggered in another transaction
+            # FIXME Events triggered in an internal transaction
             # don't have the transactionHash we are looking for here
             # so we just check if the number of unknown events we find
             # is the same as the found events

--- a/raiden_contracts/utils/sign.py
+++ b/raiden_contracts/utils/sign.py
@@ -6,6 +6,7 @@ def sign_balance_proof(
         privatekey,
         channel_identifier,
         token_network_address,
+        chain_identifier,
         nonce,
         transferred_amount,
         locksroot,
@@ -16,6 +17,7 @@ def sign_balance_proof(
         'bytes32',
         'uint256',
         'address',
+        'uint256',
         'bytes32'
     ], [
         nonce,
@@ -23,6 +25,7 @@ def sign_balance_proof(
         locksroot,
         channel_identifier,
         token_network_address,
+        chain_identifier,
         additional_hash
     ])
 

--- a/raiden_contracts/utils/sign.py
+++ b/raiden_contracts/utils/sign.py
@@ -1,5 +1,5 @@
 from web3 import Web3
-from .sign_utils import *
+from .sign_utils import sign
 
 
 def sign_balance_proof(

--- a/raiden_contracts/utils/sign_utils.py
+++ b/raiden_contracts/utils/sign_utils.py
@@ -1,38 +1,5 @@
-from coincurve import PrivateKey, PublicKey
-from eth_utils import (
-    encode_hex,
-    decode_hex,
-    remove_0x_prefix,
-    keccak,
-    is_0x_prefixed,
-    to_checksum_address
-)
-
-
-def pubkey_to_addr(pubkey) -> str:
-    if isinstance(pubkey, PublicKey):
-        pubkey = pubkey.format(compressed=False)
-    assert isinstance(pubkey, bytes)
-    return encode_hex(keccak256(pubkey[1:])[-20:])
-
-
-def privkey_to_addr(privkey: str) -> str:
-    return to_checksum_address(
-        pubkey_to_addr(PrivateKey.from_hex(remove_0x_prefix(privkey)).public_key)
-    )
-
-
-def addr_from_sig(sig: bytes, msg: bytes):
-    assert len(sig) == 65
-    # Support Ethereum's EC v value of 27 and EIP 155 values of > 35.
-    if sig[-1] >= 35:
-        network_id = (sig[-1] - 35) // 2
-        sig = sig[:-1] + bytes([sig[-1] - 35 - 2 * network_id])
-    elif sig[-1] >= 27:
-        sig = sig[:-1] + bytes([sig[-1] - 27])
-
-    receiver_pubkey = PublicKey.from_signature_and_message(sig, msg, hasher=None)
-    return pubkey_to_addr(receiver_pubkey)
+from coincurve import PrivateKey
+from eth_utils import remove_0x_prefix
 
 
 def sign(privkey: str, msg: bytes, v=0) -> bytes:

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ max-line-length = 99
 
 [coverage:run]
 branch = True
-concurrency = gevent
 
 [coverage:report]
 skip_covered = True


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden-contracts/issues/2
fixes https://github.com/raiden-network/raiden-contracts/issues/4

(LC:)
- add more tests and fixtures
- deploy script uses web3 directly; compiled contracts data must be provided (done with `populus compile`

Smart contract changes:
- `TokenNetworkRegistry` -> `TokenNetworksRegistry`
- block numbers are `uint256` instead of `uint64`
- add `chain_id` to `TokenNetwork`, `TokenNetworksRegistry` constructors 
- `event ChannelClosed(uint256 channel_identifier, address closing_address);` (replaced old argument `closing_participant`, because we provide the address of the caller - can be a 3rd party)
- support for closing & updating the channel without any existent off-chain transfers ('nonce' issue: https://github.com/raiden-network/raiden-contracts/pull/15/files#diff-1bdf2ff343918b98864fc26df16cc1ebR276)
- add channel data getters until we are able to return structs in Solidity: 
```
function getChannelInfo(
        uint256 channel_identifier)
        view
        external
        returns (uint256, address, uint256)
    {
        ....
        return (
            channel.settle_timeout,
            closing_request.closing_participant,
            closing_request.settle_block_number
        );
    }

function getChannelParticipantInfo(
        uint256 channel_identifier,
        address participant)
        view
        external
        returns (bool, uint256, uint256, uint64, bytes32)
    {
       ....
        return (
            participant_state.initialized,
            participant_state.deposit,
            participant_state.transferred_amount,
            participant_state.nonce,
            participant_state.locksroot
        );
    }

```
