### PR TITLE
Revert to initial name for ChannelClosed event - closing_participant argument

### DIFF
--- a/contracts/TokenNetwork.sol
+++ b/contracts/TokenNetwork.sol
@@ -88,7 +88,7 @@ contract TokenNetwork is Utils {
 
     event ChannelNewDeposit(uint256 channel_identifier, address participant, uint256 deposit);
 
-    event ChannelClosed(uint256 channel_identifier, address closing_address);
+    event ChannelClosed(uint256 channel_identifier, address closing_participant);
 
     event ChannelUnlocked(uint256 channel_identifier, address payer_participant, uint256 transferred_amount);
 

--- a/raiden_contracts/tests/utils.py
+++ b/raiden_contracts/tests/utils.py
@@ -28,10 +28,10 @@ def check_new_deposit(channel_identifier, participant, deposit):
     return get
 
 
-def check_channel_closed(channel_identifier, closing_address):
+def check_channel_closed(channel_identifier, closing_participant):
     def get(event):
         assert event['args']['channel_identifier'] == channel_identifier
-        assert event['args']['closing_address'] == closing_address
+        assert event['args']['closing_participant'] == closing_participant
     return get
 
 


### PR DESCRIPTION
There was no good reason to change `closing_address` to `closing_participant`.
https://github.com/raiden-network/raiden-contracts/pull/15#issuecomment-375062996
