### PR TITLE
updateTransfer should fail if nonce is 0

### DIFF
--- a/contracts/TokenNetwork.sol
+++ b/contracts/TokenNetwork.sol
@@ -395,18 +395,15 @@ contract TokenNetwork is Utils {
             signature
         );
 
-        // If there are off-chain transfers, update the participant's state
         // This will reset the transferred amount, invalidating any unlocked locks that were
         // unlocked but not included in the new locksroot
-        if (nonce > 0) {
-            updateParticipantStruct(
-                channel_identifier,
-                closing_participant,
-                nonce,
-                locksroot,
-                transferred_amount
-            );
-        }
+        updateParticipantStruct(
+            channel_identifier,
+            closing_participant,
+            nonce,
+            locksroot,
+            transferred_amount
+        );
 
         TransferUpdated(channel_identifier, closing_participant);
     }

--- a/raiden_contracts/tests/test_channel_update_transfer.py
+++ b/raiden_contracts/tests/test_channel_update_transfer.py
@@ -1,20 +1,15 @@
+import pytest
+from ethereum import tester
 from raiden_contracts.utils.config import E_TRANSFER_UPDATED
 from .utils import check_transfer_updated
 
 
-# TODO: test transferred_amount > deposit - this works now!!!!
-def test_update_channel_fail_small_deposit():
-    pass
-
-
-def test_update_channel_event_no_offchain_transfers(
+def test_update_channel_fail_no_offchain_transfers(
         get_accounts,
         token_network,
         create_channel,
-        create_balance_proof,
-        event_handler
+        create_balance_proof
 ):
-    ev_handler = event_handler(token_network)
     (A, B) = get_accounts(2)
 
     channel_identifier = create_channel(A, B)
@@ -22,10 +17,9 @@ def test_update_channel_event_no_offchain_transfers(
     balance_proof_B = create_balance_proof(channel_identifier, A, 0, 0)
 
     token_network.transact({'from': A}).closeChannel(*balance_proof_A)
-    txn_hash = token_network.transact({'from': B}).updateTransfer(*balance_proof_B)
 
-    ev_handler.add(txn_hash, E_TRANSFER_UPDATED, check_transfer_updated(channel_identifier, A))
-    ev_handler.check()
+    with pytest.raises(tester.TransactionFailed):
+        token_network.transact({'from': B}).updateTransfer(*balance_proof_B)
 
 
 def test_update_channel_event(


### PR DESCRIPTION
As discussed in https://github.com/raiden-network/raiden-contracts/pull/15#issuecomment-375062996, `updateTransfer` should fail if the `nonce` is 0.

(more updateTransfer tests will be added in another PR)