### PR TITLE
Update python to 3.6 - travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
   include:
     - language: python
       if: type = pull_request
-      python: '3.5'
+      python: '3.6'
       env:
         - TEST_TYPE=raiden_contracts
         - SOLC_URL='https://github.com/ethereum/solidity/releases/download/v0.4.19/solc-static-linux'

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ config = {
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.6',
     ],
     'entry_points': {
         'console_scripts': ['deploy = raiden_contracts.deploy.__main__:main'],


### PR DESCRIPTION
Reason: 
- stay in line with Raiden Network project
- support new string formatting such as `f"Event '{event_name}' not found.”`