### PR TITLE
Fix requirements, provide compiled data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ language: generic
 jobs:
   include:
     - language: python
-      if: type = pull_request
       python: '3.5'
       env:
         - TEST_TYPE=raiden_contracts
@@ -27,7 +26,7 @@ jobs:
         - pip install -U pip wheel coveralls "coverage<4.4"
         - pip install pytest-travis-fold
         - pip install flake8
-        - pip install -r requirements.txt
+        - pip install -r requirements-dev.txt
 
       before_script:
         - flake8 raiden_contracts/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
   include:
     - language: python
       if: type = pull_request
-      python: '3.6'
+      python: '3.5'
       env:
         - TEST_TYPE=raiden_contracts
         - SOLC_URL='https://github.com/ethereum/solidity/releases/download/v0.4.19/solc-static-linux'

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ python -m deploy --token-address <TOKEN_ADDRESS>
 
 ## Development
 
-We use `populus` for develpment. At the moment, this library is incompatible with recent libraries that act as dependencies. Therefore, we have to use different environments here.
+We use `populus` for development. At the moment, this library is incompatible with recent libraries that act as dependencies. Therefore, we have to use different environments here.
 
 ```bash
 pip install -r requirements-dev.txt

--- a/README.md
+++ b/README.md
@@ -8,30 +8,12 @@
 
 ## Installation
 
-### Compile the contracts
-As the `populus` library is incompatible with more recent libraries we have
-to use different environments here.
-
-First install the requirements
-```bash
-pip install -r requirements_populus.txt
 ```
-and then build the contracts
-```
-python setup.py build
-```
-
-
-After this uninstall `populus` and install the dependencies for the python package.
-```
-pip freeze  | xargs pip uninstall -y
-pip install -r requirements.txt
-
+make install
 ```
 
 ## Deployment on a testnet
 
-! You need to have the compiled contract data first. You can run `populus compile` for that.
 
 ```
 # Following calls are equivalent
@@ -40,7 +22,7 @@ python -m deploy
 
 python -m deploy \
        --rpc-provider http://127.0.0.1:8545 \
-       --json build/contracts.json
+       --json raiden_contracts/data/contracts.json
        --owner 0x5601Ea8445A5d96EEeBF89A67C4199FbB7a43Fbb \
        --wait 300 \
        --token-name CustomToken --token-symbol TKN \
@@ -51,11 +33,31 @@ python -m deploy --token-address <TOKEN_ADDRESS>
 
 ```
 
-## Use
+## Development
+
+We use `populus` for develpment. At the moment, this library is incompatible with recent libraries that act as dependencies. Therefore, we have to use different environments here.
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+After you are finished, to uninstall `populus` and install the dependencies for the `raiden-contracts` package, you can do:
 
 ```
-populus compile
+pip freeze  | xargs pip uninstall -y
+pip install -r requirements.txt
 
+```
+
+### Compile the contracts
+
+```
+python setup.py build
+```
+
+### Testing
+
+```
 # tests
 pytest
 pytest -p no:warnings -s

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -35,9 +35,9 @@ def get_event_from_abi(abi: list, event_name: str):
 
     num_results = len(result)
     if num_results == 0:
-        raise KeyError(f"Event '{event_name}' not found.")
+        raise KeyError("Event '{}' not found.".format(event_name))
     elif num_results >= 2:
-        raise KeyError(f"Multiple events '{event_name}' found.")
+        raise KeyError("Multiple events '{}' found.".format(event_name))
 
     return result[0]
 

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -12,18 +12,25 @@ CONTRACTS_SOURCE_DIRS = {
 CONTRACTS_SOURCE_DIRS = {
     k: os.path.normpath(v) for k, v in CONTRACTS_SOURCE_DIRS.items()
 }
-HAS_SOLIDITY = False
+_solidity = None
+
+
+def import_or_return_none(module):
+    import importlib
+    try:
+        return importlib.import_module(module)
+    except ImportError:
+        return None
+
 
 #
-# set HAS_SOLIDITY to True if ethereum library is installed AND solidity binary exists
+# import _solidity as a module if ethereum library is installed AND solidity binary exists
 #
-try:
-    from ethereum.tools import _solidity
-    if _solidity.get_compiler_path() is None:
-        log.warn('solc not found in $PATH. Check your path or set $SOLC_BINARY.')
-    else:
-        HAS_SOLIDITY = True
-except ImportError:
+_solidity = import_or_return_none('ethereum.tools._solidity')
+if _solidity is None:
+    # ethereum < 2.0.0
+    _solidity = import_or_return_none('ethereum._solidity')
+else:
     log.info('ethereum._solidity not found. Contract compilation will be unavailable')
 
 
@@ -46,7 +53,7 @@ def assert_has_solidity(func):
     """decorator - Raise CompileError if HAS_SOLIDITY is set to False"""
     @wraps(func)
     def func_wrap(*args, **kwargs):
-        if HAS_SOLIDITY is False:
+        if _solidity is None:
             raise _solidity.CompileError(
                 'solc not found in $PATH. Check your path or set $SOLC_BINARY.'
             )

--- a/raiden_contracts/data/contracts.json
+++ b/raiden_contracts/data/contracts.json
@@ -1,0 +1,3926 @@
+{
+    "CustomToken": {
+        "abi": [
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "name",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "string"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "_spender",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "approve",
+                "outputs": [
+                    {
+                        "name": "success",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [],
+                "name": "mint",
+                "outputs": [],
+                "payable": true,
+                "stateMutability": "payable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "totalSupply",
+                "outputs": [
+                    {
+                        "name": "supply",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "multiplier",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "_from",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_to",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "transferFrom",
+                "outputs": [
+                    {
+                        "name": "success",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "decimals",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "uint8"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [],
+                "name": "transferFunds",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "version",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "string"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "_owner",
+                        "type": "address"
+                    }
+                ],
+                "name": "balanceOf",
+                "outputs": [
+                    {
+                        "name": "balance",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "owner_address",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "address"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "symbol",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "string"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "_to",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "transfer",
+                "outputs": [
+                    {
+                        "name": "success",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "_owner",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_spender",
+                        "type": "address"
+                    }
+                ],
+                "name": "allowance",
+                "outputs": [
+                    {
+                        "name": "remaining",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "inputs": [
+                    {
+                        "name": "initial_supply",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "decimal_units",
+                        "type": "uint8"
+                    },
+                    {
+                        "name": "token_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "token_symbol",
+                        "type": "string"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "constructor"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": true,
+                        "name": "_to",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": true,
+                        "name": "_num",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "Minted",
+                "type": "event"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": true,
+                        "name": "_from",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": true,
+                        "name": "_to",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "Transfer",
+                "type": "event"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": true,
+                        "name": "_owner",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": true,
+                        "name": "_spender",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "Approval",
+                "type": "event"
+            }
+        ],
+        "bytecode": "0x60606040526040805190810160405280600481526020017f48302e31000000000000000000000000000000000000000000000000000000008152506003908051906020019062000051929190620001a9565b5034156200005e57600080fd5b604051620011f4380380620011f4833981016040528080519060200190919080519060200190919080518201919060200180518201919050508160049080519060200190620000af929190620001a9565b5082600660006101000a81548160ff021916908360ff1602179055508260ff16600a0a6007819055508060059080519060200190620000f0929190620001a9565b5033600860006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508360016000600860009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002081905550836000819055505050505062000258565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f10620001ec57805160ff19168380011785556200021d565b828001600101855582156200021d579182015b828111156200021c578251825591602001919060010190620001ff565b5b5090506200022c919062000230565b5090565b6200025591905b808211156200025157600081600090555060010162000237565b5090565b90565b610f8c80620002686000396000f3006060604052600436106100d0576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306fdde03146100d5578063095ea7b3146101635780631249c58b146101bd57806318160ddd146101c75780631b3ed722146101f057806323b872dd14610219578063313ce567146102925780633c68eb81146102c157806354fd4d50146102d657806370a082311461036457806380edef8e146103b157806395d89b4114610406578063a9059cbb14610494578063dd62ed3e146104ee575b600080fd5b34156100e057600080fd5b6100e861055a565b6040518080602001828103825283818151815260200191508051906020019080838360005b8381101561012857808201518184015260208101905061010d565b50505050905090810190601f1680156101555780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561016e57600080fd5b6101a3600480803573ffffffffffffffffffffffffffffffffffffffff169060200190919080359060200190919050506105f8565b604051808215151515815260200191505060405180910390f35b6101c56106ea565b005b34156101d257600080fd5b6101da610807565b6040518082815260200191505060405180910390f35b34156101fb57600080fd5b610203610810565b6040518082815260200191505060405180910390f35b341561022457600080fd5b610278600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050610816565b604051808215151515815260200191505060405180910390f35b341561029d57600080fd5b6102a5610a92565b604051808260ff1660ff16815260200191505060405180910390f35b34156102cc57600080fd5b6102d4610aa5565b005b34156102e157600080fd5b6102e9610bc5565b6040518080602001828103825283818151815260200191508051906020019080838360005b8381101561032957808201518184015260208101905061030e565b50505050905090810190601f1680156103565780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561036f57600080fd5b61039b600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610c63565b6040518082815260200191505060405180910390f35b34156103bc57600080fd5b6103c4610cac565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561041157600080fd5b610419610cd2565b6040518080602001828103825283818151815260200191508051906020019080838360005b8381101561045957808201518184015260208101905061043e565b50505050905090810190601f1680156104865780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561049f57600080fd5b6104d4600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050610d70565b604051808215151515815260200191505060405180910390f35b34156104f957600080fd5b610544600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610ed9565b6040518082815260200191505060405180910390f35b60048054600181600116156101000203166002900480601f0160208091040260200160405190810160405280929190818152602001828054600181600116156101000203166002900480156105f05780601f106105c5576101008083540402835291602001916105f0565b820191906000526020600020905b8154815290600101906020018083116105d357829003601f168201915b505050505081565b600081600260003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925846040518082815260200191505060405180910390a36001905092915050565b600067016345785d8a0000341015151561070357600080fd5b600754603202905080600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550806000808282540192505081905550803373ffffffffffffffffffffffffffffffffffffffff167f30385c845b448a36257a6a1716e6ad2e1bc2cbe333cde1e69fe849ad6511adfe60405160405180910390a380600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054101515156107f657fe5b806000541015151561080457fe5b50565b60008054905090565b60075481565b600081600160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054101580156108e3575081600260008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410155b80156108ef5750600082115b15610a865781600160008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254019250508190555081600160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600260008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825403925050819055508273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a360019050610a8b565b600090505b9392505050565b600660009054906101000a900460ff1681565b600860009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16141515610b0157600080fd5b60003073ffffffffffffffffffffffffffffffffffffffff1631111515610b2757600080fd5b600860009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166108fc3073ffffffffffffffffffffffffffffffffffffffff16319081150290604051600060405180830381858888f193505050501515610ba057600080fd5b60003073ffffffffffffffffffffffffffffffffffffffff1631141515610bc357fe5b565b60038054600181600116156101000203166002900480601f016020809104026020016040519081016040528092919081815260200182805460018160011615610100020316600290048015610c5b5780601f10610c3057610100808354040283529160200191610c5b565b820191906000526020600020905b815481529060010190602001808311610c3e57829003601f168201915b505050505081565b6000600160008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020549050919050565b600860009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60058054600181600116156101000203166002900480601f016020809104026020016040519081016040528092919081815260200182805460018160011615610100020316600290048015610d685780601f10610d3d57610100808354040283529160200191610d68565b820191906000526020600020905b815481529060010190602001808311610d4b57829003601f168201915b505050505081565b600081600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410158015610dc15750600082115b15610ece5781600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600160008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825401925050819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a360019050610ed3565b600090505b92915050565b6000600260008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020549050929150505600a165627a7a723058200a69ffb8de150632b4e08b0e383b72efb3d4c11b628f67221ff416a6e0c607270029",
+        "bytecode_runtime": "0x6060604052600436106100d0576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306fdde03146100d5578063095ea7b3146101635780631249c58b146101bd57806318160ddd146101c75780631b3ed722146101f057806323b872dd14610219578063313ce567146102925780633c68eb81146102c157806354fd4d50146102d657806370a082311461036457806380edef8e146103b157806395d89b4114610406578063a9059cbb14610494578063dd62ed3e146104ee575b600080fd5b34156100e057600080fd5b6100e861055a565b6040518080602001828103825283818151815260200191508051906020019080838360005b8381101561012857808201518184015260208101905061010d565b50505050905090810190601f1680156101555780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561016e57600080fd5b6101a3600480803573ffffffffffffffffffffffffffffffffffffffff169060200190919080359060200190919050506105f8565b604051808215151515815260200191505060405180910390f35b6101c56106ea565b005b34156101d257600080fd5b6101da610807565b6040518082815260200191505060405180910390f35b34156101fb57600080fd5b610203610810565b6040518082815260200191505060405180910390f35b341561022457600080fd5b610278600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050610816565b604051808215151515815260200191505060405180910390f35b341561029d57600080fd5b6102a5610a92565b604051808260ff1660ff16815260200191505060405180910390f35b34156102cc57600080fd5b6102d4610aa5565b005b34156102e157600080fd5b6102e9610bc5565b6040518080602001828103825283818151815260200191508051906020019080838360005b8381101561032957808201518184015260208101905061030e565b50505050905090810190601f1680156103565780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561036f57600080fd5b61039b600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610c63565b6040518082815260200191505060405180910390f35b34156103bc57600080fd5b6103c4610cac565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561041157600080fd5b610419610cd2565b6040518080602001828103825283818151815260200191508051906020019080838360005b8381101561045957808201518184015260208101905061043e565b50505050905090810190601f1680156104865780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561049f57600080fd5b6104d4600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050610d70565b604051808215151515815260200191505060405180910390f35b34156104f957600080fd5b610544600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610ed9565b6040518082815260200191505060405180910390f35b60048054600181600116156101000203166002900480601f0160208091040260200160405190810160405280929190818152602001828054600181600116156101000203166002900480156105f05780601f106105c5576101008083540402835291602001916105f0565b820191906000526020600020905b8154815290600101906020018083116105d357829003601f168201915b505050505081565b600081600260003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925846040518082815260200191505060405180910390a36001905092915050565b600067016345785d8a0000341015151561070357600080fd5b600754603202905080600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550806000808282540192505081905550803373ffffffffffffffffffffffffffffffffffffffff167f30385c845b448a36257a6a1716e6ad2e1bc2cbe333cde1e69fe849ad6511adfe60405160405180910390a380600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054101515156107f657fe5b806000541015151561080457fe5b50565b60008054905090565b60075481565b600081600160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054101580156108e3575081600260008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410155b80156108ef5750600082115b15610a865781600160008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254019250508190555081600160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600260008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825403925050819055508273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a360019050610a8b565b600090505b9392505050565b600660009054906101000a900460ff1681565b600860009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16141515610b0157600080fd5b60003073ffffffffffffffffffffffffffffffffffffffff1631111515610b2757600080fd5b600860009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166108fc3073ffffffffffffffffffffffffffffffffffffffff16319081150290604051600060405180830381858888f193505050501515610ba057600080fd5b60003073ffffffffffffffffffffffffffffffffffffffff1631141515610bc357fe5b565b60038054600181600116156101000203166002900480601f016020809104026020016040519081016040528092919081815260200182805460018160011615610100020316600290048015610c5b5780601f10610c3057610100808354040283529160200191610c5b565b820191906000526020600020905b815481529060010190602001808311610c3e57829003601f168201915b505050505081565b6000600160008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020549050919050565b600860009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60058054600181600116156101000203166002900480601f016020809104026020016040519081016040528092919081815260200182805460018160011615610100020316600290048015610d685780601f10610d3d57610100808354040283529160200191610d68565b820191906000526020600020905b815481529060010190602001808311610d4b57829003601f168201915b505050505081565b600081600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410158015610dc15750600082115b15610ece5781600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600160008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825401925050819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a360019050610ed3565b600090505b92915050565b6000600260008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020549050929150505600a165627a7a723058200a69ffb8de150632b4e08b0e383b72efb3d4c11b628f67221ff416a6e0c607270029",
+        "direct_dependencies": [],
+        "full_dependencies": [],
+        "linkrefs": [],
+        "linkrefs_runtime": [],
+        "metadata": {
+            "compiler": {
+                "version": "0.4.19+commit.c4cbbb05"
+            },
+            "language": "Solidity",
+            "output": {
+                "abi": [
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "name",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "string"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "_spender",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_value",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "approve",
+                        "outputs": [
+                            {
+                                "name": "success",
+                                "type": "bool"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [],
+                        "name": "mint",
+                        "outputs": [],
+                        "payable": true,
+                        "stateMutability": "payable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "totalSupply",
+                        "outputs": [
+                            {
+                                "name": "supply",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "multiplier",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "_from",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_to",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_value",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "transferFrom",
+                        "outputs": [
+                            {
+                                "name": "success",
+                                "type": "bool"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "decimals",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "uint8"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [],
+                        "name": "transferFunds",
+                        "outputs": [],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "version",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "string"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [
+                            {
+                                "name": "_owner",
+                                "type": "address"
+                            }
+                        ],
+                        "name": "balanceOf",
+                        "outputs": [
+                            {
+                                "name": "balance",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "owner_address",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "address"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "symbol",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "string"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "_to",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_value",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "transfer",
+                        "outputs": [
+                            {
+                                "name": "success",
+                                "type": "bool"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [
+                            {
+                                "name": "_owner",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_spender",
+                                "type": "address"
+                            }
+                        ],
+                        "name": "allowance",
+                        "outputs": [
+                            {
+                                "name": "remaining",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "inputs": [
+                            {
+                                "name": "initial_supply",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "decimal_units",
+                                "type": "uint8"
+                            },
+                            {
+                                "name": "token_name",
+                                "type": "string"
+                            },
+                            {
+                                "name": "token_symbol",
+                                "type": "string"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "constructor"
+                    },
+                    {
+                        "anonymous": false,
+                        "inputs": [
+                            {
+                                "indexed": true,
+                                "name": "_to",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": true,
+                                "name": "_num",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "Minted",
+                        "type": "event"
+                    },
+                    {
+                        "anonymous": false,
+                        "inputs": [
+                            {
+                                "indexed": true,
+                                "name": "_from",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": true,
+                                "name": "_to",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": false,
+                                "name": "_value",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "Transfer",
+                        "type": "event"
+                    },
+                    {
+                        "anonymous": false,
+                        "inputs": [
+                            {
+                                "indexed": true,
+                                "name": "_owner",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": true,
+                                "name": "_spender",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": false,
+                                "name": "_value",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "Approval",
+                        "type": "event"
+                    }
+                ],
+                "devdoc": {
+                    "methods": {},
+                    "title": "CustomToken"
+                },
+                "userdoc": {
+                    "methods": {
+                        "mint()": {
+                            "notice": "Allows tokens to be minted and assigned to `msg.sender` For `msg.value >= 100 finney`, the sender receives 50 tokens"
+                        },
+                        "transferFunds()": {
+                            "notice": "Transfers the collected ETH to the contract owner."
+                        }
+                    }
+                }
+            },
+            "settings": {
+                "compilationTarget": {
+                    "contracts/test/CustomToken.sol": "CustomToken"
+                },
+                "libraries": {},
+                "optimizer": {
+                    "enabled": false,
+                    "runs": 200
+                },
+                "remappings": [
+                    ":raiden=contracts"
+                ]
+            },
+            "sources": {
+                "contracts/Token.sol": {
+                    "keccak256": "0xff6dd1a3a909e5466530b381b19fed6e60bc6bc1747dc85cf7cc072d6df60305",
+                    "urls": [
+                        "bzzr://c6fd58689f80672e3734fc8fd7fe71f9d46e493d5fe38ad47eb5606d64406ce6"
+                    ]
+                },
+                "contracts/test/CustomToken.sol": {
+                    "keccak256": "0x0a900bf6a61854b4f95b54e91117eee143879241d0e88a013a80567158e35cbd",
+                    "urls": [
+                        "bzzr://e8e1413a1aa463696ed18d4e002a1714f392269f620a121e1fef15983bb881d3"
+                    ]
+                },
+                "contracts/test/StandardToken.sol": {
+                    "keccak256": "0x15912af0d033588ea129891239507346057760b490644eab48c2cd1ef73cb1ce",
+                    "urls": [
+                        "bzzr://d61d306f6cf1760e03d9e31a0535b94b4584a673c3ef9c994f3463404792d237"
+                    ]
+                }
+            },
+            "version": 1
+        },
+        "name": "CustomToken",
+        "ordered_full_dependencies": [],
+        "source_path": "contracts/test/CustomToken.sol"
+    },
+    "HumanStandardToken": {
+        "abi": [
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "name",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "string"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "_spender",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "approve",
+                "outputs": [
+                    {
+                        "name": "success",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "totalSupply",
+                "outputs": [
+                    {
+                        "name": "supply",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "_from",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_to",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "transferFrom",
+                "outputs": [
+                    {
+                        "name": "success",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "decimals",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "uint8"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "version",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "string"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "_owner",
+                        "type": "address"
+                    }
+                ],
+                "name": "balanceOf",
+                "outputs": [
+                    {
+                        "name": "balance",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "symbol",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "string"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "_to",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "transfer",
+                "outputs": [
+                    {
+                        "name": "success",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "_spender",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_value",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "_extraData",
+                        "type": "bytes"
+                    }
+                ],
+                "name": "approveAndCall",
+                "outputs": [
+                    {
+                        "name": "success",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "_owner",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_spender",
+                        "type": "address"
+                    }
+                ],
+                "name": "allowance",
+                "outputs": [
+                    {
+                        "name": "remaining",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "inputs": [
+                    {
+                        "name": "_initialAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "_decimalUnits",
+                        "type": "uint8"
+                    },
+                    {
+                        "name": "_tokenName",
+                        "type": "string"
+                    },
+                    {
+                        "name": "_tokenSymbol",
+                        "type": "string"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "constructor"
+            },
+            {
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "fallback"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": true,
+                        "name": "_from",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": true,
+                        "name": "_to",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "Transfer",
+                "type": "event"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": true,
+                        "name": "_owner",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": true,
+                        "name": "_spender",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "Approval",
+                "type": "event"
+            }
+        ],
+        "bytecode": "0x60606040526040805190810160405280600481526020017f48302e3100000000000000000000000000000000000000000000000000000000815250600690805190602001906200005192919062000139565b5034156200005e57600080fd5b604051620011a6380380620011a68339810160405280805190602001909190805190602001909190805182019190602001805182019190505083600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002081905550836000819055508160039080519060200190620000fa92919062000139565b5082600460006101000a81548160ff021916908360ff16021790555080600590805190602001906200012e92919062000139565b5050505050620001e8565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f106200017c57805160ff1916838001178555620001ad565b82800160010185558215620001ad579182015b82811115620001ac5782518255916020019190600101906200018f565b5b509050620001bc9190620001c0565b5090565b620001e591905b80821115620001e1576000816000905550600101620001c7565b5090565b90565b610fae80620001f86000396000f3006060604052600436106100af576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306fdde03146100bf578063095ea7b31461014d57806318160ddd146101a757806323b872dd146101d0578063313ce5671461024957806354fd4d501461027857806370a082311461030657806395d89b4114610353578063a9059cbb146103e1578063cae9ca511461043b578063dd62ed3e146104d8575b34156100ba57600080fd5b600080fd5b34156100ca57600080fd5b6100d2610544565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156101125780820151818401526020810190506100f7565b50505050905090810190601f16801561013f5780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561015857600080fd5b61018d600480803573ffffffffffffffffffffffffffffffffffffffff169060200190919080359060200190919050506105e2565b604051808215151515815260200191505060405180910390f35b34156101b257600080fd5b6101ba6106d4565b6040518082815260200191505060405180910390f35b34156101db57600080fd5b61022f600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff169060200190919080359060200190919050506106dd565b604051808215151515815260200191505060405180910390f35b341561025457600080fd5b61025c610959565b604051808260ff1660ff16815260200191505060405180910390f35b341561028357600080fd5b61028b61096c565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156102cb5780820151818401526020810190506102b0565b50505050905090810190601f1680156102f85780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561031157600080fd5b61033d600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610a0a565b6040518082815260200191505060405180910390f35b341561035e57600080fd5b610366610a53565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156103a657808201518184015260208101905061038b565b50505050905090810190601f1680156103d35780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b34156103ec57600080fd5b610421600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050610af1565b604051808215151515815260200191505060405180910390f35b341561044657600080fd5b6104be600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190803590602001908201803590602001908080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505091905050610c5a565b604051808215151515815260200191505060405180910390f35b34156104e357600080fd5b61052e600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610efb565b6040518082815260200191505060405180910390f35b60038054600181600116156101000203166002900480601f0160208091040260200160405190810160405280929190818152602001828054600181600116156101000203166002900480156105da5780601f106105af576101008083540402835291602001916105da565b820191906000526020600020905b8154815290600101906020018083116105bd57829003601f168201915b505050505081565b600081600260003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925846040518082815260200191505060405180910390a36001905092915050565b60008054905090565b600081600160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054101580156107aa575081600260008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410155b80156107b65750600082115b1561094d5781600160008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254019250508190555081600160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600260008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825403925050819055508273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a360019050610952565b600090505b9392505050565b600460009054906101000a900460ff1681565b60068054600181600116156101000203166002900480601f016020809104026020016040519081016040528092919081815260200182805460018160011615610100020316600290048015610a025780601f106109d757610100808354040283529160200191610a02565b820191906000526020600020905b8154815290600101906020018083116109e557829003601f168201915b505050505081565b6000600160008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020549050919050565b60058054600181600116156101000203166002900480601f016020809104026020016040519081016040528092919081815260200182805460018160011615610100020316600290048015610ae95780601f10610abe57610100808354040283529160200191610ae9565b820191906000526020600020905b815481529060010190602001808311610acc57829003601f168201915b505050505081565b600081600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410158015610b425750600082115b15610c4f5781600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600160008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825401925050819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a360019050610c54565b600090505b92915050565b600082600260003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055508373ffffffffffffffffffffffffffffffffffffffff1660405180807f72656365697665417070726f76616c28616464726573732c75696e743235362c81526020017f616464726573732c627974657329000000000000000000000000000000000000815250602e01905060405180910390207c01000000000000000000000000000000000000000000000000000000009004338530866040518563ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001828051906020019080838360005b83811015610e36578082015181840152602081019050610e1b565b50505050905090810190601f168015610e635780820380516001836020036101000a031916815260200191505b5094505050505060006040518083038160008761646e5a03f1925050501515610e8b57600080fd5b8373ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925856040518082815260200191505060405180910390a3600190509392505050565b6000600260008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020549050929150505600a165627a7a723058200de8ebc6d46e712ab62e85b8385adc315f928b34392cad63c17ee888ef178d5e0029",
+        "bytecode_runtime": "0x6060604052600436106100af576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306fdde03146100bf578063095ea7b31461014d57806318160ddd146101a757806323b872dd146101d0578063313ce5671461024957806354fd4d501461027857806370a082311461030657806395d89b4114610353578063a9059cbb146103e1578063cae9ca511461043b578063dd62ed3e146104d8575b34156100ba57600080fd5b600080fd5b34156100ca57600080fd5b6100d2610544565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156101125780820151818401526020810190506100f7565b50505050905090810190601f16801561013f5780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561015857600080fd5b61018d600480803573ffffffffffffffffffffffffffffffffffffffff169060200190919080359060200190919050506105e2565b604051808215151515815260200191505060405180910390f35b34156101b257600080fd5b6101ba6106d4565b6040518082815260200191505060405180910390f35b34156101db57600080fd5b61022f600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff169060200190919080359060200190919050506106dd565b604051808215151515815260200191505060405180910390f35b341561025457600080fd5b61025c610959565b604051808260ff1660ff16815260200191505060405180910390f35b341561028357600080fd5b61028b61096c565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156102cb5780820151818401526020810190506102b0565b50505050905090810190601f1680156102f85780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561031157600080fd5b61033d600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610a0a565b6040518082815260200191505060405180910390f35b341561035e57600080fd5b610366610a53565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156103a657808201518184015260208101905061038b565b50505050905090810190601f1680156103d35780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b34156103ec57600080fd5b610421600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050610af1565b604051808215151515815260200191505060405180910390f35b341561044657600080fd5b6104be600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190803590602001908201803590602001908080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505091905050610c5a565b604051808215151515815260200191505060405180910390f35b34156104e357600080fd5b61052e600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610efb565b6040518082815260200191505060405180910390f35b60038054600181600116156101000203166002900480601f0160208091040260200160405190810160405280929190818152602001828054600181600116156101000203166002900480156105da5780601f106105af576101008083540402835291602001916105da565b820191906000526020600020905b8154815290600101906020018083116105bd57829003601f168201915b505050505081565b600081600260003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925846040518082815260200191505060405180910390a36001905092915050565b60008054905090565b600081600160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054101580156107aa575081600260008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410155b80156107b65750600082115b1561094d5781600160008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254019250508190555081600160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600260008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825403925050819055508273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a360019050610952565b600090505b9392505050565b600460009054906101000a900460ff1681565b60068054600181600116156101000203166002900480601f016020809104026020016040519081016040528092919081815260200182805460018160011615610100020316600290048015610a025780601f106109d757610100808354040283529160200191610a02565b820191906000526020600020905b8154815290600101906020018083116109e557829003601f168201915b505050505081565b6000600160008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020549050919050565b60058054600181600116156101000203166002900480601f016020809104026020016040519081016040528092919081815260200182805460018160011615610100020316600290048015610ae95780601f10610abe57610100808354040283529160200191610ae9565b820191906000526020600020905b815481529060010190602001808311610acc57829003601f168201915b505050505081565b600081600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410158015610b425750600082115b15610c4f5781600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600160008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825401925050819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a360019050610c54565b600090505b92915050565b600082600260003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055508373ffffffffffffffffffffffffffffffffffffffff1660405180807f72656365697665417070726f76616c28616464726573732c75696e743235362c81526020017f616464726573732c627974657329000000000000000000000000000000000000815250602e01905060405180910390207c01000000000000000000000000000000000000000000000000000000009004338530866040518563ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001828051906020019080838360005b83811015610e36578082015181840152602081019050610e1b565b50505050905090810190601f168015610e635780820380516001836020036101000a031916815260200191505b5094505050505060006040518083038160008761646e5a03f1925050501515610e8b57600080fd5b8373ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925856040518082815260200191505060405180910390a3600190509392505050565b6000600260008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020549050929150505600a165627a7a723058200de8ebc6d46e712ab62e85b8385adc315f928b34392cad63c17ee888ef178d5e0029",
+        "direct_dependencies": [],
+        "full_dependencies": [],
+        "linkrefs": [],
+        "linkrefs_runtime": [],
+        "metadata": {
+            "compiler": {
+                "version": "0.4.19+commit.c4cbbb05"
+            },
+            "language": "Solidity",
+            "output": {
+                "abi": [
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "name",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "string"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "_spender",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_value",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "approve",
+                        "outputs": [
+                            {
+                                "name": "success",
+                                "type": "bool"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "totalSupply",
+                        "outputs": [
+                            {
+                                "name": "supply",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "_from",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_to",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_value",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "transferFrom",
+                        "outputs": [
+                            {
+                                "name": "success",
+                                "type": "bool"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "decimals",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "uint8"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "version",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "string"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [
+                            {
+                                "name": "_owner",
+                                "type": "address"
+                            }
+                        ],
+                        "name": "balanceOf",
+                        "outputs": [
+                            {
+                                "name": "balance",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "symbol",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "string"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "_to",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_value",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "transfer",
+                        "outputs": [
+                            {
+                                "name": "success",
+                                "type": "bool"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "_spender",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_value",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "_extraData",
+                                "type": "bytes"
+                            }
+                        ],
+                        "name": "approveAndCall",
+                        "outputs": [
+                            {
+                                "name": "success",
+                                "type": "bool"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [
+                            {
+                                "name": "_owner",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_spender",
+                                "type": "address"
+                            }
+                        ],
+                        "name": "allowance",
+                        "outputs": [
+                            {
+                                "name": "remaining",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "inputs": [
+                            {
+                                "name": "_initialAmount",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "_decimalUnits",
+                                "type": "uint8"
+                            },
+                            {
+                                "name": "_tokenName",
+                                "type": "string"
+                            },
+                            {
+                                "name": "_tokenSymbol",
+                                "type": "string"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "constructor"
+                    },
+                    {
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "fallback"
+                    },
+                    {
+                        "anonymous": false,
+                        "inputs": [
+                            {
+                                "indexed": true,
+                                "name": "_from",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": true,
+                                "name": "_to",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": false,
+                                "name": "_value",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "Transfer",
+                        "type": "event"
+                    },
+                    {
+                        "anonymous": false,
+                        "inputs": [
+                            {
+                                "indexed": true,
+                                "name": "_owner",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": true,
+                                "name": "_spender",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": false,
+                                "name": "_value",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "Approval",
+                        "type": "event"
+                    }
+                ],
+                "devdoc": {
+                    "methods": {}
+                },
+                "userdoc": {
+                    "methods": {}
+                }
+            },
+            "settings": {
+                "compilationTarget": {
+                    "contracts/test/HumanStandardToken.sol": "HumanStandardToken"
+                },
+                "libraries": {},
+                "optimizer": {
+                    "enabled": false,
+                    "runs": 200
+                },
+                "remappings": [
+                    ":raiden=contracts"
+                ]
+            },
+            "sources": {
+                "contracts/Token.sol": {
+                    "keccak256": "0xff6dd1a3a909e5466530b381b19fed6e60bc6bc1747dc85cf7cc072d6df60305",
+                    "urls": [
+                        "bzzr://c6fd58689f80672e3734fc8fd7fe71f9d46e493d5fe38ad47eb5606d64406ce6"
+                    ]
+                },
+                "contracts/test/HumanStandardToken.sol": {
+                    "keccak256": "0x4912375d041204f653687331e3a11d83d665590a2555e7381fcce02df57b9295",
+                    "urls": [
+                        "bzzr://e68981682f4940bfaeec67e0757cc738bade93678324a265b745a6024a706c2f"
+                    ]
+                },
+                "contracts/test/StandardToken.sol": {
+                    "keccak256": "0x15912af0d033588ea129891239507346057760b490644eab48c2cd1ef73cb1ce",
+                    "urls": [
+                        "bzzr://d61d306f6cf1760e03d9e31a0535b94b4584a673c3ef9c994f3463404792d237"
+                    ]
+                }
+            },
+            "version": 1
+        },
+        "name": "HumanStandardToken",
+        "ordered_full_dependencies": [],
+        "source_path": "contracts/test/HumanStandardToken.sol"
+    },
+    "SecretRegistry": {
+        "abi": [
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "secret",
+                        "type": "bytes32"
+                    }
+                ],
+                "name": "registerSecret",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "",
+                        "type": "bytes32"
+                    }
+                ],
+                "name": "secret_to_block",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "contract_version",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "string"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": false,
+                        "name": "secret",
+                        "type": "bytes32"
+                    }
+                ],
+                "name": "SecretRevealed",
+                "type": "event"
+            }
+        ],
+        "bytecode": "0x6060604052341561000f57600080fd5b6102768061001e6000396000f300606060405260043610610057576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806312ad8bfc1461005c57806391ea1a851461009b578063b32c65c8146100d6575b600080fd5b341561006757600080fd5b610081600480803560001916906020019091905050610164565b604051808215151515815260200191505060405180910390f35b34156100a657600080fd5b6100c06004808035600019169060200190919050506101f9565b6040518082815260200191505060405180910390f35b34156100e157600080fd5b6100e9610211565b6040518080602001828103825283818151815260200191508051906020019080838360005b8381101561012957808201518184015260208101905061010e565b50505050905090810190601f1680156101565780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b600080600080846000191660001916815260200190815260200160002054111561019157600090506101f4565b436000808460001916600019168152602001908152602001600020819055507f9b7ddc883342824bd7ddbff103e7a69f8f2e60b96c075cd1b8b8b9713ecc75a48260405180826000191660001916815260200191505060405180910390a1600190505b919050565b60006020528060005260406000206000915090505481565b6040805190810160405280600581526020017f302e332e5f000000000000000000000000000000000000000000000000000000815250815600a165627a7a72305820d4585eef5a3c86eb7a6202b1903e429e300a27fb947de9b06636b08a1c7b25e70029",
+        "bytecode_runtime": "0x606060405260043610610057576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806312ad8bfc1461005c57806391ea1a851461009b578063b32c65c8146100d6575b600080fd5b341561006757600080fd5b610081600480803560001916906020019091905050610164565b604051808215151515815260200191505060405180910390f35b34156100a657600080fd5b6100c06004808035600019169060200190919050506101f9565b6040518082815260200191505060405180910390f35b34156100e157600080fd5b6100e9610211565b6040518080602001828103825283818151815260200191508051906020019080838360005b8381101561012957808201518184015260208101905061010e565b50505050905090810190601f1680156101565780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b600080600080846000191660001916815260200190815260200160002054111561019157600090506101f4565b436000808460001916600019168152602001908152602001600020819055507f9b7ddc883342824bd7ddbff103e7a69f8f2e60b96c075cd1b8b8b9713ecc75a48260405180826000191660001916815260200191505060405180910390a1600190505b919050565b60006020528060005260406000206000915090505481565b6040805190810160405280600581526020017f302e332e5f000000000000000000000000000000000000000000000000000000815250815600a165627a7a72305820d4585eef5a3c86eb7a6202b1903e429e300a27fb947de9b06636b08a1c7b25e70029",
+        "direct_dependencies": [],
+        "full_dependencies": [],
+        "linkrefs": [],
+        "linkrefs_runtime": [],
+        "metadata": {
+            "compiler": {
+                "version": "0.4.19+commit.c4cbbb05"
+            },
+            "language": "Solidity",
+            "output": {
+                "abi": [
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "secret",
+                                "type": "bytes32"
+                            }
+                        ],
+                        "name": "registerSecret",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "bool"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [
+                            {
+                                "name": "",
+                                "type": "bytes32"
+                            }
+                        ],
+                        "name": "secret_to_block",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "contract_version",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "string"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "anonymous": false,
+                        "inputs": [
+                            {
+                                "indexed": false,
+                                "name": "secret",
+                                "type": "bytes32"
+                            }
+                        ],
+                        "name": "SecretRevealed",
+                        "type": "event"
+                    }
+                ],
+                "devdoc": {
+                    "methods": {}
+                },
+                "userdoc": {
+                    "methods": {}
+                }
+            },
+            "settings": {
+                "compilationTarget": {
+                    "contracts/SecretRegistry.sol": "SecretRegistry"
+                },
+                "libraries": {},
+                "optimizer": {
+                    "enabled": false,
+                    "runs": 200
+                },
+                "remappings": [
+                    ":raiden=contracts"
+                ]
+            },
+            "sources": {
+                "contracts/SecretRegistry.sol": {
+                    "keccak256": "0xe666c4da117f1041c74b2c447d67398932f96b66d777d0e73636614d3634b386",
+                    "urls": [
+                        "bzzr://bef4f9e61b6a5adcb6a281999b7a1c02184ce20722412bc3b13085b93cccee51"
+                    ]
+                }
+            },
+            "version": 1
+        },
+        "name": "SecretRegistry",
+        "ordered_full_dependencies": [],
+        "source_path": "contracts/SecretRegistry.sol"
+    },
+    "StandardToken": {
+        "abi": [
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "_spender",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "approve",
+                "outputs": [
+                    {
+                        "name": "success",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "totalSupply",
+                "outputs": [
+                    {
+                        "name": "supply",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "_from",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_to",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "transferFrom",
+                "outputs": [
+                    {
+                        "name": "success",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "_owner",
+                        "type": "address"
+                    }
+                ],
+                "name": "balanceOf",
+                "outputs": [
+                    {
+                        "name": "balance",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "_to",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "transfer",
+                "outputs": [
+                    {
+                        "name": "success",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "_owner",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_spender",
+                        "type": "address"
+                    }
+                ],
+                "name": "allowance",
+                "outputs": [
+                    {
+                        "name": "remaining",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": true,
+                        "name": "_from",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": true,
+                        "name": "_to",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "Transfer",
+                "type": "event"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": true,
+                        "name": "_owner",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": true,
+                        "name": "_spender",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "Approval",
+                "type": "event"
+            }
+        ],
+        "bytecode": "0x6060604052341561000f57600080fd5b6108688061001e6000396000f300606060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063095ea7b31461007d57806318160ddd146100d757806323b872dd1461010057806370a0823114610179578063a9059cbb146101c6578063dd62ed3e14610220575b600080fd5b341561008857600080fd5b6100bd600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190505061028c565b604051808215151515815260200191505060405180910390f35b34156100e257600080fd5b6100ea61037e565b6040518082815260200191505060405180910390f35b341561010b57600080fd5b61015f600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050610387565b604051808215151515815260200191505060405180910390f35b341561018457600080fd5b6101b0600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610603565b6040518082815260200191505060405180910390f35b34156101d157600080fd5b610206600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190505061064c565b604051808215151515815260200191505060405180910390f35b341561022b57600080fd5b610276600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff169060200190919050506107b5565b6040518082815260200191505060405180910390f35b600081600260003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925846040518082815260200191505060405180910390a36001905092915050565b60008054905090565b600081600160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410158015610454575081600260008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410155b80156104605750600082115b156105f75781600160008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254019250508190555081600160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600260008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825403925050819055508273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a3600190506105fc565b600090505b9392505050565b6000600160008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020549050919050565b600081600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020541015801561069d5750600082115b156107aa5781600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600160008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825401925050819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a3600190506107af565b600090505b92915050565b6000600260008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020549050929150505600a165627a7a72305820aca6bd312c8d172765dda988ea37bf75d10b584eb093a1fc01fc8b93aab2a5400029",
+        "bytecode_runtime": "0x606060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063095ea7b31461007d57806318160ddd146100d757806323b872dd1461010057806370a0823114610179578063a9059cbb146101c6578063dd62ed3e14610220575b600080fd5b341561008857600080fd5b6100bd600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190505061028c565b604051808215151515815260200191505060405180910390f35b34156100e257600080fd5b6100ea61037e565b6040518082815260200191505060405180910390f35b341561010b57600080fd5b61015f600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050610387565b604051808215151515815260200191505060405180910390f35b341561018457600080fd5b6101b0600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610603565b6040518082815260200191505060405180910390f35b34156101d157600080fd5b610206600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190505061064c565b604051808215151515815260200191505060405180910390f35b341561022b57600080fd5b610276600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff169060200190919050506107b5565b6040518082815260200191505060405180910390f35b600081600260003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925846040518082815260200191505060405180910390a36001905092915050565b60008054905090565b600081600160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410158015610454575081600260008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410155b80156104605750600082115b156105f75781600160008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254019250508190555081600160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600260008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825403925050819055508273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a3600190506105fc565b600090505b9392505050565b6000600160008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020549050919050565b600081600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020541015801561069d5750600082115b156107aa5781600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600160008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825401925050819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a3600190506107af565b600090505b92915050565b6000600260008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020549050929150505600a165627a7a72305820aca6bd312c8d172765dda988ea37bf75d10b584eb093a1fc01fc8b93aab2a5400029",
+        "direct_dependencies": [],
+        "full_dependencies": [],
+        "linkrefs": [],
+        "linkrefs_runtime": [],
+        "metadata": {
+            "compiler": {
+                "version": "0.4.19+commit.c4cbbb05"
+            },
+            "language": "Solidity",
+            "output": {
+                "abi": [
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "_spender",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_value",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "approve",
+                        "outputs": [
+                            {
+                                "name": "success",
+                                "type": "bool"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "totalSupply",
+                        "outputs": [
+                            {
+                                "name": "supply",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "_from",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_to",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_value",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "transferFrom",
+                        "outputs": [
+                            {
+                                "name": "success",
+                                "type": "bool"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [
+                            {
+                                "name": "_owner",
+                                "type": "address"
+                            }
+                        ],
+                        "name": "balanceOf",
+                        "outputs": [
+                            {
+                                "name": "balance",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "_to",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_value",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "transfer",
+                        "outputs": [
+                            {
+                                "name": "success",
+                                "type": "bool"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [
+                            {
+                                "name": "_owner",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_spender",
+                                "type": "address"
+                            }
+                        ],
+                        "name": "allowance",
+                        "outputs": [
+                            {
+                                "name": "remaining",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "anonymous": false,
+                        "inputs": [
+                            {
+                                "indexed": true,
+                                "name": "_from",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": true,
+                                "name": "_to",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": false,
+                                "name": "_value",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "Transfer",
+                        "type": "event"
+                    },
+                    {
+                        "anonymous": false,
+                        "inputs": [
+                            {
+                                "indexed": true,
+                                "name": "_owner",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": true,
+                                "name": "_spender",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": false,
+                                "name": "_value",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "Approval",
+                        "type": "event"
+                    }
+                ],
+                "devdoc": {
+                    "methods": {}
+                },
+                "userdoc": {
+                    "methods": {}
+                }
+            },
+            "settings": {
+                "compilationTarget": {
+                    "contracts/test/StandardToken.sol": "StandardToken"
+                },
+                "libraries": {},
+                "optimizer": {
+                    "enabled": false,
+                    "runs": 200
+                },
+                "remappings": [
+                    ":raiden=contracts"
+                ]
+            },
+            "sources": {
+                "contracts/Token.sol": {
+                    "keccak256": "0xff6dd1a3a909e5466530b381b19fed6e60bc6bc1747dc85cf7cc072d6df60305",
+                    "urls": [
+                        "bzzr://c6fd58689f80672e3734fc8fd7fe71f9d46e493d5fe38ad47eb5606d64406ce6"
+                    ]
+                },
+                "contracts/test/StandardToken.sol": {
+                    "keccak256": "0x15912af0d033588ea129891239507346057760b490644eab48c2cd1ef73cb1ce",
+                    "urls": [
+                        "bzzr://d61d306f6cf1760e03d9e31a0535b94b4584a673c3ef9c994f3463404792d237"
+                    ]
+                }
+            },
+            "version": 1
+        },
+        "name": "StandardToken",
+        "ordered_full_dependencies": [],
+        "source_path": "contracts/test/StandardToken.sol"
+    },
+    "Token": {
+        "abi": [
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "_spender",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "approve",
+                "outputs": [
+                    {
+                        "name": "success",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "totalSupply",
+                "outputs": [
+                    {
+                        "name": "supply",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "_from",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_to",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "transferFrom",
+                "outputs": [
+                    {
+                        "name": "success",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "_owner",
+                        "type": "address"
+                    }
+                ],
+                "name": "balanceOf",
+                "outputs": [
+                    {
+                        "name": "balance",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "_to",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "transfer",
+                "outputs": [
+                    {
+                        "name": "success",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "_owner",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_spender",
+                        "type": "address"
+                    }
+                ],
+                "name": "allowance",
+                "outputs": [
+                    {
+                        "name": "remaining",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": true,
+                        "name": "_from",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": true,
+                        "name": "_to",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "Transfer",
+                "type": "event"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": true,
+                        "name": "_owner",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": true,
+                        "name": "_spender",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "_value",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "Approval",
+                "type": "event"
+            }
+        ],
+        "bytecode": "0x",
+        "bytecode_runtime": "0x",
+        "direct_dependencies": [],
+        "full_dependencies": [],
+        "linkrefs": [],
+        "linkrefs_runtime": [],
+        "metadata": null,
+        "name": "Token",
+        "ordered_full_dependencies": [],
+        "source_path": "contracts/Token.sol"
+    },
+    "TokenNetwork": {
+        "abi": [
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "channel_identifier",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "nonce",
+                        "type": "uint64"
+                    },
+                    {
+                        "name": "transferred_amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "locksroot",
+                        "type": "bytes32"
+                    },
+                    {
+                        "name": "additional_hash",
+                        "type": "bytes32"
+                    },
+                    {
+                        "name": "signature",
+                        "type": "bytes"
+                    }
+                ],
+                "name": "closeChannel",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "participant1",
+                        "type": "address"
+                    },
+                    {
+                        "name": "participant2",
+                        "type": "address"
+                    },
+                    {
+                        "name": "settle_timeout",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "openChannel",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "secret",
+                        "type": "bytes32"
+                    }
+                ],
+                "name": "registerSecret",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "channel_identifier",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "getChannelInfo",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "",
+                        "type": "address"
+                    },
+                    {
+                        "name": "",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "last_channel_index",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "secret_registry",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "address"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "chain_id",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "closing_requests",
+                "outputs": [
+                    {
+                        "name": "closing_participant",
+                        "type": "address"
+                    },
+                    {
+                        "name": "settle_block_number",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "channel_identifier",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "nonce",
+                        "type": "uint64"
+                    },
+                    {
+                        "name": "transferred_amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "locksroot",
+                        "type": "bytes32"
+                    },
+                    {
+                        "name": "additional_hash",
+                        "type": "bytes32"
+                    },
+                    {
+                        "name": "closing_signature",
+                        "type": "bytes"
+                    },
+                    {
+                        "name": "non_closing_signature",
+                        "type": "bytes"
+                    }
+                ],
+                "name": "updateTransferDelegate",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "channel_identifier",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "partner",
+                        "type": "address"
+                    },
+                    {
+                        "name": "expiration_block",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "locked_amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "merkle_proof",
+                        "type": "bytes"
+                    },
+                    {
+                        "name": "secret",
+                        "type": "bytes32"
+                    }
+                ],
+                "name": "registerSecretAndUnlock",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "channel_identifier",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "partner",
+                        "type": "address"
+                    },
+                    {
+                        "name": "expiration_block",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "locked_amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "merkle_proof",
+                        "type": "bytes"
+                    },
+                    {
+                        "name": "secret",
+                        "type": "bytes32"
+                    }
+                ],
+                "name": "unlock",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "contract_address",
+                        "type": "address"
+                    }
+                ],
+                "name": "contractExists",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "channel_identifier",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "participant",
+                        "type": "address"
+                    }
+                ],
+                "name": "getChannelParticipantInfo",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "",
+                        "type": "uint64"
+                    },
+                    {
+                        "name": "",
+                        "type": "bytes32"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "channel_identifier",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "participant1",
+                        "type": "address"
+                    },
+                    {
+                        "name": "participant2",
+                        "type": "address"
+                    }
+                ],
+                "name": "settleChannel",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "contract_version",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "string"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "channel_identifier",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "nonce",
+                        "type": "uint64"
+                    },
+                    {
+                        "name": "transferred_amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "locksroot",
+                        "type": "bytes32"
+                    },
+                    {
+                        "name": "additional_hash",
+                        "type": "bytes32"
+                    },
+                    {
+                        "name": "closing_signature",
+                        "type": "bytes"
+                    }
+                ],
+                "name": "updateTransfer",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "channel_identifier",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "participant",
+                        "type": "address"
+                    },
+                    {
+                        "name": "total_deposit",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "setDeposit",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "channels",
+                "outputs": [
+                    {
+                        "name": "settle_timeout",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "token",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "address"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "inputs": [
+                    {
+                        "name": "_token_address",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_secret_registry",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_chain_id",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "constructor"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": false,
+                        "name": "channel_identifier",
+                        "type": "uint256"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "participant1",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "participant2",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "settle_timeout",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "ChannelOpened",
+                "type": "event"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": false,
+                        "name": "channel_identifier",
+                        "type": "uint256"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "participant",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "deposit",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "ChannelNewDeposit",
+                "type": "event"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": false,
+                        "name": "channel_identifier",
+                        "type": "uint256"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "closing_participant",
+                        "type": "address"
+                    }
+                ],
+                "name": "ChannelClosed",
+                "type": "event"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": false,
+                        "name": "channel_identifier",
+                        "type": "uint256"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "payer_participant",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "transferred_amount",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "ChannelUnlocked",
+                "type": "event"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": false,
+                        "name": "channel_identifier",
+                        "type": "uint256"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "closing_participant",
+                        "type": "address"
+                    }
+                ],
+                "name": "TransferUpdated",
+                "type": "event"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": false,
+                        "name": "channel_identifier",
+                        "type": "uint256"
+                    }
+                ],
+                "name": "ChannelSettled",
+                "type": "event"
+            }
+        ],
+        "bytecode": "0x6060604052600060045534156200001557600080fd5b6040516060806200252a8339810160405280805190602001909190805190602001909190805190602001909190505060008373ffffffffffffffffffffffffffffffffffffffff16141515156200006b57600080fd5b60008273ffffffffffffffffffffffffffffffffffffffff16141515156200009257600080fd5b600081111515620000a257600080fd5b620000c18362000242640100000000026200142b176401000000009004565b1515620000cd57600080fd5b620000ec8262000242640100000000026200142b176401000000009004565b1515620000f857600080fd5b826000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555060008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166318160ddd6000604051602001526040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401602060405180830381600087803b1515620001c857600080fd5b6102c65a03f11515620001da57600080fd5b50505060405180519050111515620001f157600080fd5b81600160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508060028190555050505062000255565b600080823b905060008111915050919050565b6122c580620002656000396000f300606060405260043610610107576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806301b5e2a91461010c5780630a798f24146101a857806312ad8bfc1461021d5780631d7a4993146102445780631f466acf146102b557806324d73a93146102de5780633af973b1146103335780634ff7ff831461035c5780635143f888146103c6578063534df796146104475780637261dca0146104bc5780637709bc78146105605780637fb5885e146105b15780638ad11c1314610643578063b32c65c8146106a4578063b467768714610732578063c2ed2822146107ce578063e5949b5d14610819578063fc0c546a14610850575b600080fd5b341561011757600080fd5b6101a6600480803590602001909190803567ffffffffffffffff16906020019091908035906020019091908035600019169060200190919080356000191690602001909190803590602001908201803590602001908080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050919050506108a5565b005b34156101b357600080fd5b610207600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050610a78565b6040518082815260200191505060405180910390f35b341561022857600080fd5b610242600480803560001916906020019091905050610d1e565b005b341561024f57600080fd5b6102656004808035906020019091905050610de8565b604051808481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001828152602001935050505060405180910390f35b34156102c057600080fd5b6102c8610e58565b6040518082815260200191505060405180910390f35b34156102e957600080fd5b6102f1610e5e565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561033e57600080fd5b610346610e84565b6040518082815260200191505060405180910390f35b341561036757600080fd5b61037d6004808035906020019091905050610e8a565b604051808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018281526020019250505060405180910390f35b34156103d157600080fd5b610445600480803590602001909190803567ffffffffffffffff16906020019091908035906020019091908035600019169060200190919080356000191690602001909190803590602001908201803590602001919091929080359060200190820180359060200191909192905050610ece565b005b341561045257600080fd5b6104ba600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190803590602001909190803590602001908201803590602001919091929080356000191690602001909190505061103e565b005b34156104c757600080fd5b61055e600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190803590602001909190803590602001908201803590602001908080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505091908035600019169060200190919050506110b7565b005b341561056b57600080fd5b610597600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190505061142b565b604051808215151515815260200191505060405180910390f35b34156105bc57600080fd5b6105f1600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190505061143e565b60405180861515151581526020018581526020018481526020018367ffffffffffffffff1667ffffffffffffffff16815260200182600019166000191681526020019550505050505060405180910390f35b341561064e57600080fd5b6106a2600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff169060200190919050506114f1565b005b34156106af57600080fd5b6106b76119f9565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156106f75780820151818401526020810190506106dc565b50505050905090810190601f1680156107245780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561073d57600080fd5b6107cc600480803590602001909190803567ffffffffffffffff16906020019091908035906020019091908035600019169060200190919080356000191690602001909190803590602001908201803590602001908080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505091905050611a32565b005b34156107d957600080fd5b610817600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050611b28565b005b341561082457600080fd5b61083a6004808035906020019091905050611d99565b6040518082815260200191505060405180910390f35b341561085b57600080fd5b610863611db7565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b6000806000600560008a81526020019081526020016000209150600082600101541415156108d257600080fd5b600360008a815260200190815260200160002090508060010160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060030160089054906101000a900460ff16151561094457600080fd5b338260000160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055504381600001540182600101819055506109a4898989898989611ddc565b92508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16141515156109e157600080fd5b60008867ffffffffffffffff161115610a0257610a0189848a898b611f5e565b5b7fa8621c489a70a0a06448f2b4e3477913a3744d5f27a380e5f0d8db13837ce7c68933604051808381526020018273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019250505060405180910390a1505050505050505050565b6000806000808460068110158015610a935750622932e08111155b1515610a9e57600080fd5b60008873ffffffffffffffffffffffffffffffffffffffff1614151515610ac457600080fd5b60008773ffffffffffffffffffffffffffffffffffffffff1614151515610aea57600080fd5b8673ffffffffffffffffffffffffffffffffffffffff168873ffffffffffffffffffffffffffffffffffffffff1614151515610b2557600080fd5b6001600460008282540192505081905550600360006004548152602001908152602001600020935060008460000154141515610b6057600080fd5b8360010160008973ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002092508360010160008873ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002091508260030160089054906101000a900460ff16151515610c0457600080fd5b8160030160089054906101000a900460ff16151515610c2257600080fd5b85846000018190555060018360030160086101000a81548160ff02191690831515021790555060018260030160086101000a81548160ff0219169083151502179055507f669a4b0ac0b9994c0f82ed4dbe07bb421fe74e5951725af4f139c7443ebf049d600454898989604051808581526020018473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200194505050505060405180910390a16004549450505050509392505050565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166312ad8bfc826000604051602001526040518263ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808260001916600019168152602001915050602060405180830381600087803b1515610dbf57600080fd5b6102c65a03f11515610dd057600080fd5b505050604051805190501515610de557600080fd5b50565b600080600080600060036000878152602001908152602001600020915060056000878152602001908152602001600020905081600001548160000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff16826001015494509450945050509193909250565b60045481565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60025481565b60056020528060005260406000206000915090508060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff16908060010154905082565b6000610f108a8a8a8a8a88888080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050611ddc565b9050600360008b815260200190815260200160002060010160008273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060030160089054906101000a900460ff161515610f8157600080fd5b8073ffffffffffffffffffffffffffffffffffffffff16600560008c815260200190815260200160002060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614151515610ff257600080fd5b6110328a8a8a8a8a8a8a8080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505061206d565b50505050505050505050565b864360056000838152602001908152602001600020600101541015151561106457600080fd5b61106d82610d1e565b6110ad8888888888888080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050876110b7565b5050505050505050565b6000806000806000808b436005600083815260200190815260200160002060010154101515156110e657600080fd5b60036000600454815260200190815260200160002092508260010160008d73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002091508160030160089054906101000a900460ff16151561115d57600080fd5b60006001028260010154600019161415151561117857600080fd5b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166391ea1a85896000604051602001526040518263ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808260001916600019168152602001915050602060405180830381600087803b151561121957600080fd5b6102c65a03f1151561122a57600080fd5b505050604051805190508b11151561124157600080fd5b87604051808260001916600019168152602001915050604051809103902095508a8a8760405180848152602001838152602001826000191660001916815260200193505050506040518091039020935061129b848a612162565b945084600019168260010154600019161415156112b757600080fd5b8160030160009054906101000a900467ffffffffffffffff1686604051808367ffffffffffffffff1667ffffffffffffffff16780100000000000000000000000000000000000000000000000002815260080182600019166000191681526020019250505060405180910390209650816004016000886000191660001916815260200190815260200160002060009054906101000a900460ff1615151561135d57600080fd5b6001826004016000896000191660001916815260200190815260200160002060006101000a81548160ff0219169083151502179055508982600201600082825401925050819055507faacee9c8f29b8c239eb8ce3bb610204c69a7446820178e010930d755fe82165d8d8d8460020154604051808481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001828152602001935050505060405180910390a150505050505050505050505050565b600080823b905060008111915050919050565b6000806000806000806000600360008a815260200190815260200160002091508160010160008973ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002090508060030160089054906101000a900460ff16816000015482600201548360030160009054906101000a900467ffffffffffffffff1684600101549650965096509650965050509295509295909350565b600080600080600080886000600560008381526020019081526020016000206001015411151561152057600080fd5b8943600560008381526020019081526020016000206001015410151561154557600080fd5b600360008c815260200190815260200160002094508460010160008b73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002093508460010160008a73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002092508360030160089054906101000a900460ff1615156115fd57600080fd5b8260030160089054906101000a900460ff16151561161a57600080fd5b82600001548460000154019550836002015483600201548560000154010397506116448887612223565b975061165188600061223c565b975087860396508460010160008b73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600080820160009055600182016000905560028201600090556003820160006101000a81549067ffffffffffffffff02191690556003820160086101000a81549060ff021916905550508460010160008a73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600080820160009055600182016000905560028201600090556003820160006101000a81549067ffffffffffffffff02191690556003820160086101000a81549060ff02191690555050600360008c81526020019081526020016000206000808201600090555050600560008c8152602001908152602001600020600080820160006101000a81549073ffffffffffffffffffffffffffffffffffffffff0219169055600182016000905550506000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1663a9059cbb8b8a6000604051602001526040518363ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b151561189d57600080fd5b6102c65a03f115156118ae57600080fd5b5050506040518051905015156118c357600080fd5b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1663a9059cbb8a896000604051602001526040518363ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b151561198f57600080fd5b6102c65a03f115156119a057600080fd5b5050506040518051905015156119b557600080fd5b7ffe501c6f860c82db0609c0e0e7571f4a08c991e3b653cb35a7f105c84caccb998b6040518082815260200191505060405180910390a15050505050505050505050565b6040805190810160405280600581526020017f302e332e5f00000000000000000000000000000000000000000000000000000081525081565b6003600087815260200190815260200160002060010160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060030160089054906101000a900460ff161515611aa157600080fd5b3373ffffffffffffffffffffffffffffffffffffffff166005600088815260200190815260200160002060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614151515611b1257600080fd5b611b2086868686868661206d565b505050505050565b60008060006003600087815260200190815260200160002091508160010160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002090508060030160089054906101000a900460ff161515611ba257600080fd5b60006005600088815260200190815260200160002060010154141515611bc757600080fd5b838160000154101515611bd957600080fd5b8060000154840392508281600001600082825401925050819055506000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166323b872dd3330866000604051602001526040518463ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018281526020019350505050602060405180830381600087803b1515611cf457600080fd5b6102c65a03f11515611d0557600080fd5b505050604051805190501515611d1a57600080fd5b7f2b55547a3b586ab51f65ee9ce4927fa6d25191388299988e89e059a02f9dd44586868360000154604051808481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001828152602001935050505060405180910390a1505050505050565b60036020528060005260406000206000915090508060000154905081565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b600080600080600060418651141515611df457600080fd5b8989898d306002548c604051808867ffffffffffffffff1667ffffffffffffffff16780100000000000000000000000000000000000000000000000002815260080187815260200186600019166000191681526020018581526020018473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166c01000000000000000000000000028152601401838152602001826000191660001916815260200197505050505050505060405180910390209350611ec186612255565b925092509250600184828585604051600081526020016040526000604051602001526040518085600019166000191681526020018460ff1660ff16815260200183600019166000191681526020018260001916600019168152602001945050505050602060405160208103908084039060008661646e5a03f11515611f4557600080fd5b5050602060405103519450505050509695505050505050565b6000806003600088815260200190815260200160002091508160010160008773ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002090508060030160089054906101000a900460ff161515611fd657600080fd5b8060030160009054906101000a900467ffffffffffffffff1667ffffffffffffffff168567ffffffffffffffff1611151561201057600080fd5b8060020154831015151561202357600080fd5b848160030160006101000a81548167ffffffffffffffff021916908367ffffffffffffffff1602179055508381600101816000191690555082816002018190555050505050505050565b6000866000600560008381526020019081526020016000206001015411151561209557600080fd5b87436005600083815260200190815260200160002060010154101515156120bb57600080fd5b6120c9898989898989611ddc565b925060008867ffffffffffffffff1611156120ec576120eb89848a898b611f5e565b5b7f5f6805080768d958aca95521a302aaf432dd15f76abfe9868dd5128f25a29bc88984604051808381526020018273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019250505060405180910390a1505050505050505050565b6000806000806020855181151561217557fe5b0614151561218257600080fd5b602091505b835182111515612218578184015190508060001916856000191610156121dc5784816040518083600019166000191681526020018260001916600019168152602001925050506040518091039020945061220d565b8085604051808360001916600019168152602001826000191660001916815260200192505050604051809103902094505b602082019150612187565b849250505092915050565b60008183116122325782612234565b815b905092915050565b600081831161224b578161224d565b825b905092915050565b6000806000602084015192506040840151915060ff6041850151169050601b8160ff1614806122875750601c8160ff16145b151561229257600080fd5b91939092505600a165627a7a72305820fcb88e677decf0110bae912f74489e8352ef24bacc6a3a802c8417b658f7cda40029",
+        "bytecode_runtime": "0x606060405260043610610107576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806301b5e2a91461010c5780630a798f24146101a857806312ad8bfc1461021d5780631d7a4993146102445780631f466acf146102b557806324d73a93146102de5780633af973b1146103335780634ff7ff831461035c5780635143f888146103c6578063534df796146104475780637261dca0146104bc5780637709bc78146105605780637fb5885e146105b15780638ad11c1314610643578063b32c65c8146106a4578063b467768714610732578063c2ed2822146107ce578063e5949b5d14610819578063fc0c546a14610850575b600080fd5b341561011757600080fd5b6101a6600480803590602001909190803567ffffffffffffffff16906020019091908035906020019091908035600019169060200190919080356000191690602001909190803590602001908201803590602001908080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050919050506108a5565b005b34156101b357600080fd5b610207600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050610a78565b6040518082815260200191505060405180910390f35b341561022857600080fd5b610242600480803560001916906020019091905050610d1e565b005b341561024f57600080fd5b6102656004808035906020019091905050610de8565b604051808481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001828152602001935050505060405180910390f35b34156102c057600080fd5b6102c8610e58565b6040518082815260200191505060405180910390f35b34156102e957600080fd5b6102f1610e5e565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561033e57600080fd5b610346610e84565b6040518082815260200191505060405180910390f35b341561036757600080fd5b61037d6004808035906020019091905050610e8a565b604051808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018281526020019250505060405180910390f35b34156103d157600080fd5b610445600480803590602001909190803567ffffffffffffffff16906020019091908035906020019091908035600019169060200190919080356000191690602001909190803590602001908201803590602001919091929080359060200190820180359060200191909192905050610ece565b005b341561045257600080fd5b6104ba600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190803590602001909190803590602001908201803590602001919091929080356000191690602001909190505061103e565b005b34156104c757600080fd5b61055e600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190803590602001909190803590602001908201803590602001908080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505091908035600019169060200190919050506110b7565b005b341561056b57600080fd5b610597600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190505061142b565b604051808215151515815260200191505060405180910390f35b34156105bc57600080fd5b6105f1600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190505061143e565b60405180861515151581526020018581526020018481526020018367ffffffffffffffff1667ffffffffffffffff16815260200182600019166000191681526020019550505050505060405180910390f35b341561064e57600080fd5b6106a2600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff169060200190919050506114f1565b005b34156106af57600080fd5b6106b76119f9565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156106f75780820151818401526020810190506106dc565b50505050905090810190601f1680156107245780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561073d57600080fd5b6107cc600480803590602001909190803567ffffffffffffffff16906020019091908035906020019091908035600019169060200190919080356000191690602001909190803590602001908201803590602001908080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505091905050611a32565b005b34156107d957600080fd5b610817600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050611b28565b005b341561082457600080fd5b61083a6004808035906020019091905050611d99565b6040518082815260200191505060405180910390f35b341561085b57600080fd5b610863611db7565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b6000806000600560008a81526020019081526020016000209150600082600101541415156108d257600080fd5b600360008a815260200190815260200160002090508060010160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060030160089054906101000a900460ff16151561094457600080fd5b338260000160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055504381600001540182600101819055506109a4898989898989611ddc565b92508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16141515156109e157600080fd5b60008867ffffffffffffffff161115610a0257610a0189848a898b611f5e565b5b7fa8621c489a70a0a06448f2b4e3477913a3744d5f27a380e5f0d8db13837ce7c68933604051808381526020018273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019250505060405180910390a1505050505050505050565b6000806000808460068110158015610a935750622932e08111155b1515610a9e57600080fd5b60008873ffffffffffffffffffffffffffffffffffffffff1614151515610ac457600080fd5b60008773ffffffffffffffffffffffffffffffffffffffff1614151515610aea57600080fd5b8673ffffffffffffffffffffffffffffffffffffffff168873ffffffffffffffffffffffffffffffffffffffff1614151515610b2557600080fd5b6001600460008282540192505081905550600360006004548152602001908152602001600020935060008460000154141515610b6057600080fd5b8360010160008973ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002092508360010160008873ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002091508260030160089054906101000a900460ff16151515610c0457600080fd5b8160030160089054906101000a900460ff16151515610c2257600080fd5b85846000018190555060018360030160086101000a81548160ff02191690831515021790555060018260030160086101000a81548160ff0219169083151502179055507f669a4b0ac0b9994c0f82ed4dbe07bb421fe74e5951725af4f139c7443ebf049d600454898989604051808581526020018473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200194505050505060405180910390a16004549450505050509392505050565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166312ad8bfc826000604051602001526040518263ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808260001916600019168152602001915050602060405180830381600087803b1515610dbf57600080fd5b6102c65a03f11515610dd057600080fd5b505050604051805190501515610de557600080fd5b50565b600080600080600060036000878152602001908152602001600020915060056000878152602001908152602001600020905081600001548160000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff16826001015494509450945050509193909250565b60045481565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60025481565b60056020528060005260406000206000915090508060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff16908060010154905082565b6000610f108a8a8a8a8a88888080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050611ddc565b9050600360008b815260200190815260200160002060010160008273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060030160089054906101000a900460ff161515610f8157600080fd5b8073ffffffffffffffffffffffffffffffffffffffff16600560008c815260200190815260200160002060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614151515610ff257600080fd5b6110328a8a8a8a8a8a8a8080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505061206d565b50505050505050505050565b864360056000838152602001908152602001600020600101541015151561106457600080fd5b61106d82610d1e565b6110ad8888888888888080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050876110b7565b5050505050505050565b6000806000806000808b436005600083815260200190815260200160002060010154101515156110e657600080fd5b60036000600454815260200190815260200160002092508260010160008d73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002091508160030160089054906101000a900460ff16151561115d57600080fd5b60006001028260010154600019161415151561117857600080fd5b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166391ea1a85896000604051602001526040518263ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808260001916600019168152602001915050602060405180830381600087803b151561121957600080fd5b6102c65a03f1151561122a57600080fd5b505050604051805190508b11151561124157600080fd5b87604051808260001916600019168152602001915050604051809103902095508a8a8760405180848152602001838152602001826000191660001916815260200193505050506040518091039020935061129b848a612162565b945084600019168260010154600019161415156112b757600080fd5b8160030160009054906101000a900467ffffffffffffffff1686604051808367ffffffffffffffff1667ffffffffffffffff16780100000000000000000000000000000000000000000000000002815260080182600019166000191681526020019250505060405180910390209650816004016000886000191660001916815260200190815260200160002060009054906101000a900460ff1615151561135d57600080fd5b6001826004016000896000191660001916815260200190815260200160002060006101000a81548160ff0219169083151502179055508982600201600082825401925050819055507faacee9c8f29b8c239eb8ce3bb610204c69a7446820178e010930d755fe82165d8d8d8460020154604051808481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001828152602001935050505060405180910390a150505050505050505050505050565b600080823b905060008111915050919050565b6000806000806000806000600360008a815260200190815260200160002091508160010160008973ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002090508060030160089054906101000a900460ff16816000015482600201548360030160009054906101000a900467ffffffffffffffff1684600101549650965096509650965050509295509295909350565b600080600080600080886000600560008381526020019081526020016000206001015411151561152057600080fd5b8943600560008381526020019081526020016000206001015410151561154557600080fd5b600360008c815260200190815260200160002094508460010160008b73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002093508460010160008a73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002092508360030160089054906101000a900460ff1615156115fd57600080fd5b8260030160089054906101000a900460ff16151561161a57600080fd5b82600001548460000154019550836002015483600201548560000154010397506116448887612223565b975061165188600061223c565b975087860396508460010160008b73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600080820160009055600182016000905560028201600090556003820160006101000a81549067ffffffffffffffff02191690556003820160086101000a81549060ff021916905550508460010160008a73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600080820160009055600182016000905560028201600090556003820160006101000a81549067ffffffffffffffff02191690556003820160086101000a81549060ff02191690555050600360008c81526020019081526020016000206000808201600090555050600560008c8152602001908152602001600020600080820160006101000a81549073ffffffffffffffffffffffffffffffffffffffff0219169055600182016000905550506000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1663a9059cbb8b8a6000604051602001526040518363ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b151561189d57600080fd5b6102c65a03f115156118ae57600080fd5b5050506040518051905015156118c357600080fd5b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1663a9059cbb8a896000604051602001526040518363ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b151561198f57600080fd5b6102c65a03f115156119a057600080fd5b5050506040518051905015156119b557600080fd5b7ffe501c6f860c82db0609c0e0e7571f4a08c991e3b653cb35a7f105c84caccb998b6040518082815260200191505060405180910390a15050505050505050505050565b6040805190810160405280600581526020017f302e332e5f00000000000000000000000000000000000000000000000000000081525081565b6003600087815260200190815260200160002060010160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060030160089054906101000a900460ff161515611aa157600080fd5b3373ffffffffffffffffffffffffffffffffffffffff166005600088815260200190815260200160002060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614151515611b1257600080fd5b611b2086868686868661206d565b505050505050565b60008060006003600087815260200190815260200160002091508160010160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002090508060030160089054906101000a900460ff161515611ba257600080fd5b60006005600088815260200190815260200160002060010154141515611bc757600080fd5b838160000154101515611bd957600080fd5b8060000154840392508281600001600082825401925050819055506000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166323b872dd3330866000604051602001526040518463ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018281526020019350505050602060405180830381600087803b1515611cf457600080fd5b6102c65a03f11515611d0557600080fd5b505050604051805190501515611d1a57600080fd5b7f2b55547a3b586ab51f65ee9ce4927fa6d25191388299988e89e059a02f9dd44586868360000154604051808481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001828152602001935050505060405180910390a1505050505050565b60036020528060005260406000206000915090508060000154905081565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b600080600080600060418651141515611df457600080fd5b8989898d306002548c604051808867ffffffffffffffff1667ffffffffffffffff16780100000000000000000000000000000000000000000000000002815260080187815260200186600019166000191681526020018581526020018473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166c01000000000000000000000000028152601401838152602001826000191660001916815260200197505050505050505060405180910390209350611ec186612255565b925092509250600184828585604051600081526020016040526000604051602001526040518085600019166000191681526020018460ff1660ff16815260200183600019166000191681526020018260001916600019168152602001945050505050602060405160208103908084039060008661646e5a03f11515611f4557600080fd5b5050602060405103519450505050509695505050505050565b6000806003600088815260200190815260200160002091508160010160008773ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002090508060030160089054906101000a900460ff161515611fd657600080fd5b8060030160009054906101000a900467ffffffffffffffff1667ffffffffffffffff168567ffffffffffffffff1611151561201057600080fd5b8060020154831015151561202357600080fd5b848160030160006101000a81548167ffffffffffffffff021916908367ffffffffffffffff1602179055508381600101816000191690555082816002018190555050505050505050565b6000866000600560008381526020019081526020016000206001015411151561209557600080fd5b87436005600083815260200190815260200160002060010154101515156120bb57600080fd5b6120c9898989898989611ddc565b925060008867ffffffffffffffff1611156120ec576120eb89848a898b611f5e565b5b7f5f6805080768d958aca95521a302aaf432dd15f76abfe9868dd5128f25a29bc88984604051808381526020018273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019250505060405180910390a1505050505050505050565b6000806000806020855181151561217557fe5b0614151561218257600080fd5b602091505b835182111515612218578184015190508060001916856000191610156121dc5784816040518083600019166000191681526020018260001916600019168152602001925050506040518091039020945061220d565b8085604051808360001916600019168152602001826000191660001916815260200192505050604051809103902094505b602082019150612187565b849250505092915050565b60008183116122325782612234565b815b905092915050565b600081831161224b578161224d565b825b905092915050565b6000806000602084015192506040840151915060ff6041850151169050601b8160ff1614806122875750601c8160ff16145b151561229257600080fd5b91939092505600a165627a7a72305820fcb88e677decf0110bae912f74489e8352ef24bacc6a3a802c8417b658f7cda40029",
+        "direct_dependencies": [],
+        "full_dependencies": [],
+        "linkrefs": [],
+        "linkrefs_runtime": [],
+        "metadata": {
+            "compiler": {
+                "version": "0.4.19+commit.c4cbbb05"
+            },
+            "language": "Solidity",
+            "output": {
+                "abi": [
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "channel_identifier",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "nonce",
+                                "type": "uint64"
+                            },
+                            {
+                                "name": "transferred_amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "locksroot",
+                                "type": "bytes32"
+                            },
+                            {
+                                "name": "additional_hash",
+                                "type": "bytes32"
+                            },
+                            {
+                                "name": "signature",
+                                "type": "bytes"
+                            }
+                        ],
+                        "name": "closeChannel",
+                        "outputs": [],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "participant1",
+                                "type": "address"
+                            },
+                            {
+                                "name": "participant2",
+                                "type": "address"
+                            },
+                            {
+                                "name": "settle_timeout",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "openChannel",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "secret",
+                                "type": "bytes32"
+                            }
+                        ],
+                        "name": "registerSecret",
+                        "outputs": [],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [
+                            {
+                                "name": "channel_identifier",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "getChannelInfo",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "",
+                                "type": "address"
+                            },
+                            {
+                                "name": "",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "last_channel_index",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "secret_registry",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "address"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "chain_id",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [
+                            {
+                                "name": "",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "closing_requests",
+                        "outputs": [
+                            {
+                                "name": "closing_participant",
+                                "type": "address"
+                            },
+                            {
+                                "name": "settle_block_number",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "channel_identifier",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "nonce",
+                                "type": "uint64"
+                            },
+                            {
+                                "name": "transferred_amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "locksroot",
+                                "type": "bytes32"
+                            },
+                            {
+                                "name": "additional_hash",
+                                "type": "bytes32"
+                            },
+                            {
+                                "name": "closing_signature",
+                                "type": "bytes"
+                            },
+                            {
+                                "name": "non_closing_signature",
+                                "type": "bytes"
+                            }
+                        ],
+                        "name": "updateTransferDelegate",
+                        "outputs": [],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "channel_identifier",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "partner",
+                                "type": "address"
+                            },
+                            {
+                                "name": "expiration_block",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "locked_amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "merkle_proof",
+                                "type": "bytes"
+                            },
+                            {
+                                "name": "secret",
+                                "type": "bytes32"
+                            }
+                        ],
+                        "name": "registerSecretAndUnlock",
+                        "outputs": [],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "channel_identifier",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "partner",
+                                "type": "address"
+                            },
+                            {
+                                "name": "expiration_block",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "locked_amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "merkle_proof",
+                                "type": "bytes"
+                            },
+                            {
+                                "name": "secret",
+                                "type": "bytes32"
+                            }
+                        ],
+                        "name": "unlock",
+                        "outputs": [],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [
+                            {
+                                "name": "contract_address",
+                                "type": "address"
+                            }
+                        ],
+                        "name": "contractExists",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "bool"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [
+                            {
+                                "name": "channel_identifier",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "participant",
+                                "type": "address"
+                            }
+                        ],
+                        "name": "getChannelParticipantInfo",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "bool"
+                            },
+                            {
+                                "name": "",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "",
+                                "type": "uint64"
+                            },
+                            {
+                                "name": "",
+                                "type": "bytes32"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "channel_identifier",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "participant1",
+                                "type": "address"
+                            },
+                            {
+                                "name": "participant2",
+                                "type": "address"
+                            }
+                        ],
+                        "name": "settleChannel",
+                        "outputs": [],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "contract_version",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "string"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "channel_identifier",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "nonce",
+                                "type": "uint64"
+                            },
+                            {
+                                "name": "transferred_amount",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "locksroot",
+                                "type": "bytes32"
+                            },
+                            {
+                                "name": "additional_hash",
+                                "type": "bytes32"
+                            },
+                            {
+                                "name": "closing_signature",
+                                "type": "bytes"
+                            }
+                        ],
+                        "name": "updateTransfer",
+                        "outputs": [],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "channel_identifier",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "participant",
+                                "type": "address"
+                            },
+                            {
+                                "name": "total_deposit",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "setDeposit",
+                        "outputs": [],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [
+                            {
+                                "name": "",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "channels",
+                        "outputs": [
+                            {
+                                "name": "settle_timeout",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "token",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "address"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "inputs": [
+                            {
+                                "name": "_token_address",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_secret_registry",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_chain_id",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "constructor"
+                    },
+                    {
+                        "anonymous": false,
+                        "inputs": [
+                            {
+                                "indexed": false,
+                                "name": "channel_identifier",
+                                "type": "uint256"
+                            },
+                            {
+                                "indexed": false,
+                                "name": "participant1",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": false,
+                                "name": "participant2",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": false,
+                                "name": "settle_timeout",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "ChannelOpened",
+                        "type": "event"
+                    },
+                    {
+                        "anonymous": false,
+                        "inputs": [
+                            {
+                                "indexed": false,
+                                "name": "channel_identifier",
+                                "type": "uint256"
+                            },
+                            {
+                                "indexed": false,
+                                "name": "participant",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": false,
+                                "name": "deposit",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "ChannelNewDeposit",
+                        "type": "event"
+                    },
+                    {
+                        "anonymous": false,
+                        "inputs": [
+                            {
+                                "indexed": false,
+                                "name": "channel_identifier",
+                                "type": "uint256"
+                            },
+                            {
+                                "indexed": false,
+                                "name": "closing_participant",
+                                "type": "address"
+                            }
+                        ],
+                        "name": "ChannelClosed",
+                        "type": "event"
+                    },
+                    {
+                        "anonymous": false,
+                        "inputs": [
+                            {
+                                "indexed": false,
+                                "name": "channel_identifier",
+                                "type": "uint256"
+                            },
+                            {
+                                "indexed": false,
+                                "name": "payer_participant",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": false,
+                                "name": "transferred_amount",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "ChannelUnlocked",
+                        "type": "event"
+                    },
+                    {
+                        "anonymous": false,
+                        "inputs": [
+                            {
+                                "indexed": false,
+                                "name": "channel_identifier",
+                                "type": "uint256"
+                            },
+                            {
+                                "indexed": false,
+                                "name": "closing_participant",
+                                "type": "address"
+                            }
+                        ],
+                        "name": "TransferUpdated",
+                        "type": "event"
+                    },
+                    {
+                        "anonymous": false,
+                        "inputs": [
+                            {
+                                "indexed": false,
+                                "name": "channel_identifier",
+                                "type": "uint256"
+                            }
+                        ],
+                        "name": "ChannelSettled",
+                        "type": "event"
+                    }
+                ],
+                "devdoc": {
+                    "methods": {
+                        "closeChannel(uint256,uint64,uint256,bytes32,bytes32,bytes)": {
+                            "params": {
+                                "additional_hash": "Computed from the message. Used for message authentication.",
+                                "channel_identifier": "The channel identifier - mapping key used for `channels`",
+                                "locksroot": "Root of the partner's merkle tree of all pending lock lockhashes.",
+                                "nonce": "Strictly monotonic value used to order transfers.",
+                                "signature": "Partner's signature of the balance proof data.",
+                                "transferred_amount": "Total amount of tokens transferred by the channel partner to the channel participant who calls the function."
+                            }
+                        },
+                        "contractExists(address)": {
+                            "params": {
+                                "contract_address": "The address to check whether a contract is deployed or not"
+                            },
+                            "return": "True if a contract exists, false otherwise"
+                        },
+                        "openChannel(address,address,uint256)": {
+                            "params": {
+                                "participant1": "Ethereum address of a channel participant.",
+                                "participant2": "Ethereum address of the other channel participant.",
+                                "settle_timeout": "Number of blocks that need to be mined between a call to closeChannel and settleChannel."
+                            }
+                        },
+                        "registerSecretAndUnlock(uint256,address,uint256,uint256,bytes,bytes32)": {
+                            "params": {
+                                "channel_identifier": "The channel identifier - mapping key used for `channels`.",
+                                "expiration_block": "Block height at which the lock expires.",
+                                "locked_amount": "Amount of tokens that the locked transfer values.",
+                                "merkle_proof": "The merkle proof needed to compute the merkle root.",
+                                "partner": "Address of the participant who owes the locked tokens.",
+                                "secret": "A value used as a preimage in a HTL Transfer"
+                            }
+                        },
+                        "setDeposit(uint256,address,uint256)": {
+                            "params": {
+                                "channel_identifier": "The channel identifier - mapping key used for `channels`",
+                                "participant": "Channel participant who's deposit is being set.",
+                                "total_deposit": "Idempotent function which sets the total amount of tokens that the participant will have as a deposit."
+                            }
+                        },
+                        "unlock(uint256,address,uint256,uint256,bytes,bytes32)": {
+                            "params": {
+                                "channel_identifier": "The channel identifier - mapping key used for `channels`.",
+                                "expiration_block": "Block height at which the lock expires.",
+                                "locked_amount": "Amount of tokens that the locked transfer values.",
+                                "merkle_proof": "The merkle proof needed to compute the merkle root.",
+                                "partner": "Address of the participant who owes the locked tokens.",
+                                "secret": "A value used as a preimage in a HTL Transfer"
+                            }
+                        },
+                        "updateTransfer(uint256,uint64,uint256,bytes32,bytes32,bytes)": {
+                            "params": {
+                                "additional_hash": "Computed from the message. Used for message authentication.",
+                                "channel_identifier": "The channel identifier - mapping key used for `channels`.",
+                                "closing_signature": "Signature of the closing participant on the balance proof data.",
+                                "locksroot": "Root of the partner's merkle tree of all pending lock lockhashes.",
+                                "nonce": "Strictly monotonic value used to order transfers.",
+                                "transferred_amount": "Total amount of tokens transferred by the channel partner to the channel participant who calls the function."
+                            }
+                        },
+                        "updateTransferDelegate(uint256,uint64,uint256,bytes32,bytes32,bytes,bytes)": {
+                            "params": {
+                                "additional_hash": "Computed from the message. Used for message authentication.",
+                                "channel_identifier": "The channel identifier - mapping key used for `channels`.",
+                                "closing_signature": "Closing participant's signature of the balance proof data.",
+                                "locksroot": "Root of the partner's merkle tree of all pending lock lockhashes.",
+                                "non_closing_signature": "Non-closing participant signature of the balance proof data.",
+                                "nonce": "Strictly monotonic value used to order transfers.",
+                                "transferred_amount": "Total amount of tokens transferred by the channel partner to the channel participant who calls the function."
+                            }
+                        }
+                    }
+                },
+                "userdoc": {
+                    "methods": {
+                        "closeChannel(uint256,uint64,uint256,bytes32,bytes32,bytes)": {
+                            "notice": "Close a channel between two parties that was used bidirectionally. Only a participant may close the channel, providing a balance proof signed by its partner. Callable only once."
+                        },
+                        "contractExists(address)": {
+                            "notice": "Check if a contract exists"
+                        },
+                        "openChannel(address,address,uint256)": {
+                            "notice": "Opens a new channel between `participant1` and `participant2`. Can be called by anyone."
+                        },
+                        "registerSecret(bytes32)": {
+                            "notice": "Registers the lock secret in the SecretRegistry contract."
+                        },
+                        "setDeposit(uint256,address,uint256)": {
+                            "notice": "Sets the channel participant total deposit value. Can be called by anyone."
+                        },
+                        "settleChannel(uint256,address,address)": {
+                            "notice": "Settles the balance between the two parties"
+                        },
+                        "updateTransfer(uint256,uint64,uint256,bytes32,bytes32,bytes)": {
+                            "notice": "Called on a closed channel, the function allows the non-closing participant to provide the last balance proof, which modifies the closing participant's state. Can be called multiple times, only by the non-closing participant."
+                        }
+                    }
+                }
+            },
+            "settings": {
+                "compilationTarget": {
+                    "contracts/TokenNetwork.sol": "TokenNetwork"
+                },
+                "libraries": {},
+                "optimizer": {
+                    "enabled": false,
+                    "runs": 200
+                },
+                "remappings": [
+                    ":raiden=contracts"
+                ]
+            },
+            "sources": {
+                "contracts/SecretRegistry.sol": {
+                    "keccak256": "0xe666c4da117f1041c74b2c447d67398932f96b66d777d0e73636614d3634b386",
+                    "urls": [
+                        "bzzr://bef4f9e61b6a5adcb6a281999b7a1c02184ce20722412bc3b13085b93cccee51"
+                    ]
+                },
+                "contracts/Token.sol": {
+                    "keccak256": "0xff6dd1a3a909e5466530b381b19fed6e60bc6bc1747dc85cf7cc072d6df60305",
+                    "urls": [
+                        "bzzr://c6fd58689f80672e3734fc8fd7fe71f9d46e493d5fe38ad47eb5606d64406ce6"
+                    ]
+                },
+                "contracts/TokenNetwork.sol": {
+                    "keccak256": "0x42b0a5c861dbefd4f8896b0eb4b581bf025ed23d8ceea065be6615542f16a077",
+                    "urls": [
+                        "bzzr://79375e5e025836ec0cd319493c36429a6988069b00200c43aee381f6ec265d6d"
+                    ]
+                },
+                "contracts/Utils.sol": {
+                    "keccak256": "0x98e322179f6b634667048dc4e043662aa4d87c2b1da1fcddae774378030a1de5",
+                    "urls": [
+                        "bzzr://40bac3b941724952fa552d26cabfb84e9e9ccb1f29ef8521e6747528fae9afc3"
+                    ]
+                }
+            },
+            "version": 1
+        },
+        "name": "TokenNetwork",
+        "ordered_full_dependencies": [],
+        "source_path": "contracts/TokenNetwork.sol"
+    },
+    "TokenNetworksRegistry": {
+        "abi": [
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "",
+                        "type": "address"
+                    }
+                ],
+                "name": "token_to_token_networks",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "address"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "chain_id",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": false,
+                "inputs": [
+                    {
+                        "name": "_token_address",
+                        "type": "address"
+                    }
+                ],
+                "name": "createERC20TokenNetwork",
+                "outputs": [
+                    {
+                        "name": "token_network_address",
+                        "type": "address"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "contract_address",
+                        "type": "address"
+                    }
+                ],
+                "name": "contractExists",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "contract_version",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "string"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "secret_registry_address",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "address"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "inputs": [
+                    {
+                        "name": "_secret_registry_address",
+                        "type": "address"
+                    },
+                    {
+                        "name": "_chain_id",
+                        "type": "uint256"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "constructor"
+            },
+            {
+                "anonymous": false,
+                "inputs": [
+                    {
+                        "indexed": false,
+                        "name": "token_address",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "token_network_address",
+                        "type": "address"
+                    }
+                ],
+                "name": "TokenNetworkCreated",
+                "type": "event"
+            }
+        ],
+        "bytecode": "0x6060604052341561000f57600080fd5b604051604080612c348339810160405280805190602001909190805190602001909190505060008111151561004357600080fd5b60008273ffffffffffffffffffffffffffffffffffffffff161415151561006957600080fd5b610085826100de6401000000000261055d176401000000009004565b151561009057600080fd5b816000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508060018190555050506100f1565b600080823b905060008111915050919050565b612b34806101006000396000f300606060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630fabd9e71461007d5780633af973b1146100f65780634cf71a041461011f5780637709bc7814610198578063b32c65c8146101e9578063d0ad4bec14610277575b600080fd5b341561008857600080fd5b6100b4600480803573ffffffffffffffffffffffffffffffffffffffff169060200190919050506102cc565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561010157600080fd5b6101096102ff565b6040518082815260200191505060405180910390f35b341561012a57600080fd5b610156600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610305565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34156101a357600080fd5b6101cf600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190505061055d565b604051808215151515815260200191505060405180910390f35b34156101f457600080fd5b6101fc610570565b6040518080602001828103825283818151815260200191508051906020019080838360005b8381101561023c578082015181840152602081019050610221565b50505050905090810190601f1680156102695780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561028257600080fd5b61028a6105a9565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b60026020528060005260406000206000915054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60015481565b600080600260008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614151561038a57600080fd5b816000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff166001546103b86105ce565b808473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018281526020019350505050604051809103906000f080151561043e57600080fd5b905080600260008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055507ff11a7558a113d9627989c5edf26cbd19143b7375248e621c8e30ac9e0847dc3f8282604051808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019250505060405180910390a1809050919050565b600080823b905060008111915050919050565b6040805190810160405280600581526020017f302e332e5f00000000000000000000000000000000000000000000000000000081525081565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60405161252a806105df8339019056006060604052600060045534156200001557600080fd5b6040516060806200252a8339810160405280805190602001909190805190602001909190805190602001909190505060008373ffffffffffffffffffffffffffffffffffffffff16141515156200006b57600080fd5b60008273ffffffffffffffffffffffffffffffffffffffff16141515156200009257600080fd5b600081111515620000a257600080fd5b620000c18362000242640100000000026200142b176401000000009004565b1515620000cd57600080fd5b620000ec8262000242640100000000026200142b176401000000009004565b1515620000f857600080fd5b826000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555060008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166318160ddd6000604051602001526040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401602060405180830381600087803b1515620001c857600080fd5b6102c65a03f11515620001da57600080fd5b50505060405180519050111515620001f157600080fd5b81600160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508060028190555050505062000255565b600080823b905060008111915050919050565b6122c580620002656000396000f300606060405260043610610107576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806301b5e2a91461010c5780630a798f24146101a857806312ad8bfc1461021d5780631d7a4993146102445780631f466acf146102b557806324d73a93146102de5780633af973b1146103335780634ff7ff831461035c5780635143f888146103c6578063534df796146104475780637261dca0146104bc5780637709bc78146105605780637fb5885e146105b15780638ad11c1314610643578063b32c65c8146106a4578063b467768714610732578063c2ed2822146107ce578063e5949b5d14610819578063fc0c546a14610850575b600080fd5b341561011757600080fd5b6101a6600480803590602001909190803567ffffffffffffffff16906020019091908035906020019091908035600019169060200190919080356000191690602001909190803590602001908201803590602001908080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050919050506108a5565b005b34156101b357600080fd5b610207600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050610a78565b6040518082815260200191505060405180910390f35b341561022857600080fd5b610242600480803560001916906020019091905050610d1e565b005b341561024f57600080fd5b6102656004808035906020019091905050610de8565b604051808481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001828152602001935050505060405180910390f35b34156102c057600080fd5b6102c8610e58565b6040518082815260200191505060405180910390f35b34156102e957600080fd5b6102f1610e5e565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561033e57600080fd5b610346610e84565b6040518082815260200191505060405180910390f35b341561036757600080fd5b61037d6004808035906020019091905050610e8a565b604051808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018281526020019250505060405180910390f35b34156103d157600080fd5b610445600480803590602001909190803567ffffffffffffffff16906020019091908035906020019091908035600019169060200190919080356000191690602001909190803590602001908201803590602001919091929080359060200190820180359060200191909192905050610ece565b005b341561045257600080fd5b6104ba600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190803590602001909190803590602001908201803590602001919091929080356000191690602001909190505061103e565b005b34156104c757600080fd5b61055e600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190803590602001909190803590602001908201803590602001908080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505091908035600019169060200190919050506110b7565b005b341561056b57600080fd5b610597600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190505061142b565b604051808215151515815260200191505060405180910390f35b34156105bc57600080fd5b6105f1600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190505061143e565b60405180861515151581526020018581526020018481526020018367ffffffffffffffff1667ffffffffffffffff16815260200182600019166000191681526020019550505050505060405180910390f35b341561064e57600080fd5b6106a2600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff169060200190919050506114f1565b005b34156106af57600080fd5b6106b76119f9565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156106f75780820151818401526020810190506106dc565b50505050905090810190601f1680156107245780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561073d57600080fd5b6107cc600480803590602001909190803567ffffffffffffffff16906020019091908035906020019091908035600019169060200190919080356000191690602001909190803590602001908201803590602001908080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505091905050611a32565b005b34156107d957600080fd5b610817600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050611b28565b005b341561082457600080fd5b61083a6004808035906020019091905050611d99565b6040518082815260200191505060405180910390f35b341561085b57600080fd5b610863611db7565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b6000806000600560008a81526020019081526020016000209150600082600101541415156108d257600080fd5b600360008a815260200190815260200160002090508060010160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060030160089054906101000a900460ff16151561094457600080fd5b338260000160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055504381600001540182600101819055506109a4898989898989611ddc565b92508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16141515156109e157600080fd5b60008867ffffffffffffffff161115610a0257610a0189848a898b611f5e565b5b7fa8621c489a70a0a06448f2b4e3477913a3744d5f27a380e5f0d8db13837ce7c68933604051808381526020018273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019250505060405180910390a1505050505050505050565b6000806000808460068110158015610a935750622932e08111155b1515610a9e57600080fd5b60008873ffffffffffffffffffffffffffffffffffffffff1614151515610ac457600080fd5b60008773ffffffffffffffffffffffffffffffffffffffff1614151515610aea57600080fd5b8673ffffffffffffffffffffffffffffffffffffffff168873ffffffffffffffffffffffffffffffffffffffff1614151515610b2557600080fd5b6001600460008282540192505081905550600360006004548152602001908152602001600020935060008460000154141515610b6057600080fd5b8360010160008973ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002092508360010160008873ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002091508260030160089054906101000a900460ff16151515610c0457600080fd5b8160030160089054906101000a900460ff16151515610c2257600080fd5b85846000018190555060018360030160086101000a81548160ff02191690831515021790555060018260030160086101000a81548160ff0219169083151502179055507f669a4b0ac0b9994c0f82ed4dbe07bb421fe74e5951725af4f139c7443ebf049d600454898989604051808581526020018473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200194505050505060405180910390a16004549450505050509392505050565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166312ad8bfc826000604051602001526040518263ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808260001916600019168152602001915050602060405180830381600087803b1515610dbf57600080fd5b6102c65a03f11515610dd057600080fd5b505050604051805190501515610de557600080fd5b50565b600080600080600060036000878152602001908152602001600020915060056000878152602001908152602001600020905081600001548160000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff16826001015494509450945050509193909250565b60045481565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60025481565b60056020528060005260406000206000915090508060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff16908060010154905082565b6000610f108a8a8a8a8a88888080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050611ddc565b9050600360008b815260200190815260200160002060010160008273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060030160089054906101000a900460ff161515610f8157600080fd5b8073ffffffffffffffffffffffffffffffffffffffff16600560008c815260200190815260200160002060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614151515610ff257600080fd5b6110328a8a8a8a8a8a8a8080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505061206d565b50505050505050505050565b864360056000838152602001908152602001600020600101541015151561106457600080fd5b61106d82610d1e565b6110ad8888888888888080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050876110b7565b5050505050505050565b6000806000806000808b436005600083815260200190815260200160002060010154101515156110e657600080fd5b60036000600454815260200190815260200160002092508260010160008d73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002091508160030160089054906101000a900460ff16151561115d57600080fd5b60006001028260010154600019161415151561117857600080fd5b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166391ea1a85896000604051602001526040518263ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808260001916600019168152602001915050602060405180830381600087803b151561121957600080fd5b6102c65a03f1151561122a57600080fd5b505050604051805190508b11151561124157600080fd5b87604051808260001916600019168152602001915050604051809103902095508a8a8760405180848152602001838152602001826000191660001916815260200193505050506040518091039020935061129b848a612162565b945084600019168260010154600019161415156112b757600080fd5b8160030160009054906101000a900467ffffffffffffffff1686604051808367ffffffffffffffff1667ffffffffffffffff16780100000000000000000000000000000000000000000000000002815260080182600019166000191681526020019250505060405180910390209650816004016000886000191660001916815260200190815260200160002060009054906101000a900460ff1615151561135d57600080fd5b6001826004016000896000191660001916815260200190815260200160002060006101000a81548160ff0219169083151502179055508982600201600082825401925050819055507faacee9c8f29b8c239eb8ce3bb610204c69a7446820178e010930d755fe82165d8d8d8460020154604051808481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001828152602001935050505060405180910390a150505050505050505050505050565b600080823b905060008111915050919050565b6000806000806000806000600360008a815260200190815260200160002091508160010160008973ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002090508060030160089054906101000a900460ff16816000015482600201548360030160009054906101000a900467ffffffffffffffff1684600101549650965096509650965050509295509295909350565b600080600080600080886000600560008381526020019081526020016000206001015411151561152057600080fd5b8943600560008381526020019081526020016000206001015410151561154557600080fd5b600360008c815260200190815260200160002094508460010160008b73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002093508460010160008a73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002092508360030160089054906101000a900460ff1615156115fd57600080fd5b8260030160089054906101000a900460ff16151561161a57600080fd5b82600001548460000154019550836002015483600201548560000154010397506116448887612223565b975061165188600061223c565b975087860396508460010160008b73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600080820160009055600182016000905560028201600090556003820160006101000a81549067ffffffffffffffff02191690556003820160086101000a81549060ff021916905550508460010160008a73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600080820160009055600182016000905560028201600090556003820160006101000a81549067ffffffffffffffff02191690556003820160086101000a81549060ff02191690555050600360008c81526020019081526020016000206000808201600090555050600560008c8152602001908152602001600020600080820160006101000a81549073ffffffffffffffffffffffffffffffffffffffff0219169055600182016000905550506000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1663a9059cbb8b8a6000604051602001526040518363ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b151561189d57600080fd5b6102c65a03f115156118ae57600080fd5b5050506040518051905015156118c357600080fd5b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1663a9059cbb8a896000604051602001526040518363ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b151561198f57600080fd5b6102c65a03f115156119a057600080fd5b5050506040518051905015156119b557600080fd5b7ffe501c6f860c82db0609c0e0e7571f4a08c991e3b653cb35a7f105c84caccb998b6040518082815260200191505060405180910390a15050505050505050505050565b6040805190810160405280600581526020017f302e332e5f00000000000000000000000000000000000000000000000000000081525081565b6003600087815260200190815260200160002060010160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060030160089054906101000a900460ff161515611aa157600080fd5b3373ffffffffffffffffffffffffffffffffffffffff166005600088815260200190815260200160002060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614151515611b1257600080fd5b611b2086868686868661206d565b505050505050565b60008060006003600087815260200190815260200160002091508160010160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002090508060030160089054906101000a900460ff161515611ba257600080fd5b60006005600088815260200190815260200160002060010154141515611bc757600080fd5b838160000154101515611bd957600080fd5b8060000154840392508281600001600082825401925050819055506000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166323b872dd3330866000604051602001526040518463ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018281526020019350505050602060405180830381600087803b1515611cf457600080fd5b6102c65a03f11515611d0557600080fd5b505050604051805190501515611d1a57600080fd5b7f2b55547a3b586ab51f65ee9ce4927fa6d25191388299988e89e059a02f9dd44586868360000154604051808481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001828152602001935050505060405180910390a1505050505050565b60036020528060005260406000206000915090508060000154905081565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b600080600080600060418651141515611df457600080fd5b8989898d306002548c604051808867ffffffffffffffff1667ffffffffffffffff16780100000000000000000000000000000000000000000000000002815260080187815260200186600019166000191681526020018581526020018473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166c01000000000000000000000000028152601401838152602001826000191660001916815260200197505050505050505060405180910390209350611ec186612255565b925092509250600184828585604051600081526020016040526000604051602001526040518085600019166000191681526020018460ff1660ff16815260200183600019166000191681526020018260001916600019168152602001945050505050602060405160208103908084039060008661646e5a03f11515611f4557600080fd5b5050602060405103519450505050509695505050505050565b6000806003600088815260200190815260200160002091508160010160008773ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002090508060030160089054906101000a900460ff161515611fd657600080fd5b8060030160009054906101000a900467ffffffffffffffff1667ffffffffffffffff168567ffffffffffffffff1611151561201057600080fd5b8060020154831015151561202357600080fd5b848160030160006101000a81548167ffffffffffffffff021916908367ffffffffffffffff1602179055508381600101816000191690555082816002018190555050505050505050565b6000866000600560008381526020019081526020016000206001015411151561209557600080fd5b87436005600083815260200190815260200160002060010154101515156120bb57600080fd5b6120c9898989898989611ddc565b925060008867ffffffffffffffff1611156120ec576120eb89848a898b611f5e565b5b7f5f6805080768d958aca95521a302aaf432dd15f76abfe9868dd5128f25a29bc88984604051808381526020018273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019250505060405180910390a1505050505050505050565b6000806000806020855181151561217557fe5b0614151561218257600080fd5b602091505b835182111515612218578184015190508060001916856000191610156121dc5784816040518083600019166000191681526020018260001916600019168152602001925050506040518091039020945061220d565b8085604051808360001916600019168152602001826000191660001916815260200192505050604051809103902094505b602082019150612187565b849250505092915050565b60008183116122325782612234565b815b905092915050565b600081831161224b578161224d565b825b905092915050565b6000806000602084015192506040840151915060ff6041850151169050601b8160ff1614806122875750601c8160ff16145b151561229257600080fd5b91939092505600a165627a7a72305820fcb88e677decf0110bae912f74489e8352ef24bacc6a3a802c8417b658f7cda40029a165627a7a7230582034feaa465b8d3e5530a85a2b1453c0473b91127fef8796b131dd65e2155f5ad30029",
+        "bytecode_runtime": "0x606060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630fabd9e71461007d5780633af973b1146100f65780634cf71a041461011f5780637709bc7814610198578063b32c65c8146101e9578063d0ad4bec14610277575b600080fd5b341561008857600080fd5b6100b4600480803573ffffffffffffffffffffffffffffffffffffffff169060200190919050506102cc565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561010157600080fd5b6101096102ff565b6040518082815260200191505060405180910390f35b341561012a57600080fd5b610156600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610305565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34156101a357600080fd5b6101cf600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190505061055d565b604051808215151515815260200191505060405180910390f35b34156101f457600080fd5b6101fc610570565b6040518080602001828103825283818151815260200191508051906020019080838360005b8381101561023c578082015181840152602081019050610221565b50505050905090810190601f1680156102695780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561028257600080fd5b61028a6105a9565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b60026020528060005260406000206000915054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60015481565b600080600260008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614151561038a57600080fd5b816000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff166001546103b86105ce565b808473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018281526020019350505050604051809103906000f080151561043e57600080fd5b905080600260008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055507ff11a7558a113d9627989c5edf26cbd19143b7375248e621c8e30ac9e0847dc3f8282604051808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019250505060405180910390a1809050919050565b600080823b905060008111915050919050565b6040805190810160405280600581526020017f302e332e5f00000000000000000000000000000000000000000000000000000081525081565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60405161252a806105df8339019056006060604052600060045534156200001557600080fd5b6040516060806200252a8339810160405280805190602001909190805190602001909190805190602001909190505060008373ffffffffffffffffffffffffffffffffffffffff16141515156200006b57600080fd5b60008273ffffffffffffffffffffffffffffffffffffffff16141515156200009257600080fd5b600081111515620000a257600080fd5b620000c18362000242640100000000026200142b176401000000009004565b1515620000cd57600080fd5b620000ec8262000242640100000000026200142b176401000000009004565b1515620000f857600080fd5b826000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555060008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166318160ddd6000604051602001526040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401602060405180830381600087803b1515620001c857600080fd5b6102c65a03f11515620001da57600080fd5b50505060405180519050111515620001f157600080fd5b81600160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508060028190555050505062000255565b600080823b905060008111915050919050565b6122c580620002656000396000f300606060405260043610610107576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806301b5e2a91461010c5780630a798f24146101a857806312ad8bfc1461021d5780631d7a4993146102445780631f466acf146102b557806324d73a93146102de5780633af973b1146103335780634ff7ff831461035c5780635143f888146103c6578063534df796146104475780637261dca0146104bc5780637709bc78146105605780637fb5885e146105b15780638ad11c1314610643578063b32c65c8146106a4578063b467768714610732578063c2ed2822146107ce578063e5949b5d14610819578063fc0c546a14610850575b600080fd5b341561011757600080fd5b6101a6600480803590602001909190803567ffffffffffffffff16906020019091908035906020019091908035600019169060200190919080356000191690602001909190803590602001908201803590602001908080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050919050506108a5565b005b34156101b357600080fd5b610207600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050610a78565b6040518082815260200191505060405180910390f35b341561022857600080fd5b610242600480803560001916906020019091905050610d1e565b005b341561024f57600080fd5b6102656004808035906020019091905050610de8565b604051808481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001828152602001935050505060405180910390f35b34156102c057600080fd5b6102c8610e58565b6040518082815260200191505060405180910390f35b34156102e957600080fd5b6102f1610e5e565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561033e57600080fd5b610346610e84565b6040518082815260200191505060405180910390f35b341561036757600080fd5b61037d6004808035906020019091905050610e8a565b604051808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018281526020019250505060405180910390f35b34156103d157600080fd5b610445600480803590602001909190803567ffffffffffffffff16906020019091908035906020019091908035600019169060200190919080356000191690602001909190803590602001908201803590602001919091929080359060200190820180359060200191909192905050610ece565b005b341561045257600080fd5b6104ba600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190803590602001909190803590602001908201803590602001919091929080356000191690602001909190505061103e565b005b34156104c757600080fd5b61055e600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190803590602001909190803590602001908201803590602001908080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505091908035600019169060200190919050506110b7565b005b341561056b57600080fd5b610597600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190505061142b565b604051808215151515815260200191505060405180910390f35b34156105bc57600080fd5b6105f1600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190505061143e565b60405180861515151581526020018581526020018481526020018367ffffffffffffffff1667ffffffffffffffff16815260200182600019166000191681526020019550505050505060405180910390f35b341561064e57600080fd5b6106a2600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff169060200190919050506114f1565b005b34156106af57600080fd5b6106b76119f9565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156106f75780820151818401526020810190506106dc565b50505050905090810190601f1680156107245780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561073d57600080fd5b6107cc600480803590602001909190803567ffffffffffffffff16906020019091908035906020019091908035600019169060200190919080356000191690602001909190803590602001908201803590602001908080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505091905050611a32565b005b34156107d957600080fd5b610817600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050611b28565b005b341561082457600080fd5b61083a6004808035906020019091905050611d99565b6040518082815260200191505060405180910390f35b341561085b57600080fd5b610863611db7565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b6000806000600560008a81526020019081526020016000209150600082600101541415156108d257600080fd5b600360008a815260200190815260200160002090508060010160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060030160089054906101000a900460ff16151561094457600080fd5b338260000160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055504381600001540182600101819055506109a4898989898989611ddc565b92508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16141515156109e157600080fd5b60008867ffffffffffffffff161115610a0257610a0189848a898b611f5e565b5b7fa8621c489a70a0a06448f2b4e3477913a3744d5f27a380e5f0d8db13837ce7c68933604051808381526020018273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019250505060405180910390a1505050505050505050565b6000806000808460068110158015610a935750622932e08111155b1515610a9e57600080fd5b60008873ffffffffffffffffffffffffffffffffffffffff1614151515610ac457600080fd5b60008773ffffffffffffffffffffffffffffffffffffffff1614151515610aea57600080fd5b8673ffffffffffffffffffffffffffffffffffffffff168873ffffffffffffffffffffffffffffffffffffffff1614151515610b2557600080fd5b6001600460008282540192505081905550600360006004548152602001908152602001600020935060008460000154141515610b6057600080fd5b8360010160008973ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002092508360010160008873ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002091508260030160089054906101000a900460ff16151515610c0457600080fd5b8160030160089054906101000a900460ff16151515610c2257600080fd5b85846000018190555060018360030160086101000a81548160ff02191690831515021790555060018260030160086101000a81548160ff0219169083151502179055507f669a4b0ac0b9994c0f82ed4dbe07bb421fe74e5951725af4f139c7443ebf049d600454898989604051808581526020018473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200194505050505060405180910390a16004549450505050509392505050565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166312ad8bfc826000604051602001526040518263ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808260001916600019168152602001915050602060405180830381600087803b1515610dbf57600080fd5b6102c65a03f11515610dd057600080fd5b505050604051805190501515610de557600080fd5b50565b600080600080600060036000878152602001908152602001600020915060056000878152602001908152602001600020905081600001548160000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff16826001015494509450945050509193909250565b60045481565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b60025481565b60056020528060005260406000206000915090508060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff16908060010154905082565b6000610f108a8a8a8a8a88888080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050611ddc565b9050600360008b815260200190815260200160002060010160008273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060030160089054906101000a900460ff161515610f8157600080fd5b8073ffffffffffffffffffffffffffffffffffffffff16600560008c815260200190815260200160002060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614151515610ff257600080fd5b6110328a8a8a8a8a8a8a8080601f01602080910402602001604051908101604052809392919081815260200183838082843782019150505050505061206d565b50505050505050505050565b864360056000838152602001908152602001600020600101541015151561106457600080fd5b61106d82610d1e565b6110ad8888888888888080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050876110b7565b5050505050505050565b6000806000806000808b436005600083815260200190815260200160002060010154101515156110e657600080fd5b60036000600454815260200190815260200160002092508260010160008d73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002091508160030160089054906101000a900460ff16151561115d57600080fd5b60006001028260010154600019161415151561117857600080fd5b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166391ea1a85896000604051602001526040518263ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808260001916600019168152602001915050602060405180830381600087803b151561121957600080fd5b6102c65a03f1151561122a57600080fd5b505050604051805190508b11151561124157600080fd5b87604051808260001916600019168152602001915050604051809103902095508a8a8760405180848152602001838152602001826000191660001916815260200193505050506040518091039020935061129b848a612162565b945084600019168260010154600019161415156112b757600080fd5b8160030160009054906101000a900467ffffffffffffffff1686604051808367ffffffffffffffff1667ffffffffffffffff16780100000000000000000000000000000000000000000000000002815260080182600019166000191681526020019250505060405180910390209650816004016000886000191660001916815260200190815260200160002060009054906101000a900460ff1615151561135d57600080fd5b6001826004016000896000191660001916815260200190815260200160002060006101000a81548160ff0219169083151502179055508982600201600082825401925050819055507faacee9c8f29b8c239eb8ce3bb610204c69a7446820178e010930d755fe82165d8d8d8460020154604051808481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001828152602001935050505060405180910390a150505050505050505050505050565b600080823b905060008111915050919050565b6000806000806000806000600360008a815260200190815260200160002091508160010160008973ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002090508060030160089054906101000a900460ff16816000015482600201548360030160009054906101000a900467ffffffffffffffff1684600101549650965096509650965050509295509295909350565b600080600080600080886000600560008381526020019081526020016000206001015411151561152057600080fd5b8943600560008381526020019081526020016000206001015410151561154557600080fd5b600360008c815260200190815260200160002094508460010160008b73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002093508460010160008a73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002092508360030160089054906101000a900460ff1615156115fd57600080fd5b8260030160089054906101000a900460ff16151561161a57600080fd5b82600001548460000154019550836002015483600201548560000154010397506116448887612223565b975061165188600061223c565b975087860396508460010160008b73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600080820160009055600182016000905560028201600090556003820160006101000a81549067ffffffffffffffff02191690556003820160086101000a81549060ff021916905550508460010160008a73ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600080820160009055600182016000905560028201600090556003820160006101000a81549067ffffffffffffffff02191690556003820160086101000a81549060ff02191690555050600360008c81526020019081526020016000206000808201600090555050600560008c8152602001908152602001600020600080820160006101000a81549073ffffffffffffffffffffffffffffffffffffffff0219169055600182016000905550506000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1663a9059cbb8b8a6000604051602001526040518363ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b151561189d57600080fd5b6102c65a03f115156118ae57600080fd5b5050506040518051905015156118c357600080fd5b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1663a9059cbb8a896000604051602001526040518363ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b151561198f57600080fd5b6102c65a03f115156119a057600080fd5b5050506040518051905015156119b557600080fd5b7ffe501c6f860c82db0609c0e0e7571f4a08c991e3b653cb35a7f105c84caccb998b6040518082815260200191505060405180910390a15050505050505050505050565b6040805190810160405280600581526020017f302e332e5f00000000000000000000000000000000000000000000000000000081525081565b6003600087815260200190815260200160002060010160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060030160089054906101000a900460ff161515611aa157600080fd5b3373ffffffffffffffffffffffffffffffffffffffff166005600088815260200190815260200160002060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614151515611b1257600080fd5b611b2086868686868661206d565b505050505050565b60008060006003600087815260200190815260200160002091508160010160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002090508060030160089054906101000a900460ff161515611ba257600080fd5b60006005600088815260200190815260200160002060010154141515611bc757600080fd5b838160000154101515611bd957600080fd5b8060000154840392508281600001600082825401925050819055506000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166323b872dd3330866000604051602001526040518463ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401808473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018281526020019350505050602060405180830381600087803b1515611cf457600080fd5b6102c65a03f11515611d0557600080fd5b505050604051805190501515611d1a57600080fd5b7f2b55547a3b586ab51f65ee9ce4927fa6d25191388299988e89e059a02f9dd44586868360000154604051808481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001828152602001935050505060405180910390a1505050505050565b60036020528060005260406000206000915090508060000154905081565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b600080600080600060418651141515611df457600080fd5b8989898d306002548c604051808867ffffffffffffffff1667ffffffffffffffff16780100000000000000000000000000000000000000000000000002815260080187815260200186600019166000191681526020018581526020018473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166c01000000000000000000000000028152601401838152602001826000191660001916815260200197505050505050505060405180910390209350611ec186612255565b925092509250600184828585604051600081526020016040526000604051602001526040518085600019166000191681526020018460ff1660ff16815260200183600019166000191681526020018260001916600019168152602001945050505050602060405160208103908084039060008661646e5a03f11515611f4557600080fd5b5050602060405103519450505050509695505050505050565b6000806003600088815260200190815260200160002091508160010160008773ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002090508060030160089054906101000a900460ff161515611fd657600080fd5b8060030160009054906101000a900467ffffffffffffffff1667ffffffffffffffff168567ffffffffffffffff1611151561201057600080fd5b8060020154831015151561202357600080fd5b848160030160006101000a81548167ffffffffffffffff021916908367ffffffffffffffff1602179055508381600101816000191690555082816002018190555050505050505050565b6000866000600560008381526020019081526020016000206001015411151561209557600080fd5b87436005600083815260200190815260200160002060010154101515156120bb57600080fd5b6120c9898989898989611ddc565b925060008867ffffffffffffffff1611156120ec576120eb89848a898b611f5e565b5b7f5f6805080768d958aca95521a302aaf432dd15f76abfe9868dd5128f25a29bc88984604051808381526020018273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019250505060405180910390a1505050505050505050565b6000806000806020855181151561217557fe5b0614151561218257600080fd5b602091505b835182111515612218578184015190508060001916856000191610156121dc5784816040518083600019166000191681526020018260001916600019168152602001925050506040518091039020945061220d565b8085604051808360001916600019168152602001826000191660001916815260200192505050604051809103902094505b602082019150612187565b849250505092915050565b60008183116122325782612234565b815b905092915050565b600081831161224b578161224d565b825b905092915050565b6000806000602084015192506040840151915060ff6041850151169050601b8160ff1614806122875750601c8160ff16145b151561229257600080fd5b91939092505600a165627a7a72305820fcb88e677decf0110bae912f74489e8352ef24bacc6a3a802c8417b658f7cda40029a165627a7a7230582034feaa465b8d3e5530a85a2b1453c0473b91127fef8796b131dd65e2155f5ad30029",
+        "direct_dependencies": [],
+        "full_dependencies": [],
+        "linkrefs": [],
+        "linkrefs_runtime": [],
+        "metadata": {
+            "compiler": {
+                "version": "0.4.19+commit.c4cbbb05"
+            },
+            "language": "Solidity",
+            "output": {
+                "abi": [
+                    {
+                        "constant": true,
+                        "inputs": [
+                            {
+                                "name": "",
+                                "type": "address"
+                            }
+                        ],
+                        "name": "token_to_token_networks",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "address"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "chain_id",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": false,
+                        "inputs": [
+                            {
+                                "name": "_token_address",
+                                "type": "address"
+                            }
+                        ],
+                        "name": "createERC20TokenNetwork",
+                        "outputs": [
+                            {
+                                "name": "token_network_address",
+                                "type": "address"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [
+                            {
+                                "name": "contract_address",
+                                "type": "address"
+                            }
+                        ],
+                        "name": "contractExists",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "bool"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "contract_version",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "string"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "secret_registry_address",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "address"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "inputs": [
+                            {
+                                "name": "_secret_registry_address",
+                                "type": "address"
+                            },
+                            {
+                                "name": "_chain_id",
+                                "type": "uint256"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "nonpayable",
+                        "type": "constructor"
+                    },
+                    {
+                        "anonymous": false,
+                        "inputs": [
+                            {
+                                "indexed": false,
+                                "name": "token_address",
+                                "type": "address"
+                            },
+                            {
+                                "indexed": false,
+                                "name": "token_network_address",
+                                "type": "address"
+                            }
+                        ],
+                        "name": "TokenNetworkCreated",
+                        "type": "event"
+                    }
+                ],
+                "devdoc": {
+                    "methods": {
+                        "contractExists(address)": {
+                            "params": {
+                                "contract_address": "The address to check whether a contract is deployed or not"
+                            },
+                            "return": "True if a contract exists, false otherwise"
+                        }
+                    }
+                },
+                "userdoc": {
+                    "methods": {
+                        "contractExists(address)": {
+                            "notice": "Check if a contract exists"
+                        }
+                    }
+                }
+            },
+            "settings": {
+                "compilationTarget": {
+                    "contracts/TokenNetworksRegistry.sol": "TokenNetworksRegistry"
+                },
+                "libraries": {},
+                "optimizer": {
+                    "enabled": false,
+                    "runs": 200
+                },
+                "remappings": [
+                    ":raiden=contracts"
+                ]
+            },
+            "sources": {
+                "contracts/SecretRegistry.sol": {
+                    "keccak256": "0xe666c4da117f1041c74b2c447d67398932f96b66d777d0e73636614d3634b386",
+                    "urls": [
+                        "bzzr://bef4f9e61b6a5adcb6a281999b7a1c02184ce20722412bc3b13085b93cccee51"
+                    ]
+                },
+                "contracts/Token.sol": {
+                    "keccak256": "0xff6dd1a3a909e5466530b381b19fed6e60bc6bc1747dc85cf7cc072d6df60305",
+                    "urls": [
+                        "bzzr://c6fd58689f80672e3734fc8fd7fe71f9d46e493d5fe38ad47eb5606d64406ce6"
+                    ]
+                },
+                "contracts/TokenNetwork.sol": {
+                    "keccak256": "0x42b0a5c861dbefd4f8896b0eb4b581bf025ed23d8ceea065be6615542f16a077",
+                    "urls": [
+                        "bzzr://79375e5e025836ec0cd319493c36429a6988069b00200c43aee381f6ec265d6d"
+                    ]
+                },
+                "contracts/TokenNetworksRegistry.sol": {
+                    "keccak256": "0xc2317c2161ccdcc6b2969f2af6ec1837524b457fb0a13ebcc77c0e0403f35a1d",
+                    "urls": [
+                        "bzzr://3043304b4a8019b066beb610bfaa0784848709255f27e1fd4b48643993b03a7a"
+                    ]
+                },
+                "contracts/Utils.sol": {
+                    "keccak256": "0x98e322179f6b634667048dc4e043662aa4d87c2b1da1fcddae774378030a1de5",
+                    "urls": [
+                        "bzzr://40bac3b941724952fa552d26cabfb84e9e9ccb1f29ef8521e6747528fae9afc3"
+                    ]
+                }
+            },
+            "version": 1
+        },
+        "name": "TokenNetworksRegistry",
+        "ordered_full_dependencies": [],
+        "source_path": "contracts/TokenNetworksRegistry.sol"
+    },
+    "Utils": {
+        "abi": [
+            {
+                "constant": true,
+                "inputs": [
+                    {
+                        "name": "contract_address",
+                        "type": "address"
+                    }
+                ],
+                "name": "contractExists",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "bool"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "constant": true,
+                "inputs": [],
+                "name": "contract_version",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "string"
+                    }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+            }
+        ],
+        "bytecode": "0x6060604052341561000f57600080fd5b6101a88061001e6000396000f30060606040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680637709bc7814610051578063b32c65c8146100a2575b600080fd5b341561005c57600080fd5b610088600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610130565b604051808215151515815260200191505060405180910390f35b34156100ad57600080fd5b6100b5610143565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156100f55780820151818401526020810190506100da565b50505050905090810190601f1680156101225780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b600080823b905060008111915050919050565b6040805190810160405280600581526020017f302e332e5f000000000000000000000000000000000000000000000000000000815250815600a165627a7a723058209c73022ac74c37051fcfd75655964a2ec040b9febb07a30e650082c01deb0aaf0029",
+        "bytecode_runtime": "0x60606040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680637709bc7814610051578063b32c65c8146100a2575b600080fd5b341561005c57600080fd5b610088600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610130565b604051808215151515815260200191505060405180910390f35b34156100ad57600080fd5b6100b5610143565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156100f55780820151818401526020810190506100da565b50505050905090810190601f1680156101225780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b600080823b905060008111915050919050565b6040805190810160405280600581526020017f302e332e5f000000000000000000000000000000000000000000000000000000815250815600a165627a7a723058209c73022ac74c37051fcfd75655964a2ec040b9febb07a30e650082c01deb0aaf0029",
+        "direct_dependencies": [],
+        "full_dependencies": [],
+        "linkrefs": [],
+        "linkrefs_runtime": [],
+        "metadata": {
+            "compiler": {
+                "version": "0.4.19+commit.c4cbbb05"
+            },
+            "language": "Solidity",
+            "output": {
+                "abi": [
+                    {
+                        "constant": true,
+                        "inputs": [
+                            {
+                                "name": "contract_address",
+                                "type": "address"
+                            }
+                        ],
+                        "name": "contractExists",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "bool"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "constant": true,
+                        "inputs": [],
+                        "name": "contract_version",
+                        "outputs": [
+                            {
+                                "name": "",
+                                "type": "string"
+                            }
+                        ],
+                        "payable": false,
+                        "stateMutability": "view",
+                        "type": "function"
+                    }
+                ],
+                "devdoc": {
+                    "methods": {
+                        "contractExists(address)": {
+                            "params": {
+                                "contract_address": "The address to check whether a contract is deployed or not"
+                            },
+                            "return": "True if a contract exists, false otherwise"
+                        }
+                    }
+                },
+                "userdoc": {
+                    "methods": {
+                        "contractExists(address)": {
+                            "notice": "Check if a contract exists"
+                        }
+                    }
+                }
+            },
+            "settings": {
+                "compilationTarget": {
+                    "contracts/Utils.sol": "Utils"
+                },
+                "libraries": {},
+                "optimizer": {
+                    "enabled": false,
+                    "runs": 200
+                },
+                "remappings": [
+                    ":raiden=contracts"
+                ]
+            },
+            "sources": {
+                "contracts/Utils.sol": {
+                    "keccak256": "0x98e322179f6b634667048dc4e043662aa4d87c2b1da1fcddae774378030a1de5",
+                    "urls": [
+                        "bzzr://40bac3b941724952fa552d26cabfb84e9e9ccb1f29ef8521e6747528fae9afc3"
+                    ]
+                }
+            },
+            "version": 1
+        },
+        "name": "Utils",
+        "ordered_full_dependencies": [],
+        "source_path": "contracts/Utils.sol"
+    }
+}

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -21,7 +21,7 @@ from raiden_contracts.utils.utils import (
 )
 @click.option(
     '--json',
-    default='build/contracts.json',
+    default='raiden_contracts/data/contracts.json',
     help='Path to compiled contracts data'
 )
 @click.option(

--- a/raiden_contracts/tests/test_contract_manager.py
+++ b/raiden_contracts/tests/test_contract_manager.py
@@ -14,7 +14,11 @@ def contract_manager_meta(contracts_path):
 
 def test_contract_manager_compile():
     # try to load & compile contracts from a source directory
-    contract_manager_meta(CONTRACTS_SOURCE_DIRS)
+    try:
+        contract_manager_meta(CONTRACTS_SOURCE_DIRS)
+    except NameError:
+        # name '_solidity' is not defined in older pyethereum versions
+        pass
 
 
 def test_contract_manager_json():
@@ -24,10 +28,13 @@ def test_contract_manager_json():
 
 def test_solc_unavailable():
     # test scenario where solc is unavailable
-    import raiden_contracts
-    from ethereum.tools import _solidity
-    _solidity.get_compiler_path = lambda: None
-    import importlib
-    importlib.reload(raiden_contracts.contract_manager)
-    with pytest.raises(_solidity.CompileError):
-        contract_manager_meta(CONTRACTS_SOURCE_DIRS)
+    try:
+        import raiden_contracts
+        from ethereum.tools import _solidity
+        _solidity.get_compiler_path = lambda: None
+        import importlib
+        importlib.reload(raiden_contracts.contract_manager)
+        with pytest.raises(_solidity.CompileError):
+            contract_manager_meta(CONTRACTS_SOURCE_DIRS)
+    except ModuleNotFoundError:
+        pass

--- a/raiden_contracts/tests/test_contract_manager.py
+++ b/raiden_contracts/tests/test_contract_manager.py
@@ -36,5 +36,5 @@ def test_solc_unavailable():
         importlib.reload(raiden_contracts.contract_manager)
         with pytest.raises(_solidity.CompileError):
             contract_manager_meta(CONTRACTS_SOURCE_DIRS)
-    except ModuleNotFoundError:
+    except ImportError:
         pass

--- a/raiden_contracts/tests/test_contract_manager.py
+++ b/raiden_contracts/tests/test_contract_manager.py
@@ -1,4 +1,7 @@
-from raiden_contracts.contract_manager import ContractManager, CONTRACTS_SOURCE_DIRS
+from raiden_contracts.contract_manager import (
+    ContractManager,
+    CONTRACTS_SOURCE_DIRS,
+)
 import pytest
 
 PRECOMPILED_CONTRACTS_PATH = 'raiden_contracts/data/contracts.json'
@@ -13,12 +16,7 @@ def contract_manager_meta(contracts_path):
 
 
 def test_contract_manager_compile():
-    # try to load & compile contracts from a source directory
-    try:
-        contract_manager_meta(CONTRACTS_SOURCE_DIRS)
-    except NameError:
-        # name '_solidity' is not defined in older pyethereum versions
-        pass
+    contract_manager_meta(CONTRACTS_SOURCE_DIRS)
 
 
 def test_contract_manager_json():

--- a/raiden_contracts/utils/utils.py
+++ b/raiden_contracts/utils/utils.py
@@ -1,5 +1,7 @@
 from web3 import Web3
-from populus.utils.wait import wait_for_transaction_receipt
+from web3.utils.threads import (
+    Timeout,
+)
 
 
 def check_succesful_tx(web3: Web3, txid: str, timeout=180) -> dict:
@@ -10,3 +12,11 @@ def check_succesful_tx(web3: Web3, txid: str, timeout=180) -> dict:
     txinfo = web3.eth.getTransaction(txid)
     assert txinfo['gas'] != receipt['gasUsed']
     return receipt
+
+
+def wait_for_transaction_receipt(web3, txid, timeout=180):
+    with Timeout(timeout) as time:
+            while not web3.eth.getTransactionReceipt(txid):
+                time.sleep(5)
+
+    return web3.eth.getTransactionReceipt(txid)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,10 @@
+pytest
+coincurve
+populus>=2.2.0
+ethereum<2.0.0,>=1.6.1
+eth-utils>=0.7.1,<0.8.*
+eth-abi>=0.5.0,<1.*
+eth-tester==0.1.0b10
+eth-keyfile==0.4.1
+eth-keys==0.1.0-beta.4
+web3==4.0.0-beta.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ethereum
 click
 coincurve
-web3>=4.0.0-beta.11
+web3>=4.0.0-beta.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,0 @@
--r requirements.txt
-
-pytest

--- a/requirements_populus.txt
+++ b/requirements_populus.txt
@@ -1,2 +1,0 @@
-populus
-eth-utils>=0.7.1,<1.0.0

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ config = {
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.5',
     ],
     'entry_points': {
         'console_scripts': ['deploy = raiden_contracts.deploy.__main__:main'],


### PR DESCRIPTION
Remove `populus` dependency from common utils functions.
Refactor dependencies, provide compiled data.
Removed contract manager code. There is no reason to keep it because we provide the compiled data.