### PR TITLE
Extract address verification in a separate reusable contract

### DIFF
--- a/raiden_contracts/contracts/lib/ECVerify.sol
+++ b/raiden_contracts/contracts/lib/ECVerify.sol
@@ -1,0 +1,43 @@
+pragma solidity ^0.4.17;
+
+library ECVerify {
+
+    function ecverify(
+        bytes32 hash,
+        bytes signature)
+        internal
+        pure
+        returns (address signature_address)
+    {
+        require(signature.length == 65);
+
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+
+        // The signature format is a compact form of:
+        //   {bytes32 r}{bytes32 s}{uint8 v}
+        // Compact means, uint8 is not padded to 32 bytes.
+        assembly {
+            r := mload(add(signature, 32))
+            s := mload(add(signature, 64))
+
+            // Here we are loading the last 32 bytes, including 31 bytes of 's'.
+            v := byte(0, mload(add(signature, 96)))
+        }
+
+        // Version of signature should be 27 or 28, but 0 and 1 are also possible
+        if (v < 27) {
+            v += 27;
+        }
+
+        require(v == 27 || v == 28);
+
+        signature_address = ecrecover(hash, v, r, s);
+
+        // ecrecover returns zero on error
+        require(signature_address != 0x0);
+
+        return signature_address;
+    }
+}

--- a/raiden_contracts/contracts/test/SignatureVerifyTest.sol
+++ b/raiden_contracts/contracts/test/SignatureVerifyTest.sol
@@ -1,0 +1,32 @@
+pragma solidity ^0.4.17;
+
+/*
+This is a contract used for testing the ECVerify library and ecrecover behaviour.
+.*/
+
+import "raiden/lib/ECVerify.sol";
+
+contract SignatureVerifyTest {
+    function verify(
+        bytes32 _message_hash,
+        bytes _signed_message)
+        pure
+        public
+        returns (address signer)
+    {
+        // Derive address from signature
+        signer = ECVerify.ecverify(_message_hash, _signed_message);
+    }
+
+    function verifyEcrecoverOutput(
+        bytes32 hash,
+        bytes32 r,
+        bytes32 s,
+        uint8 v)
+        pure
+        public
+        returns (address signature_address)
+    {
+        signature_address = ecrecover(hash, v, r, s);
+    }
+}

--- a/raiden_contracts/contracts/test/SignatureVerifyTest.sol
+++ b/raiden_contracts/contracts/test/SignatureVerifyTest.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.4.17;
 
 /*
-This is a contract used for testing the ECVerify library and ecrecover behaviour.
-.*/
+ * This is a contract used for testing the ECVerify library and ecrecover behaviour.
+ */
 
 import "raiden/lib/ECVerify.sol";
 

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -46,7 +46,8 @@ def create_balance_proof(token_network, get_private_key):
             transferred_amount=0,
             nonce=0,
             locksroot=None,
-            additional_hash=None
+            additional_hash=None,
+            v=27
     ):
         private_key = get_private_key(participant)
         locksroot = locksroot or b'\x00' * 32
@@ -54,13 +55,14 @@ def create_balance_proof(token_network, get_private_key):
 
         signature = sign_balance_proof(
             private_key,
-            channel_identifier,
             token_network.address,
             int(token_network.call().chain_id()),
+            channel_identifier,
             nonce,
             transferred_amount,
             locksroot,
-            additional_hash
+            additional_hash,
+            v
         )
         return (
             channel_identifier,

--- a/raiden_contracts/tests/fixtures/utils.py
+++ b/raiden_contracts/tests/fixtures/utils.py
@@ -50,7 +50,8 @@ def create_accounts(web3):
 def get_private_key(web3):
     def get(account_address):
         index = web3.eth.accounts.index(account_address)
-        return getattr(tester, 'k' + str(index))
+        privkey = getattr(tester, 'k' + str(index))
+        return hex(int.from_bytes(privkey, byteorder='big'))
     return get
 
 

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -78,9 +78,9 @@ def test_channel_cycle(web3, token_network, custom_token, get_accounts, print_ga
     additional_hash = b'\x00' * 32
     signature = sign_balance_proof(
         tester.k3,
-        1,
         token_network.address,
         chain_id,
+        1,
         nonce,
         transferred_amount,
         locksroot,
@@ -103,9 +103,9 @@ def test_channel_cycle(web3, token_network, custom_token, get_accounts, print_ga
     additional_hash = b'\x00' * 32
     closing_signature = sign_balance_proof(
         tester.k2,
-        1,
         token_network.address,
         chain_id,
+        1,
         nonce,
         transferred_amount,
         locksroot,

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -1,4 +1,3 @@
-from ethereum import tester
 from raiden_contracts.utils.config import (
     C_TOKEN_NETWORK_REGISTRY,
     C_TOKEN_NETWORK,
@@ -53,7 +52,14 @@ def test_secret_registry(secret_registry, print_gas):
     print_gas(txn_hash, C_SECRET_REGISTRY + '.registerSecret')
 
 
-def test_channel_cycle(web3, token_network, custom_token, get_accounts, print_gas):
+def test_channel_cycle(
+        web3,
+        token_network,
+        custom_token,
+        get_accounts,
+        print_gas,
+        get_private_key
+):
     (A, B) = get_accounts(2)
     chain_id = int(web3.version.network)
 
@@ -77,7 +83,7 @@ def test_channel_cycle(web3, token_network, custom_token, get_accounts, print_ga
     locksroot = b'\x00' * 32
     additional_hash = b'\x00' * 32
     signature = sign_balance_proof(
-        tester.k3,
+        get_private_key(B),
         token_network.address,
         chain_id,
         1,
@@ -86,7 +92,7 @@ def test_channel_cycle(web3, token_network, custom_token, get_accounts, print_ga
         locksroot,
         additional_hash,
     )
-    # TODO: compare transferred_amount with deposit!!!!
+
     txn_hash = token_network.transact({'from': A}).closeChannel(
         1,
         nonce,
@@ -102,7 +108,7 @@ def test_channel_cycle(web3, token_network, custom_token, get_accounts, print_ga
     locksroot = b'\x00' * 32
     additional_hash = b'\x00' * 32
     closing_signature = sign_balance_proof(
-        tester.k2,
+        get_private_key(A),
         token_network.address,
         chain_id,
         1,

--- a/raiden_contracts/tests/test_recover_from_signature.py
+++ b/raiden_contracts/tests/test_recover_from_signature.py
@@ -91,6 +91,7 @@ def test_ecrecover_output(
 
 
 def test_ecrecover_output_zero(signature_test_contract, get_accounts, get_private_key):
+    """ ecrecover returns 0 due to an error caused by an incorrect value of the v parameter """
     A = get_accounts(1)[0]
     privatekey = get_private_key(A)
     message_hash = Web3.soliditySha3(['string', 'uint256'], ['hello', 5])

--- a/raiden_contracts/tests/test_recover_from_signature.py
+++ b/raiden_contracts/tests/test_recover_from_signature.py
@@ -1,0 +1,126 @@
+import pytest
+from ethereum import tester
+from web3 import Web3
+from raiden_contracts.utils.sign import hash_balance_proof
+from .fixtures.config import empty_address
+from raiden_contracts.utils.sign_utils import sign
+
+
+@pytest.fixture
+def signature_test_contract(chain, create_contract, custom_token, secret_registry):
+    SignatureVerifyTest = chain.provider.get_contract_factory('SignatureVerifyTest')
+    signature_test_contract = create_contract(SignatureVerifyTest, [])
+
+    return signature_test_contract
+
+
+def test_verify(
+        web3,
+        token_network,
+        signature_test_contract,
+        get_accounts,
+        create_channel,
+        create_balance_proof
+):
+    (A, B) = get_accounts(2)
+    channel_identifier = create_channel(A, B)
+
+    balance_proof_A = create_balance_proof(channel_identifier, A, 2, 3)
+    signature = balance_proof_A[5]
+    balance_proof_hash = hash_balance_proof(
+        token_network.address,
+        int(web3.version.network),
+        *balance_proof_A[:5]
+    )
+    address = signature_test_contract.call().verify(balance_proof_hash, signature)
+    assert address == A
+
+    balance_proof_B = create_balance_proof(channel_identifier, B, 0, 0)
+    signature = balance_proof_B[5]
+    balance_proof_hash = hash_balance_proof(
+        token_network.address,
+        int(web3.version.network),
+        *balance_proof_B[:5]
+    )
+    address = signature_test_contract.call().verify(balance_proof_hash, signature)
+    assert address == B
+
+
+def test_verify_fail(signature_test_contract, get_accounts, get_private_key):
+    (A, B) = get_accounts(2)
+    message_hash = Web3.soliditySha3(['string', 'uint256'], ['hello', 5])
+    signature = sign(get_private_key(A), message_hash, v=27)
+
+    assert signature_test_contract.call().verify(message_hash, signature) == A
+
+    message_hash = Web3.soliditySha3(['string', 'uint256'], ['hello', 6])
+    assert signature_test_contract.call().verify(message_hash, signature) != A
+
+    signature2 = signature[:65] + bytes([2])
+    with pytest.raises(tester.TransactionFailed):
+        signature_test_contract.call().verify(message_hash, signature2)
+
+
+def test_ecrecover_output(
+        web3,
+        token_network,
+        signature_test_contract,
+        get_accounts, create_channel,
+        create_balance_proof
+):
+    (A, B) = get_accounts(2)
+    channel_identifier = create_channel(A, B)
+    balance_proof_A = create_balance_proof(channel_identifier, A, 2, 3)
+    signature = balance_proof_A[5]
+    r = signature[:32]
+    s = signature[32:64]
+    v = signature[64:]
+    balance_proof_hash = hash_balance_proof(
+        token_network.address,
+        int(web3.version.network),
+        *balance_proof_A[:5]
+    )
+
+    address = signature_test_contract.call().verifyEcrecoverOutput(
+        balance_proof_hash,
+        r,
+        s,
+        int.from_bytes(v, byteorder='big')
+    )
+    assert address == A
+
+
+def test_ecrecover_output_zero(signature_test_contract, get_accounts, get_private_key):
+    A = get_accounts(1)[0]
+    privatekey = get_private_key(A)
+    message_hash = Web3.soliditySha3(['string', 'uint256'], ['hello', 5])
+    signature = sign(privatekey, message_hash, v=27)
+
+    assert signature_test_contract.call().verifyEcrecoverOutput(
+        message_hash,
+        signature[:32],
+        signature[32:64],
+        2
+    ) == empty_address
+
+
+def test_ecrecover_output_fail(signature_test_contract, get_accounts, get_private_key):
+    A = get_accounts(1)[0]
+    privatekey = get_private_key(A)
+    message_hash = Web3.soliditySha3(['string', 'uint256'], ['hello', 5])
+    signature = sign(privatekey, message_hash, v=27)
+
+    assert signature_test_contract.call().verifyEcrecoverOutput(
+        message_hash,
+        signature[:32],
+        signature[32:64],
+        int.from_bytes(signature[64:], byteorder='big')
+    ) == A
+
+    message_hash2 = Web3.soliditySha3(['string', 'uint256'], ['hello', 6])
+    assert signature_test_contract.call().verifyEcrecoverOutput(
+        message_hash2,
+        signature[:32],
+        signature[32:64],
+        int.from_bytes(signature[64:], byteorder='big')
+    ) != A

--- a/raiden_contracts/utils/sign.py
+++ b/raiden_contracts/utils/sign.py
@@ -2,16 +2,15 @@ from web3 import Web3
 from .sign_utils import sign
 
 
-def sign_balance_proof(
-        privatekey,
-        channel_identifier,
+def hash_balance_proof(
         token_network_address,
         chain_identifier,
+        channel_identifier,
         nonce,
         transferred_amount,
         locksroot,
         additional_hash):
-    message_hash = Web3.soliditySha3([
+    return Web3.soliditySha3([
         'uint64',
         'uint256',
         'bytes32',
@@ -29,6 +28,25 @@ def sign_balance_proof(
         additional_hash
     ])
 
-    privatekey = hex(int.from_bytes(privatekey, byteorder='big'))
 
-    return sign(privatekey, message_hash, v=27)
+def sign_balance_proof(
+        privatekey,
+        token_network_address,
+        chain_identifier,
+        channel_identifier,
+        nonce,
+        transferred_amount,
+        locksroot,
+        additional_hash,
+        v=27):
+    message_hash = hash_balance_proof(
+        token_network_address,
+        chain_identifier,
+        channel_identifier,
+        nonce,
+        transferred_amount,
+        locksroot,
+        additional_hash
+    )
+
+    return sign(privatekey, message_hash, v)

--- a/raiden_contracts/utils/sign_utils.py
+++ b/raiden_contracts/utils/sign_utils.py
@@ -3,8 +3,6 @@ from eth_utils import remove_0x_prefix
 
 
 def sign(privkey: str, msg: bytes, v=0) -> bytes:
-    if isinstance(privkey, bytes):
-        privkey = hex(int.from_bytes(privkey, byteorder='big'))
     assert isinstance(msg, bytes)
     assert isinstance(privkey, str)
 

--- a/raiden_contracts/utils/sign_utils.py
+++ b/raiden_contracts/utils/sign_utils.py
@@ -3,6 +3,8 @@ from eth_utils import remove_0x_prefix
 
 
 def sign(privkey: str, msg: bytes, v=0) -> bytes:
+    if isinstance(privkey, bytes):
+        privkey = hex(int.from_bytes(privkey, byteorder='big'))
     assert isinstance(msg, bytes)
     assert isinstance(privkey, str)
 


### PR DESCRIPTION
We can reuse the `ECVerify` library for all projects. It is better to have it separately.
Small refactoring for the address recover code.
Added tests.