### PR TITLE
Cooperative settle

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -576,10 +576,13 @@ contract TokenNetwork is Utils {
 
     function cooperativeSettle(
         uint256 channel_identifier,
+        address participant1_address,
         uint256 participant1_balance,
+        address participant2_address,
         uint256 participant2_balance,
         bytes participant1_signature,
-        bytes participant2_signature)
+        bytes participant2_signature
+    )
         public
     {
         address participant1;
@@ -589,14 +592,18 @@ contract TokenNetwork is Utils {
 
         participant1 = recoverAddressFromCooperativeSettleSignature(
             channel_identifier,
+            participant1_address,
             participant1_balance,
+            participant2_address,
             participant2_balance,
             participant1_signature
         );
 
         participant2 = recoverAddressFromCooperativeSettleSignature(
             channel_identifier,
+            participant1_address,
             participant1_balance,
+            participant2_address,
             participant2_balance,
             participant2_signature
         );
@@ -605,6 +612,10 @@ contract TokenNetwork is Utils {
         Participant storage participant2_state = channel.participants[participant2];
 
         total_deposit = participant1_state.deposit + participant2_state.deposit;
+
+        // The provided addresses must be the same as the recovered ones
+        require(participant1 == participant1_address);
+        require(participant2 == participant2_address);
 
         // The channel must be open
         require(channel.state == 1);
@@ -807,7 +818,9 @@ contract TokenNetwork is Utils {
 
     function recoverAddressFromCooperativeSettleSignature(
         uint256 channel_identifier,
+        address participant1,
         uint256 participant1_balance,
+        address participant2,
         uint256 participant2_balance,
         bytes signature
     )
@@ -816,7 +829,9 @@ contract TokenNetwork is Utils {
         returns (address signature_address)
     {
         bytes32 message_hash = keccak256(
+            participant1,
             participant1_balance,
+            participant2,
             participant2_balance,
             channel_identifier,
             address(this),

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -585,6 +585,9 @@ contract TokenNetwork is Utils {
     )
         public
     {
+        require(participant1_address != 0x0);
+        require(participant2_address != 0x0);
+
         address participant1;
         address participant2;
         uint256 total_deposit;

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -1,5 +1,5 @@
 import pytest
-from raiden_contracts.utils.config import C_TOKEN_NETWORK, SETTLE_TIMEOUT_MIN
+from raiden_contracts.utils.config import C_TOKEN_NETWORK, SETTLE_TIMEOUT_MIN, CHANNEL_STATE_NONEXISTENT_OR_SETTLED
 from raiden_contracts.utils.sign import (
     sign_balance_proof,
     hash_balance_data,
@@ -8,6 +8,7 @@ from raiden_contracts.utils.sign import (
 )
 from .token_network import *  # flake8: noqa
 from .secret_registry import *  # flake8: noqa
+from .config import fake_bytes
 
 
 @pytest.fixture()
@@ -40,6 +41,75 @@ def channel_deposit(token_network, custom_token):
             deposit
         )
         return txn_hash
+    return get
+
+
+@pytest.fixture()
+def create_channel_and_deposit(create_channel, channel_deposit):
+    def get(participant1, participant2, deposit1=0, deposit2=0, settle_timeout=SETTLE_TIMEOUT_MIN):
+        channel_identifier = create_channel(participant1, participant2, settle_timeout)
+
+        if deposit1 > 0:
+            channel_deposit(channel_identifier, participant1, deposit1)
+        if deposit2 > 0:
+            channel_deposit(channel_identifier, participant2, deposit2)
+        return channel_identifier
+    return get
+
+
+@pytest.fixture()
+def cooperative_settle_state_tests(custom_token, token_network):
+    def get(
+            channel_identifier,
+            A, balance_A,
+            B, balance_B,
+            pre_account_balance_A,
+            pre_account_balance_B,
+            pre_balance_contract
+    ):
+        # Make sure the correct amount of tokens has been transferred
+        account_balance_A = custom_token.call().balanceOf(A)
+        account_balance_B = custom_token.call().balanceOf(B)
+        balance_contract = custom_token.call().balanceOf(token_network.address)
+        assert account_balance_A == pre_account_balance_A + balance_A
+        assert account_balance_B == pre_account_balance_B + balance_B
+        assert balance_contract == pre_balance_contract - balance_A - balance_B
+
+        # Make sure channel data has been removed
+        (settle_block_number, state) = token_network.call().getChannelInfo(1)
+        assert settle_block_number == 0  # settle_block_number
+        assert state == CHANNEL_STATE_NONEXISTENT_OR_SETTLED  # state
+
+        # Make sure participant data has been removed
+        (
+            A_deposit,
+            A_is_initialized,
+            A_is_the_closer,
+            A_locksroot,
+            A_locked_amount
+        ) = token_network.call().getChannelParticipantInfo(1, A, B)
+        assert A_deposit == 0
+        assert A_is_initialized == 0
+        assert A_is_the_closer == 0
+
+        # Make sure there is no balance data
+        assert A_locksroot == fake_bytes(32)
+        assert A_locked_amount == 0
+
+        (
+            B_deposit,
+            B_is_initialized,
+            B_is_the_closer,
+            B_locksroot,
+            B_locked_amount
+        ) = token_network.call().getChannelParticipantInfo(1, B, A)
+        assert B_deposit == 0
+        assert B_is_initialized == 0
+        assert B_is_the_closer == 0
+
+        # Make sure there is no balance data
+        assert B_locksroot == fake_bytes(32)
+        assert B_locked_amount == 0
     return get
 
 
@@ -110,28 +180,30 @@ def create_balance_proof_update_signature(token_network, get_private_key):
 
 
 @pytest.fixture()
-def create_cooperative_settle_signature(token_network, get_private_key):
+def create_cooperative_settle_signatures(token_network, get_private_key):
     def get(
+            participants_to_sign,
             channel_identifier,
-            participant,
             participant1_address,
             participant1_balance,
             participant2_address,
             participant2_balance,
             v=27
     ):
-        private_key = get_private_key(participant)
-
-        signature = sign_cooperative_settle_message(
-            private_key,
-            token_network.address,
-            int(token_network.call().chain_id()),
-            channel_identifier,
-            participant1_address,
-            participant1_balance,
-            participant2_address,
-            participant2_balance,
-            v
-        )
-        return signature
+        signatures = []
+        for participant in participants_to_sign:
+            private_key = get_private_key(participant)
+            signature = sign_cooperative_settle_message(
+                private_key,
+                token_network.address,
+                int(token_network.call().chain_id()),
+                channel_identifier,
+                participant1_address,
+                participant1_balance,
+                participant2_address,
+                participant2_balance,
+                v
+            )
+            signatures.append(signature)
+        return signatures
     return get

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -114,7 +114,9 @@ def create_cooperative_settle_signature(token_network, get_private_key):
     def get(
             channel_identifier,
             participant,
+            participant1_address,
             participant1_balance,
+            participant2_address,
             participant2_balance,
             v=27
     ):
@@ -125,7 +127,9 @@ def create_cooperative_settle_signature(token_network, get_private_key):
             token_network.address,
             int(token_network.call().chain_id()),
             channel_identifier,
+            participant1_address,
             participant1_balance,
+            participant2_address,
             participant2_balance,
             v
         )

--- a/raiden_contracts/tests/test_channel_cooperative_settle.py
+++ b/raiden_contracts/tests/test_channel_cooperative_settle.py
@@ -34,14 +34,14 @@ def test_cooperative_settle_channel_state(
     signature_A = create_cooperative_settle_signature(
         channel_identifier,
         A,
-        balance_A,
-        balance_B
+        A, balance_A,
+        B, balance_B
     )
     signature_B = create_cooperative_settle_signature(
         channel_identifier,
         B,
-        balance_A,
-        balance_B
+        A, balance_A,
+        B, balance_B
     )
 
     pre_account_balance_A = custom_token.call().balanceOf(A)
@@ -51,8 +51,8 @@ def test_cooperative_settle_channel_state(
     # Settle the channel
     token_network.transact({'from': C}).cooperativeSettle(
         channel_identifier,
-        balance_A,
-        balance_B,
+        A, balance_A,
+        B, balance_B,
         signature_A,
         signature_B
     )
@@ -122,23 +122,23 @@ def test_update_channel_event(
     signature_A = create_cooperative_settle_signature(
         channel_identifier,
         A,
-        balance_A,
-        balance_B
+        B, balance_B,
+        A, balance_A
     )
     signature_B = create_cooperative_settle_signature(
         channel_identifier,
         B,
-        balance_A,
-        balance_B
+        B, balance_B,
+        A, balance_A
     )
 
     # Settle the channel
     txn_hash = token_network.transact({'from': B}).cooperativeSettle(
         channel_identifier,
-        balance_A,
-        balance_B,
-        signature_A,
-        signature_B
+        B, balance_B,
+        A, balance_A,
+        signature_B,
+        signature_A
     )
 
     ev_handler.add(txn_hash, E_CHANNEL_SETTLED, check_channel_settled(channel_identifier))

--- a/raiden_contracts/tests/test_channel_cooperative_settle.py
+++ b/raiden_contracts/tests/test_channel_cooperative_settle.py
@@ -1,0 +1,145 @@
+from raiden_contracts.utils.config import (
+    E_CHANNEL_SETTLED,
+    SETTLE_TIMEOUT_MIN,
+    CHANNEL_STATE_OPEN,
+    CHANNEL_STATE_NONEXISTENT_OR_SETTLED
+)
+from raiden_contracts.utils.events import check_channel_settled
+from .fixtures.config import fake_bytes
+
+
+def test_cooperative_settle_channel_state(
+        web3,
+        custom_token,
+        token_network,
+        create_channel,
+        channel_deposit,
+        get_accounts,
+        get_block,
+        create_cooperative_settle_signature
+):
+    (A, B, C) = get_accounts(3)
+    settle_timeout = SETTLE_TIMEOUT_MIN
+    deposit_A = 20
+    deposit_B = 10
+    balance_A = 5
+    balance_B = 25
+
+    # Create channel and deposit
+    channel_identifier = create_channel(A, B, settle_timeout)
+    channel_deposit(channel_identifier, A, deposit_A)
+    channel_deposit(channel_identifier, B, deposit_B)
+
+    # Create cooperative settle message
+    signature_A = create_cooperative_settle_signature(
+        channel_identifier,
+        A,
+        balance_A,
+        balance_B
+    )
+    signature_B = create_cooperative_settle_signature(
+        channel_identifier,
+        B,
+        balance_A,
+        balance_B
+    )
+
+    pre_account_balance_A = custom_token.call().balanceOf(A)
+    pre_account_balance_B = custom_token.call().balanceOf(B)
+    pre_balance_contract = custom_token.call().balanceOf(token_network.address)
+
+    # Settle the channel
+    token_network.transact({'from': C}).cooperativeSettle(
+        channel_identifier,
+        balance_A,
+        balance_B,
+        signature_A,
+        signature_B
+    )
+
+    # Make sure the correct amount of tokens has been transferred
+    account_balance_A = custom_token.call().balanceOf(A)
+    account_balance_B = custom_token.call().balanceOf(B)
+    balance_contract = custom_token.call().balanceOf(token_network.address)
+    assert account_balance_A == pre_account_balance_A + balance_A
+    assert account_balance_B == pre_account_balance_B + balance_B
+    assert balance_contract == pre_balance_contract - balance_A - balance_B
+
+    # Make sure channel data has been removed
+    (settle_block_number, state) = token_network.call().getChannelInfo(1)
+    assert settle_block_number == 0  # settle_block_number
+    assert state == CHANNEL_STATE_NONEXISTENT_OR_SETTLED  # state
+
+    # Make sure participant data has been removed
+    (
+        A_deposit,
+        A_is_initialized,
+        A_is_the_closer,
+        A_locksroot,
+        A_locked_amount
+    ) = token_network.call().getChannelParticipantInfo(1, A, B)
+    assert A_deposit == 0
+    assert A_is_initialized == 0
+    assert A_is_the_closer == 0
+
+    # Make sure there is no balance data
+    assert A_locksroot == fake_bytes(32)
+    assert A_locked_amount == 0
+
+    (
+        B_deposit,
+        B_is_initialized,
+        B_is_the_closer,
+        B_locksroot,
+        B_locked_amount
+    ) = token_network.call().getChannelParticipantInfo(1, B, A)
+    assert B_deposit == 0
+    assert B_is_initialized == 0
+    assert B_is_the_closer == 0
+
+    # Make sure there is no balance data
+    assert B_locksroot == fake_bytes(32)
+    assert B_locked_amount == 0
+
+
+def test_update_channel_event(
+        web3,
+        get_accounts,
+        token_network,
+        create_channel,
+        channel_deposit,
+        create_cooperative_settle_signature,
+        event_handler
+):
+    ev_handler = event_handler(token_network)
+    (A, B) = get_accounts(2)
+    deposit_A = 10
+    balance_A = 2
+    balance_B = 8
+    channel_identifier = create_channel(A, B)
+    channel_deposit(channel_identifier, A, deposit_A)
+
+    signature_A = create_cooperative_settle_signature(
+        channel_identifier,
+        A,
+        balance_A,
+        balance_B
+    )
+    signature_B = create_cooperative_settle_signature(
+        channel_identifier,
+        B,
+        balance_A,
+        balance_B
+    )
+
+    # Settle the channel
+    txn_hash = token_network.transact({'from': B}).cooperativeSettle(
+        channel_identifier,
+        balance_A,
+        balance_B,
+        signature_A,
+        signature_B
+    )
+
+    ev_handler.add(txn_hash, E_CHANNEL_SETTLED, check_channel_settled(channel_identifier))
+    ev_handler.check()

--- a/raiden_contracts/tests/test_channel_cooperative_settle.py
+++ b/raiden_contracts/tests/test_channel_cooperative_settle.py
@@ -18,10 +18,8 @@ def test_cooperative_settle_channel_call(
     balance_A = 5
     balance_B = 25
 
-    # Create channel and deposit
     channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
 
-    # Create cooperative settle signatures
     (signature_A, signature_B) = create_cooperative_settle_signatures(
         [A, B],
         channel_identifier,
@@ -120,7 +118,6 @@ def test_cooperative_settle_channel_signatures(
 
     channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
 
-    # Create cooperative settle signatures
     (signature_A, signature_B, signature_C) = create_cooperative_settle_signatures(
         [A, B, C],
         channel_identifier,
@@ -178,7 +175,6 @@ def test_cooperative_settle_channel_0(
 
     channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
 
-    # Create cooperative settle signatures
     (signature_A, signature_B, signature_C) = create_cooperative_settle_signatures(
         [A, B, C],
         channel_identifier,
@@ -224,7 +220,6 @@ def test_cooperative_settle_channel_00(
 
     channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
 
-    # Create cooperative settle signatures
     (signature_A, signature_B, signature_C) = create_cooperative_settle_signatures(
         [A, B, C],
         channel_identifier,
@@ -269,10 +264,8 @@ def test_cooperative_settle_channel_state(
     balance_A = 5
     balance_B = 25
 
-    # Create channel and deposit
     channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
 
-    # Create cooperative settle signatures
     (signature_A, signature_B) = create_cooperative_settle_signatures(
         [A, B],
         channel_identifier,
@@ -284,7 +277,6 @@ def test_cooperative_settle_channel_state(
     pre_account_balance_B = custom_token.call().balanceOf(B)
     pre_balance_contract = custom_token.call().balanceOf(token_network.address)
 
-    # Settle the channel
     token_network.transact({'from': C}).cooperativeSettle(
         channel_identifier,
         A, balance_A,
@@ -323,10 +315,8 @@ def test_cooperative_settle_channel_wrong_balances(
     balance_A_fail2 = 6
     balance_B_fail2 = 8
 
-    # Create channel and deposit
     channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
 
-    # Create cooperative settle signatures
     (signature_A, signature_B) = create_cooperative_settle_signatures(
         [A, B],
         channel_identifier,
@@ -396,7 +386,6 @@ def test_update_channel_event(
         A, balance_A
     )
 
-    # Settle the channel
     txn_hash = token_network.transact({'from': B}).cooperativeSettle(
         channel_identifier,
         B, balance_B,

--- a/raiden_contracts/utils/sign.py
+++ b/raiden_contracts/utils/sign.py
@@ -66,17 +66,23 @@ def hash_cooperative_settle_message(
         token_network_address,
         chain_identifier,
         channel_identifier,
+        participant1_address,
         participant1_balance,
+        participant2_address,
         participant2_balance
 ):
     return Web3.soliditySha3([
+        'address',
         'uint256',
+        'address',
         'uint256',
         'uint256',
         'address',
         'uint256'
     ], [
+        participant1_address,
         participant1_balance,
+        participant2_address,
         participant2_balance,
         channel_identifier,
         token_network_address,
@@ -135,7 +141,9 @@ def sign_cooperative_settle_message(
         token_network_address,
         chain_identifier,
         channel_identifier,
+        participant1_address,
         participant1_balance,
+        participant2_address,
         participant2_balance,
         v=27
 ):
@@ -143,7 +151,9 @@ def sign_cooperative_settle_message(
         token_network_address,
         chain_identifier,
         channel_identifier,
+        participant1_address,
         participant1_balance,
+        participant2_address,
         participant2_balance
     )
 

--- a/raiden_contracts/utils/sign.py
+++ b/raiden_contracts/utils/sign.py
@@ -62,6 +62,28 @@ def hash_balance_proof_update_message(
     ])
 
 
+def hash_cooperative_settle_message(
+        token_network_address,
+        chain_identifier,
+        channel_identifier,
+        participant1_balance,
+        participant2_balance
+):
+    return Web3.soliditySha3([
+        'uint256',
+        'uint256',
+        'uint256',
+        'address',
+        'uint256'
+    ], [
+        participant1_balance,
+        participant2_balance,
+        channel_identifier,
+        token_network_address,
+        chain_identifier
+    ])
+
+
 def sign_balance_proof(
         privatekey,
         token_network_address,
@@ -103,6 +125,26 @@ def sign_balance_proof_update_message(
         nonce,
         additional_hash,
         closing_signature
+    )
+
+    return sign(privatekey, message_hash, v)
+
+
+def sign_cooperative_settle_message(
+        privatekey,
+        token_network_address,
+        chain_identifier,
+        channel_identifier,
+        participant1_balance,
+        participant2_balance,
+        v=27
+):
+    message_hash = hash_cooperative_settle_message(
+        token_network_address,
+        chain_identifier,
+        channel_identifier,
+        participant1_balance,
+        participant2_balance
     )
 
     return sign(privatekey, message_hash, v)


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden-contracts/issues/49

Adds support for an instant channel close & settle if both participants exchange signatures on balances calculated off-chain.