### PR TITLE
TokenNetwork - 2 nodes can have maximum 1 channel

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -42,7 +42,7 @@ contract TokenNetwork is Utils {
         // This is bytes1 and it gets packed with the rest of the struct data.
         bool is_the_closer;
 
-        // keccak256 of the balance data provided after a closeChannel or a
+        // keccak256 of the balance data provided after a closeChannel or an
         // updateNonClosingBalanceProof call
         bytes32 balance_hash;
 
@@ -157,7 +157,6 @@ contract TokenNetwork is Utils {
     {
         require(participant1 != 0x0);
         require(participant2 != 0x0);
-        require(participant1 != participant2);
 
         bytes32 channel_identifier = getChannelIdentifier(participant1, participant2);
         Channel storage channel = channels[channel_identifier];
@@ -230,9 +229,6 @@ contract TokenNetwork is Utils {
     {
         require(partner != 0x0);
 
-        // Message sender and partner must be different
-        require(msg.sender != partner);
-
         address recovered_partner_address;
         bytes32 channel_identifier;
 
@@ -291,7 +287,6 @@ contract TokenNetwork is Utils {
     {
         require(closing_participant != 0x0);
         require(non_closing_participant != 0x0);
-        require(closing_participant != non_closing_participant);
         require(balance_hash != 0x0);
         require(nonce > 0);
 
@@ -642,6 +637,9 @@ contract TokenNetwork is Utils {
         public
         returns (bytes32)
     {
+        // Participant addresses must be different
+        require(participant != partner);
+
         // Lexicographic order of the channel addresses
         // This limits the number of channels that can be opened between two nodes to 1.
         if (participant < partner) {

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -155,9 +155,6 @@ contract TokenNetwork is Utils {
         public
         returns (bytes32)
     {
-        require(participant1 != 0x0);
-        require(participant2 != 0x0);
-
         bytes32 channel_identifier = getChannelIdentifier(participant1, participant2);
         Channel storage channel = channels[channel_identifier];
 
@@ -184,8 +181,6 @@ contract TokenNetwork is Utils {
         isOpen(participant, partner)
         public
     {
-        require(participant != 0x0);
-        require(partner != 0x0);
         require(total_deposit > 0);
 
         bytes32 channel_identifier;
@@ -227,8 +222,6 @@ contract TokenNetwork is Utils {
         isOpen(msg.sender, partner)
         public
     {
-        require(partner != 0x0);
-
         address recovered_partner_address;
         bytes32 channel_identifier;
 
@@ -285,8 +278,6 @@ contract TokenNetwork is Utils {
     )
         external
     {
-        require(closing_participant != 0x0);
-        require(non_closing_participant != 0x0);
         require(balance_hash != 0x0);
         require(nonce > 0);
 
@@ -502,8 +493,6 @@ contract TokenNetwork is Utils {
     )
         public
     {
-        require(participant != 0x0);
-        require(partner != 0x0);
         require(merkle_tree_leaves.length > 0);
 
         bytes32 channel_identifier;
@@ -567,9 +556,6 @@ contract TokenNetwork is Utils {
     )
         public
     {
-        require(participant1_address != 0x0);
-        require(participant2_address != 0x0);
-
         bytes32 channel_identifier;
         address participant1;
         address participant2;
@@ -637,6 +623,9 @@ contract TokenNetwork is Utils {
         public
         returns (bytes32)
     {
+        require(participant != 0x0);
+        require(partner != 0x0);
+
         // Participant addresses must be different
         require(participant != partner);
 

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -44,10 +44,12 @@ contract TokenNetwork is Utils {
         // This is bytes1 and it gets packed with the rest of the struct data.
         bool is_the_closer;
 
-        // keccak256 of the balance data provided after a closeChannel or a updateNonClosingBalanceProof call
+        // keccak256 of the balance data provided after a closeChannel or a
+        // updateNonClosingBalanceProof call
         bytes32 balance_hash;
 
-        // Monotonically increasing counter of the off-chain transfers, provided along with the balance_hash
+        // Monotonically increasing counter of the off-chain transfers, provided along
+        // with the balance_hash
         uint256 nonce;
     }
 
@@ -166,9 +168,6 @@ contract TokenNetwork is Utils {
         require(channel.settle_block_number == 0);
         require(channel.state == 0);
 
-        Participant storage participant1_state = channel.participants[participant1];
-        Participant storage participant2_state = channel.participants[participant2];
-
         // Store channel information
         channel.settle_block_number = settle_timeout;
         // Mark channel as opened
@@ -189,6 +188,10 @@ contract TokenNetwork is Utils {
         isOpen(participant, partner)
         public
     {
+        require(participant != 0x0);
+        require(partner != 0x0);
+        require(total_deposit > 0);
+
         bytes32 channel_identifier;
         uint256 added_deposit;
 
@@ -651,7 +654,14 @@ contract TokenNetwork is Utils {
         }
     }
 
-    function updateBalanceProofData(Channel storage channel, address participant, uint256 nonce, bytes32 balance_hash) internal {
+    function updateBalanceProofData(
+        Channel storage channel,
+        address participant,
+        uint256 nonce,
+        bytes32 balance_hash
+    )
+        internal
+    {
         Participant storage participant_state = channel.participants[participant];
 
         // Multiple calls to updateNonClosingBalanceProof can be made and we need to store
@@ -730,7 +740,8 @@ contract TokenNetwork is Utils {
     /// @dev Returns the channel specific data.
     /// @param participant Address of the channel participant whose data will be returned.
     /// @param partner Address of the participant's channel partner.
-    /// @return Participant's channel deposit, whether the participant has called `closeChannel` or not, balance_hash and nonce.
+    /// @return Participant's channel deposit, whether the participant has called
+    /// `closeChannel` or not, balance_hash and nonce.
     function getChannelParticipantInfo(address participant, address partner)
         view
         external
@@ -766,8 +777,9 @@ contract TokenNetwork is Utils {
     {
         bytes32 channel_identifier;
         channel_identifier = getChannelIdentifier(participant1, participant2);
+        UnlockData storage unlock_data = channel_identifier_to_unlock_data[channel_identifier];
 
-        return channel_identifier_to_unlock_data[channel_identifier].locksroot_to_locked_amount[locksroot];
+        return unlock_data.locksroot_to_locked_amount[locksroot];
     }
 
     /*

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -22,15 +22,13 @@ contract TokenNetwork is Utils {
     // Chain ID as specified by EIP155 used in balance proof signatures to avoid replay attacks
     uint256 public chain_id;
 
-    // Channel identifier is a uint256, incremented after each new channel
     // channel_identifier => Channel, where the channel identifier is the keccak256 of the
     // addresses of the two participants
     mapping (bytes32 => Channel) public channels;
 
-    // We keep the balance data in a separate mapping to allow channel data structures to be
-    // removed when settling the channel. If there are locked transfers, we need to store
-    // balance data to be able to unlock them at a later time.
-    // Key is the channel_identifier
+    // We keep the unlock data in a separate mapping to allow channel data structures to be
+    // removed when settling. If there are locked transfers, we need to store data needed to
+    // unlock them at a later time. Key is the channel_identifier.
     mapping(bytes32 => UnlockData) channel_identifier_to_unlock_data;
 
     struct Participant {
@@ -54,10 +52,9 @@ contract TokenNetwork is Utils {
     }
 
     struct UnlockData {
-        // Data provided when uncooperatively settling the channel, used to unlock
-        // locked transfers at a later point in time
-        // The key is the merkle tree root of all pending transfers
-        // The value is the total amount of tokens locked in the pending transfers
+        // Data provided when uncooperatively settling the channel, used to unlock locked
+        // transfers at a later point in time. The key is the merkle tree root of all pending
+        // transfers. The value is the total amount of tokens locked in the pending transfers.
         // Note that we store all locksroots for both participants here, with the assumption that
         // no two locksroots can be the same due to having different values for
         // the secrethash of each lock.
@@ -214,7 +211,7 @@ contract TokenNetwork is Utils {
     }
 
     /// @notice Close the channel defined by the two participant addresses. Only a participant
-    // may close the channel, providing a balance proof signed by its partner. Callable only once.
+    /// may close the channel, providing a balance proof signed by its partner. Callable only once.
     /// @param partner Channel partner of the `msg.sender`, who provided the signature.
     /// We need the partner for computing the channel identifier.
     /// @param balance_hash Hash of (transferred_amount, locked_amount, locksroot).

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -32,7 +32,7 @@ def create_channel(token_network):
         assert channel_settle_timeout == settle_timeout
         assert channel_state == CHANNEL_STATE_OPEN
 
-        return txn_hash
+        return (channel_identifier, txn_hash)
     return get
 
 
@@ -73,7 +73,6 @@ def create_channel_and_deposit(create_channel, channel_deposit):
 @pytest.fixture()
 def cooperative_settle_state_tests(custom_token, token_network):
     def get(
-            channel_identifier,
             A, balance_A,
             B, balance_B,
             pre_account_balance_A,
@@ -89,14 +88,13 @@ def cooperative_settle_state_tests(custom_token, token_network):
         assert balance_contract == pre_balance_contract - balance_A - balance_B
 
         # Make sure channel data has been removed
-        (settle_block_number, state) = token_network.call().getChannelInfo(A, B)
+        (_, settle_block_number, state) = token_network.call().getChannelInfo(A, B)
         assert settle_block_number == 0  # settle_block_number
         assert state == CHANNEL_STATE_NONEXISTENT_OR_SETTLED  # state
 
         # Make sure participant data has been removed
         (
             A_deposit,
-            A_is_initialized,
             A_is_the_closer,
             A_balance_hash,
             A_nonce
@@ -108,7 +106,6 @@ def cooperative_settle_state_tests(custom_token, token_network):
 
         (
             B_deposit,
-            B_is_initialized,
             B_is_the_closer,
             B_balance_hash,
             B_nonce
@@ -149,7 +146,6 @@ def create_balance_proof(token_network, get_private_key):
             v
         )
         return (
-            channel_identifier,
             balance_hash,
             nonce,
             additional_hash,

--- a/raiden_contracts/tests/fixtures/token_network.py
+++ b/raiden_contracts/tests/fixtures/token_network.py
@@ -12,7 +12,7 @@ def get_token_network(chain, create_contract):
 
 
 @pytest.fixture()
-def token_network(chain, token_network_registry, custom_token, secret_registry):
+def token_network(chain, token_network_registry, custom_token):
     token_network_address = token_network_registry.call().createERC20TokenNetwork(
         custom_token.address
     )

--- a/raiden_contracts/tests/test_channel_cooperative_settle.py
+++ b/raiden_contracts/tests/test_channel_cooperative_settle.py
@@ -18,7 +18,7 @@ def test_cooperative_settle_channel_call(
     balance_A = 5
     balance_B = 25
 
-    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
+    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)[0]
 
     (signature_A, signature_B) = create_cooperative_settle_signatures(
         [A, B],
@@ -29,7 +29,6 @@ def test_cooperative_settle_channel_call(
 
     with pytest.raises(TypeError):
         token_network.transact({'from': C}).cooperativeSettle(
-            channel_identifier,
             A, -1,
             B, balance_B,
             signature_A,
@@ -37,7 +36,6 @@ def test_cooperative_settle_channel_call(
         )
     with pytest.raises(TypeError):
         token_network.transact({'from': C}).cooperativeSettle(
-            channel_identifier,
             A, balance_A,
             B, -1,
             signature_A,
@@ -45,7 +43,6 @@ def test_cooperative_settle_channel_call(
         )
     with pytest.raises(TypeError):
         token_network.transact({'from': C}).cooperativeSettle(
-            channel_identifier,
             0x0, balance_A,
             B, balance_B,
             signature_A,
@@ -53,7 +50,6 @@ def test_cooperative_settle_channel_call(
         )
     with pytest.raises(TypeError):
         token_network.transact({'from': C}).cooperativeSettle(
-            channel_identifier,
             A, balance_A,
             0x0, balance_B,
             signature_A,
@@ -69,7 +65,6 @@ def test_cooperative_settle_channel_call(
         )
     with pytest.raises(TypeError):
         token_network.transact({'from': C}).cooperativeSettle(
-            channel_identifier,
             A, balance_A,
             B, balance_B,
             signature_A,
@@ -78,7 +73,6 @@ def test_cooperative_settle_channel_call(
 
     with pytest.raises(tester.TransactionFailed):
         token_network.transact({'from': C}).cooperativeSettle(
-            channel_identifier,
             empty_address,
             balance_A,
             B, balance_B,
@@ -87,7 +81,6 @@ def test_cooperative_settle_channel_call(
         )
     with pytest.raises(tester.TransactionFailed):
         token_network.transact({'from': C}).cooperativeSettle(
-            channel_identifier,
             A, balance_A,
             empty_address,
             balance_B,
@@ -96,7 +89,6 @@ def test_cooperative_settle_channel_call(
         )
 
     token_network.transact({'from': C}).cooperativeSettle(
-        channel_identifier,
         A, balance_A,
         B, balance_B,
         signature_A,
@@ -116,7 +108,7 @@ def test_cooperative_settle_channel_signatures(
     balance_A = 4
     balance_B = 26
 
-    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
+    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)[0]
 
     (signature_A, signature_B, signature_C) = create_cooperative_settle_signatures(
         [A, B, C],
@@ -127,7 +119,6 @@ def test_cooperative_settle_channel_signatures(
 
     with pytest.raises(tester.TransactionFailed):
         token_network.transact({'from': C}).cooperativeSettle(
-            channel_identifier,
             A, balance_A,
             B, balance_B,
             signature_C,
@@ -135,7 +126,6 @@ def test_cooperative_settle_channel_signatures(
         )
     with pytest.raises(tester.TransactionFailed):
         token_network.transact({'from': C}).cooperativeSettle(
-            channel_identifier,
             A, balance_A,
             B, balance_B,
             signature_A,
@@ -143,7 +133,6 @@ def test_cooperative_settle_channel_signatures(
         )
     with pytest.raises(tester.TransactionFailed):
         token_network.transact({'from': C}).cooperativeSettle(
-            channel_identifier,
             A, balance_B,
             B, balance_A,
             signature_A,
@@ -151,7 +140,6 @@ def test_cooperative_settle_channel_signatures(
         )
 
     token_network.transact({'from': C}).cooperativeSettle(
-        channel_identifier,
         A, balance_A,
         B, balance_B,
         signature_A,
@@ -173,7 +161,7 @@ def test_cooperative_settle_channel_0(
     balance_A = 0
     balance_B = 30
 
-    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
+    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)[0]
 
     (signature_A, signature_B, signature_C) = create_cooperative_settle_signatures(
         [A, B, C],
@@ -187,7 +175,6 @@ def test_cooperative_settle_channel_0(
     pre_balance_contract = custom_token.call().balanceOf(token_network.address)
 
     token_network.transact({'from': C}).cooperativeSettle(
-        channel_identifier,
         A, balance_A,
         B, balance_B,
         signature_A,
@@ -195,7 +182,6 @@ def test_cooperative_settle_channel_0(
     )
 
     cooperative_settle_state_tests(
-        channel_identifier,
         A, balance_A,
         B, balance_B,
         pre_account_balance_A,
@@ -218,7 +204,7 @@ def test_cooperative_settle_channel_00(
     balance_A = 0
     balance_B = 0
 
-    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
+    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)[0]
 
     (signature_A, signature_B, signature_C) = create_cooperative_settle_signatures(
         [A, B, C],
@@ -232,7 +218,6 @@ def test_cooperative_settle_channel_00(
     pre_balance_contract = custom_token.call().balanceOf(token_network.address)
 
     token_network.transact({'from': C}).cooperativeSettle(
-        channel_identifier,
         A, balance_A,
         B, balance_B,
         signature_A,
@@ -240,7 +225,6 @@ def test_cooperative_settle_channel_00(
     )
 
     cooperative_settle_state_tests(
-        channel_identifier,
         A, balance_A,
         B, balance_B,
         pre_account_balance_A,
@@ -264,7 +248,7 @@ def test_cooperative_settle_channel_state(
     balance_A = 5
     balance_B = 25
 
-    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
+    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)[0]
 
     (signature_A, signature_B) = create_cooperative_settle_signatures(
         [A, B],
@@ -278,7 +262,6 @@ def test_cooperative_settle_channel_state(
     pre_balance_contract = custom_token.call().balanceOf(token_network.address)
 
     token_network.transact({'from': C}).cooperativeSettle(
-        channel_identifier,
         A, balance_A,
         B, balance_B,
         signature_A,
@@ -286,7 +269,6 @@ def test_cooperative_settle_channel_state(
     )
 
     cooperative_settle_state_tests(
-        channel_identifier,
         A, balance_A,
         B, balance_B,
         pre_account_balance_A,
@@ -315,7 +297,7 @@ def test_cooperative_settle_channel_wrong_balances(
     balance_A_fail2 = 6
     balance_B_fail2 = 8
 
-    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
+    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)[0]
 
     (signature_A, signature_B) = create_cooperative_settle_signatures(
         [A, B],
@@ -338,7 +320,6 @@ def test_cooperative_settle_channel_wrong_balances(
 
     with pytest.raises(tester.TransactionFailed):
         token_network.transact({'from': C}).cooperativeSettle(
-            channel_identifier,
             A, balance_A_fail1,
             B, balance_B_fail1,
             signature_A_fail1,
@@ -346,7 +327,6 @@ def test_cooperative_settle_channel_wrong_balances(
         )
     with pytest.raises(tester.TransactionFailed):
         token_network.transact({'from': C}).cooperativeSettle(
-            channel_identifier,
             A, balance_A_fail2,
             B, balance_B_fail2,
             signature_A_fail2,
@@ -354,7 +334,6 @@ def test_cooperative_settle_channel_wrong_balances(
         )
 
     token_network.transact({'from': C}).cooperativeSettle(
-        channel_identifier,
         A, balance_A,
         B, balance_B,
         signature_A,
@@ -362,7 +341,7 @@ def test_cooperative_settle_channel_wrong_balances(
     )
 
 
-def test_update_channel_event(
+def test_cooperative_settle_channel_event(
         web3,
         get_accounts,
         token_network,
@@ -376,8 +355,8 @@ def test_update_channel_event(
     deposit_A = 10
     balance_A = 2
     balance_B = 8
-    channel_identifier = create_channel(A, B)
-    channel_deposit(channel_identifier, A, deposit_A)
+    channel_identifier = create_channel(A, B)[0]
+    channel_deposit(A, deposit_A, B)
 
     (signature_A, signature_B) = create_cooperative_settle_signatures(
         [A, B],
@@ -387,7 +366,6 @@ def test_update_channel_event(
     )
 
     txn_hash = token_network.transact({'from': B}).cooperativeSettle(
-        channel_identifier,
         B, balance_B,
         A, balance_A,
         signature_B,

--- a/raiden_contracts/tests/test_channel_open.py
+++ b/raiden_contracts/tests/test_channel_open.py
@@ -44,53 +44,38 @@ def test_open_channel_call(token_network, get_accounts):
         token_network.transact().openChannel(A, B, SETTLE_TIMEOUT_MAX + 1)
 
 
-def test_open_channel_index(token_network, get_accounts):
-    (A, B, C, D) = get_accounts(4)
-    settle_timeout = SETTLE_TIMEOUT_MIN + 10
-
-    assert token_network.call().last_channel_index() == 0
-
-    for i in range(1, 10):
-        token_network.transact().openChannel(A, B, settle_timeout)
-        assert token_network.call().last_channel_index() == i
-
-
 def test_open_channel_state(token_network, get_accounts):
     (A, B) = get_accounts(2)
     settle_timeout = SETTLE_TIMEOUT_MIN + 10
 
-    (settle_block_number, state) = token_network.call().getChannelInfo(1)
-    assert settle_block_number == 0  # settle_block_number
-    assert state == CHANNEL_STATE_NONEXISTENT_OR_SETTLED  # state
+    (_, settle_block_number, state) = token_network.call().getChannelInfo(A, B)
+    assert settle_block_number == 0
+    assert state == CHANNEL_STATE_NONEXISTENT_OR_SETTLED
 
     token_network.transact().openChannel(A, B, settle_timeout)
 
-    (settle_block_number, state) = token_network.call().getChannelInfo(1)
-    assert settle_block_number == settle_timeout  # settle_block_number
-    assert state == CHANNEL_STATE_OPEN  # state
+    (_, settle_block_number, state) = token_network.call().getChannelInfo(A, B)
+    assert settle_block_number == settle_timeout
+    assert state == CHANNEL_STATE_OPEN
 
     (
         A_deposit,
-        A_is_initialized,
         A_is_the_closer,
         A_balance_hash,
         A_nonce
-    ) = token_network.call().getChannelParticipantInfo(1, A, B)
+    ) = token_network.call().getChannelParticipantInfo(A, B)
     assert A_deposit == 0
-    assert A_is_initialized is True
     assert A_is_the_closer is False
     assert A_balance_hash == fake_bytes(32)
     assert A_nonce == 0
 
     (
         B_deposit,
-        B_is_initialized,
         B_is_the_closer,
         B_balance_hash,
         B_nonce
-    ) = token_network.call().getChannelParticipantInfo(1, B, A)
+    ) = token_network.call().getChannelParticipantInfo(B, A)
     assert B_deposit == 0
-    assert B_is_initialized is True
     assert B_is_the_closer is False
     assert B_balance_hash == fake_bytes(32)
     assert B_nonce == 0
@@ -101,6 +86,11 @@ def test_open_channel_event(get_accounts, token_network, event_handler):
     (A, B) = get_accounts(2)
 
     txn_hash = token_network.transact().openChannel(A, B, SETTLE_TIMEOUT_MIN)
+    channel_identifier = token_network.call().getChannelIdentifier(A, B)
 
-    ev_handler.add(txn_hash, E_CHANNEL_OPENED, check_channel_opened(1, A, B, SETTLE_TIMEOUT_MIN))
+    ev_handler.add(
+        txn_hash,
+        E_CHANNEL_OPENED,
+        check_channel_opened(channel_identifier, A, B, SETTLE_TIMEOUT_MIN)
+    )
     ev_handler.check()

--- a/raiden_contracts/tests/test_channel_open.py
+++ b/raiden_contracts/tests/test_channel_open.py
@@ -44,6 +44,16 @@ def test_open_channel_call(token_network, get_accounts):
         token_network.transact().openChannel(A, B, SETTLE_TIMEOUT_MAX + 1)
 
 
+def test_max_1_channel(token_network, get_accounts, create_channel):
+    (A, B) = get_accounts(2)
+    create_channel(A, B)
+
+    with pytest.raises(tester.TransactionFailed):
+        token_network.transact().openChannel(A, B, SETTLE_TIMEOUT_MIN)
+    with pytest.raises(tester.TransactionFailed):
+        token_network.transact().openChannel(B, A, SETTLE_TIMEOUT_MIN)
+
+
 def test_open_channel_state(token_network, get_accounts):
     (A, B) = get_accounts(2)
     settle_timeout = SETTLE_TIMEOUT_MIN + 10

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -5,7 +5,7 @@ from raiden_contracts.utils.config import (
 )
 from raiden_contracts.utils.events import check_channel_settled
 from .utils import get_settlement_amounts
-from .fixtures.config import fake_hex
+from .fixtures.config import fake_hex, fake_bytes
 
 
 def test_settle_no_bp_success(
@@ -21,7 +21,7 @@ def test_settle_no_bp_success(
     settle_timeout = SETTLE_TIMEOUT_MIN
     locksroot = fake_hex(32, '00')
     additional_hash = fake_hex(32, '00')
-    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
+    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)[0]
 
     # Create balance proofs
     balance_proof_B = create_balance_proof(
@@ -31,7 +31,7 @@ def test_settle_no_bp_success(
     )
 
     # Close channel and update balance proofs
-    token_network.transact({'from': A}).closeChannel(*balance_proof_B)
+    token_network.transact({'from': A}).closeChannel(B, *balance_proof_B)
 
     # Do not call updateNonClosingBalanceProof
 
@@ -40,7 +40,6 @@ def test_settle_no_bp_success(
 
     # Settling the channel should work with no balance proofs
     token_network.transact({'from': A}).settleChannel(
-        channel_identifier,
         A, 0, 0, locksroot,
         B, 0, 0, locksroot
     )
@@ -65,8 +64,8 @@ def test_settle_channel_state(
     locksroot2 = fake_hex(32, '04')
 
     # Create channel and deposit
-    channel_identifier = create_channel(A, B, settle_timeout)
-    channel_deposit(channel_identifier, A, deposit_A)
+    channel_identifier = create_channel(A, B, settle_timeout)[0]
+    channel_deposit(A, deposit_A, B)
 
     # Create balance proofs
     balance_proof_A = create_balance_proof(
@@ -79,11 +78,16 @@ def test_settle_channel_state(
         B, 5, 1, 3,
         locksroot2, additional_hash
     )
-    balance_proof_update_signature_B = create_balance_proof_update_signature(B, *balance_proof_A)
+    balance_proof_update_signature_B = create_balance_proof_update_signature(
+        B,
+        channel_identifier,
+        *balance_proof_A
+    )
 
     # Close channel and update balance proofs
-    token_network.transact({'from': A}).closeChannel(*balance_proof_B)
+    token_network.transact({'from': A}).closeChannel(B, *balance_proof_B)
     token_network.transact({'from': B}).updateNonClosingBalanceProof(
+        A, B,
         *balance_proof_A,
         balance_proof_update_signature_B
     )
@@ -96,45 +100,44 @@ def test_settle_channel_state(
     pre_balance_contract = custom_token.call().balanceOf(token_network.address)
 
     token_network.transact({'from': A}).settleChannel(
-        channel_identifier,
         A, 10, 2, locksroot1,
         B, 5, 1, locksroot2
     )
 
     # Make sure channel data has been removed
-    (settle_block_number, state) = token_network.call().getChannelInfo(1)
+    (_, settle_block_number, state) = token_network.call().getChannelInfo(A, B)
     assert settle_block_number == 0  # settle_block_number
     assert state == CHANNEL_STATE_NONEXISTENT_OR_SETTLED  # state
 
     # Make sure participant data has been removed
     (
         A_deposit,
-        A_is_initialized,
         A_is_the_closer,
-        A_locksroot,
-        A_locked_amount
-    ) = token_network.call().getChannelParticipantInfo(1, A, B)
+        A_balance_hash,
+        A_nonce
+    ) = token_network.call().getChannelParticipantInfo(A, B)
     assert A_deposit == 0
-    assert A_is_initialized == 0
     assert A_is_the_closer == 0
+    assert A_balance_hash == fake_bytes(32)
+    assert A_nonce == 0
 
     # Make sure balance data has been updated
-    assert A_locksroot == bytearray.fromhex(locksroot1[2:])
+    A_locked_amount = token_network.call().getParticipantLockedAmount(A, B, locksroot1)
     assert A_locked_amount == 2
 
     (
         B_deposit,
-        B_is_initialized,
         B_is_the_closer,
-        B_locksroot,
-        B_locked_amount
-    ) = token_network.call().getChannelParticipantInfo(1, B, A)
+        B_balance_hash,
+        B_nonce
+    ) = token_network.call().getChannelParticipantInfo(B, A)
     assert B_deposit == 0
-    assert B_is_initialized == 0
     assert B_is_the_closer == 0
+    assert B_balance_hash == fake_bytes(32)
+    assert B_nonce == 0
 
     # Make sure balance data has been updated
-    assert B_locksroot == bytearray.fromhex(locksroot2[2:])
+    B_locked_amount = token_network.call().getParticipantLockedAmount(A, B, locksroot2)
     assert B_locked_amount == 1
 
     # Make sure the correct amount of tokens has been transferred
@@ -147,7 +150,7 @@ def test_settle_channel_state(
     assert balance_contract == pre_balance_contract - A_amount - B_amount
 
 
-def test_update_channel_event(
+def test_settle_channel_event(
         web3,
         get_accounts,
         token_network,
@@ -163,22 +166,26 @@ def test_update_channel_event(
     settle_timeout = SETTLE_TIMEOUT_MIN
     locksroot = fake_hex(32, '00')
 
-    channel_identifier = create_channel(A, B)
-    channel_deposit(channel_identifier, A, deposit_A)
+    channel_identifier = create_channel(A, B)[0]
+    channel_deposit(A, deposit_A, B)
 
     balance_proof_A = create_balance_proof(channel_identifier, A, 10, 0, 1, locksroot)
     balance_proof_B = create_balance_proof(channel_identifier, B, 5, 0, 3, locksroot)
-    balance_proof_update_signature_B = create_balance_proof_update_signature(B, *balance_proof_A)
+    balance_proof_update_signature_B = create_balance_proof_update_signature(
+        B,
+        channel_identifier,
+        *balance_proof_A
+    )
 
-    token_network.transact({'from': A}).closeChannel(*balance_proof_B)
+    token_network.transact({'from': A}).closeChannel(B, *balance_proof_B)
     token_network.transact({'from': B}).updateNonClosingBalanceProof(
+        A, B,
         *balance_proof_A,
         balance_proof_update_signature_B
     )
 
     web3.testing.mine(settle_timeout)
     txn_hash = token_network.transact({'from': A}).settleChannel(
-        channel_identifier,
         A, 10, 0, locksroot,
         B, 5, 0, locksroot
     )

--- a/raiden_contracts/tests/test_recover_from_signature.py
+++ b/raiden_contracts/tests/test_recover_from_signature.py
@@ -23,24 +23,26 @@ def test_verify(
         create_balance_proof
 ):
     (A, B) = get_accounts(2)
-    channel_identifier = create_channel(A, B)
+    channel_identifier = create_channel(A, B)[0]
 
     balance_proof_A = create_balance_proof(channel_identifier, A, 2, 0, 3)
-    signature = balance_proof_A[4]
+    signature = balance_proof_A[3]
     balance_proof_hash = hash_balance_proof(
         token_network.address,
         int(web3.version.network),
-        *balance_proof_A[:4]
+        channel_identifier,
+        *balance_proof_A[:3]
     )
     address = signature_test_contract.call().verify(balance_proof_hash, signature)
     assert address == A
 
     balance_proof_B = create_balance_proof(channel_identifier, B, 0, 0, 0)
-    signature = balance_proof_B[4]
+    signature = balance_proof_B[3]
     balance_proof_hash = hash_balance_proof(
         token_network.address,
         int(web3.version.network),
-        *balance_proof_B[:4]
+        channel_identifier,
+        *balance_proof_B[:3]
     )
     address = signature_test_contract.call().verify(balance_proof_hash, signature)
     assert address == B
@@ -69,16 +71,17 @@ def test_ecrecover_output(
         create_balance_proof
 ):
     (A, B) = get_accounts(2)
-    channel_identifier = create_channel(A, B)
+    channel_identifier = create_channel(A, B)[0]
     balance_proof_A = create_balance_proof(channel_identifier, A, 2, 0, 3)
-    signature = balance_proof_A[4]
+    signature = balance_proof_A[3]
     r = signature[:32]
     s = signature[32:64]
     v = signature[64:]
     balance_proof_hash = hash_balance_proof(
         token_network.address,
         int(web3.version.network),
-        *balance_proof_A[:4]
+        channel_identifier,
+        *balance_proof_A[:3]
     )
 
     address = signature_test_contract.call().verifyEcrecoverOutput(

--- a/raiden_contracts/utils/sign.py
+++ b/raiden_contracts/utils/sign.py
@@ -21,7 +21,7 @@ def hash_balance_proof(
         'bytes32',
         'uint256',
         'bytes32',
-        'uint256',
+        'bytes32',
         'address',
         'uint256'
     ], [
@@ -47,7 +47,7 @@ def hash_balance_proof_update_message(
         'bytes32',
         'uint256',
         'bytes32',
-        'uint256',
+        'bytes32',
         'address',
         'uint256',
         'bytes'
@@ -76,7 +76,7 @@ def hash_cooperative_settle_message(
         'uint256',
         'address',
         'uint256',
-        'uint256',
+        'bytes32',
         'address',
         'uint256'
     ], [


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden-contracts/issues/40

Structural changes for limiting the number of channels between two nodes to 1.
All changes stem from changing the `channel_identifier` from a monotonically increasing `uint256` to the `keccak256` of the two channel participant addresses, ordered lexicographically.


Changes:

- `channel_identifier` from `uint256` to `bytes32` - for all events
- `openChannel` returns `bytes32`
- `setDeposit(address participant, uint256 total_deposit, address partner)`
- getters:
  - `function getChannelIdentifier(address participant, address partner)` returns `bytes32`
  - `function getChannelInfo(address participant1, address participant2)` returns `(channel_identifier, settle_block_number, state)`
  - `function getChannelParticipantInfo(address participant, address partner)` returns `(deposit, is_the_closer, balance_hash, nonce)`
  - `function getParticipantLockedAmount(address participant1, address participant2, bytes32 locksroot)` returns `locked_amount`
- other abi changes:
```
function closeChannel(
        address partner,
        bytes32 balance_hash,
        uint256 nonce,
        bytes32 additional_hash,
        bytes signature
    )
```
```
function updateNonClosingBalanceProof(
        address closing_participant,
        address non_closing_participant,
        bytes32 balance_hash,
        uint256 nonce,
        bytes32 additional_hash,
        bytes closing_signature,
        bytes non_closing_signature
    )
```
```
function settleChannel(
        address participant1,
        uint256 participant1_transferred_amount,
        uint256 participant1_locked_amount,
        bytes32 participant1_locksroot,
        address participant2,
        uint256 participant2_transferred_amount,
        uint256 participant2_locked_amount,
        bytes32 participant2_locksroot
    )
```
```
function unlock(
        address participant,
        address partner,
        bytes merkle_tree_leaves
    )
```
```
function cooperativeSettle(
        address participant1_address,
        uint256 participant1_balance,
        address participant2_address,
        uint256 participant2_balance,
        bytes participant1_signature,
        bytes participant2_signature
    )
```

## New gas costs 

```
TokenNetworksRegistry DEPLOYMENT 3836879
TokenNetworksRegistry.createERC20TokenNetwork 2547850
SecretRegistry.registerSecret 45414
TokenNetwork.openChannel 67891
TokenNetwork.setDeposit 54760
TokenNetwork.closeChannel 109590
TokenNetwork.updateNonClosingBalanceProof 91011
TokenNetwork.settleChannel 78445
TokenNetwork.unlock 1 locks 40209
TokenNetwork.unlock 6 locks 74128
```