### PR TITLE
Use 'bin' as the source of a contracts bytecode

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -147,7 +147,7 @@ def instantiate_contract(web3, contracts_compiled_data, contract_name, contract_
 
     contract = web3.eth.contract(
         abi=contract_interface['abi'],
-        bytecode=contract_interface['bytecode'],
+        bytecode=contract_interface['bin'],
         address=contract_address
     )
 
@@ -167,7 +167,7 @@ def deploy_contract(
     # Instantiate and deploy contract
     contract = web3.eth.contract(
         abi=contract_interface['abi'],
-        bytecode=contract_interface['bytecode']
+        bytecode=contract_interface['bin']
     )
 
     # Get transaction hash from deployed contract


### PR DESCRIPTION
Hello,

While trying to run contract deployment i came across the fact that `contracts.json` will contain `bin` instead of `bytecode`. Which matches the requested `output_values` here: https://github.com/raiden-network/raiden-contracts/blob/master/raiden_contracts/contract_manager.py#L67

My solc version is as follows:
```
solc, the solidity compiler commandline interface
Version: 0.4.23+commit.124ca40d.Linux.g++
```