### PR TITLE
Move test fixtures from libs to contracts

### DIFF
--- a/raiden_contracts/tests/conftest.py
+++ b/raiden_contracts/tests/conftest.py
@@ -1,4 +1,3 @@
-from raiden_libs.test.fixtures.contracts import *  # flake8: noqa
 from raiden_libs.test.fixtures.web3 import *  # flake8: noqa
 from raiden_libs.test.fixtures.address import *  # flake8: noqa
 

--- a/raiden_contracts/tests/fixtures/__init__.py
+++ b/raiden_contracts/tests/fixtures/__init__.py
@@ -7,4 +7,5 @@ from .token_network_registry import *
 from .token_network import *
 from .channel import *
 from .test_contracts import *
+from .contracts import *
 from .contract_manager import *

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -220,11 +220,11 @@ def create_settled_channel(
 
 
 @pytest.fixture()
-def reveal_secrets(web3, secret_registry):
+def reveal_secrets(web3, secret_registry_contract):
     def get(tx_from, transfers):
         for (_, _, secrethash, secret) in transfers:
-            secret_registry.transact({'from': tx_from}).registerSecret(secret)
-            assert secret_registry.call().getSecretRevealBlockHeight(secrethash) == web3.eth.blockNumber
+            secret_registry_contract.transact({'from': tx_from}).registerSecret(secret)
+            assert secret_registry_contract.call().getSecretRevealBlockHeight(secrethash) == web3.eth.blockNumber
     return get
 
 

--- a/raiden_contracts/tests/fixtures/contracts.py
+++ b/raiden_contracts/tests/fixtures/contracts.py
@@ -1,0 +1,97 @@
+import pytest
+import logging
+from web3.utils.events import get_event_data
+from eth_utils import is_address
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def contract_deployer_address(faucet_address) -> str:
+    """Reimplement this - fixture should return an address of the account
+    that has enough eth to deploy the contracts."""
+    raise NotImplementedError(
+        'Address of a deployer account must be overriden.'
+    )
+
+
+@pytest.fixture
+def deploy_tester_contract(
+        web3,
+        contracts_manager,
+        deploy_contract,
+        contract_deployer_address,
+        wait_for_transaction,
+        get_random_address
+):
+    """Returns a function that can be used to deploy a named contract,
+    using conract manager to compile the bytecode and get the ABI"""
+    def f(contract_name, libs=None, args=list()):
+        json_contract = contracts_manager.compile_contract(contract_name, libs)
+        contract = deploy_contract(
+            web3,
+            contract_deployer_address,
+            json_contract['abi'],
+            json_contract['bin'],
+            args
+        )
+        return contract
+    return f
+
+
+@pytest.fixture
+def deploy_tester_contract_txhash(
+        web3,
+        contracts_manager,
+        deploy_contract_txhash,
+        contract_deployer_address,
+        wait_for_transaction,
+        get_random_address
+):
+    """Returns a function that can be used to deploy a named contract,
+    but returning txhash only"""
+    def f(contract_name, libs=None, args=list()):
+        json_contract = contracts_manager.compile_contract(contract_name, libs)
+        txhash = deploy_contract_txhash(
+            web3,
+            contract_deployer_address,
+            json_contract['abi'],
+            json_contract['bin'],
+            args
+        )
+        return txhash
+    return f
+
+
+@pytest.fixture
+def utils_contract(deploy_tester_contract):
+    """Deployed Utils contract"""
+    return deploy_tester_contract('Utils')
+
+
+@pytest.fixture
+def standard_token_network_contract(
+        web3,
+        contracts_manager,
+        wait_for_transaction,
+        token_network_registry_contract,
+        standard_token_contract,
+        contract_deployer_address
+):
+    """Return instance of a deployed TokenNetwork for HumanStandardToken."""
+    txid = token_network_registry_contract.functions.createERC20TokenNetwork(
+        standard_token_contract.address
+    ).transact({'from': contract_deployer_address})
+    tx_receipt = wait_for_transaction(txid)
+    assert len(tx_receipt['logs']) == 1
+    event_abi = contracts_manager.get_event_abi(
+        'TokenNetworksRegistry',
+        'TokenNetworkCreated'
+    )
+    decoded_event = get_event_data(event_abi, tx_receipt['logs'][0])
+    assert decoded_event is not None
+    assert is_address(decoded_event['args']['token_address'])
+    assert is_address(decoded_event['args']['token_network_address'])
+    token_network_address = decoded_event['args']['token_network_address']
+    token_network_abi = contracts_manager.get_contract_abi('TokenNetwork')
+    return web3.eth.contract(abi=token_network_abi, address=token_network_address)

--- a/raiden_contracts/tests/fixtures/secret_registry.py
+++ b/raiden_contracts/tests/fixtures/secret_registry.py
@@ -1,6 +1,7 @@
 import pytest
 
 
-@pytest.fixture()
-def secret_registry(secret_registry_contract):
-    return secret_registry_contract
+@pytest.fixture
+def secret_registry_contract(deploy_tester_contract):
+    """Deployed SecretRegistry contract"""
+    return deploy_tester_contract('SecretRegistry')

--- a/raiden_contracts/tests/fixtures/test_contracts.py
+++ b/raiden_contracts/tests/fixtures/test_contracts.py
@@ -13,9 +13,9 @@ def get_token_network_test(deploy_tester_contract):
 
 
 @pytest.fixture()
-def token_network_test(web3, get_token_network_test, custom_token, secret_registry):
+def token_network_test(web3, get_token_network_test, custom_token, secret_registry_contract):
     return get_token_network_test([
         custom_token.address,
-        secret_registry.address,
+        secret_registry_contract.address,
         int(web3.version.network)
     ])

--- a/raiden_contracts/tests/fixtures/token.py
+++ b/raiden_contracts/tests/fixtures/token.py
@@ -3,20 +3,42 @@ from raiden_contracts.utils.config import C_CUSTOM_TOKEN
 from .utils import *  # flake8: noqa
 
 token_args = [
-    (10 ** 26, 18, 'CustomToken', 'TKN'),
-    # (10 ** 26, 0, 'CustomToken', 'TKN')
+    (10 ** 26, 18, 'CustomToken', 'TKN')
 ]
 
 
 @pytest.fixture(params=token_args)
-def token_params(request):
+def custom_token_params(request):
     return request.param
 
 
 @pytest.fixture()
-def custom_token(deploy_tester_contract, token_params):
+def custom_token(deploy_tester_contract, custom_token_params):
+    """Deploy CustomToken contract"""
     return deploy_tester_contract(
         C_CUSTOM_TOKEN,
         [],
-        token_params
+        custom_token_params
     )
+
+
+@pytest.fixture
+def deploy_token_contract(deploy_tester_contract):
+    """Returns a function that deploys a generic HumanStandardToken contract"""
+    def f(initial_amount: int, decimals: int, token_name: str, token_symbol: str):
+        assert initial_amount > 0
+        assert decimals > 0
+        return deploy_tester_contract(
+            'HumanStandardToken',
+            [],
+            [initial_amount, decimals, token_name, token_symbol]
+        )
+
+    return f
+
+
+
+@pytest.fixture
+def standard_token_contract(deploy_token_contract):
+    """Deployed HumanStandardToken contract"""
+    return deploy_token_contract(1000000, 10, 'TT', 'TTK')

--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -14,6 +14,51 @@ def get_token_network_registry(deploy_tester_contract):
     return get
 
 
-@pytest.fixture()
-def token_network_registry(token_network_registry_contract):
-    return token_network_registry_contract
+@pytest.fixture
+def token_network_registry_contract(deploy_tester_contract, secret_registry_contract, web3):
+    """Deployed TokenNetworksRegistry contract"""
+    return deploy_tester_contract(
+        'TokenNetworksRegistry',
+        [],
+        [secret_registry_contract.address, int(web3.version.network)]
+    )
+
+
+@pytest.fixture
+def token_network_registry_address(token_network_registry_contract):
+    """Address of TokenNetworksRegistry contract"""
+    return token_network_registry_contract.address
+
+
+@pytest.fixture
+def add_and_register_token(
+        web3,
+        wait_for_transaction,
+        token_network_registry_contract,
+        deploy_token_contract,
+        contract_deployer_address,
+        contracts_manager
+):
+    """Deploy a token and register it in TokenNetworksRegistry"""
+    def f(initial_amount: int, decimals: int, token_name: str, token_symbol: str):
+        token_contract = deploy_token_contract(initial_amount, decimals, token_name, token_symbol)
+        txid = token_network_registry_contract.functions.createERC20TokenNetwork(
+            token_contract.address
+        ).transact({'from': contract_deployer_address})
+        tx_receipt = wait_for_transaction(txid)
+        assert len(tx_receipt['logs']) == 1
+        event_abi = contracts_manager.get_event_abi(
+            'TokenNetworksRegistry',
+            'TokenNetworkCreated'
+        )
+        decoded_event = get_event_data(event_abi, tx_receipt['logs'][0])
+        assert decoded_event is not None
+        assert is_address(decoded_event['args']['token_address'])
+        assert is_address(decoded_event['args']['token_network_address'])
+        token_network_address = decoded_event['args']['token_network_address']
+        token_network_abi = contracts_manager.get_contract_abi('TokenNetwork')
+        return web3.eth.contract(abi=token_network_abi, address=token_network_address)
+
+    return f
+
+

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -43,17 +43,19 @@ def test_token_network_deployment(
 def test_token_network_create(
         print_gas,
         custom_token,
-        secret_registry,
-        token_network_registry
+        secret_registry_contract,
+        token_network_registry_contract
 ):
-    txn_hash = token_network_registry.transact().createERC20TokenNetwork(custom_token.address)
+    txn_hash = token_network_registry_contract.transact().createERC20TokenNetwork(
+        custom_token.address
+    )
 
     print_gas(txn_hash, C_TOKEN_NETWORK_REGISTRY + ' createERC20TokenNetwork')
 
 
-def test_secret_registry(secret_registry, print_gas):
+def test_secret_registry(secret_registry_contract, print_gas):
     secret = b'secretsecretsecretsecretsecretse'
-    txn_hash = secret_registry.transact().registerSecret(secret)
+    txn_hash = secret_registry_contract.transact().registerSecret(secret)
     print_gas(txn_hash, C_SECRET_REGISTRY + '.registerSecret')
 
 
@@ -62,7 +64,7 @@ def test_channel_cycle(
         token_network,
         create_channel,
         channel_deposit,
-        secret_registry,
+        secret_registry_contract,
         get_accounts,
         print_gas,
         create_balance_proof,
@@ -109,9 +111,9 @@ def test_channel_cycle(
     )
 
     for lock in pending_transfers_tree1.unlockable:
-        txn_hash = secret_registry.transact({'from': A}).registerSecret(lock[3])
+        txn_hash = secret_registry_contract.transact({'from': A}).registerSecret(lock[3])
     for lock in pending_transfers_tree2.unlockable:
-        txn_hash = secret_registry.transact({'from': A}).registerSecret(lock[3])
+        txn_hash = secret_registry_contract.transact({'from': A}).registerSecret(lock[3])
 
     print_gas(txn_hash, C_SECRET_REGISTRY + '.registerSecret')
 

--- a/raiden_contracts/tests/test_secret_registry.py
+++ b/raiden_contracts/tests/test_secret_registry.py
@@ -6,66 +6,68 @@ from raiden_contracts.utils.events import check_secret_revealed
 from .fixtures.config import fake_bytes, raiden_contracts_version
 
 
-def test_version(secret_registry):
-    assert secret_registry.call().contract_version()[:2] == raiden_contracts_version[:2]
+def test_version(secret_registry_contract):
+    assert secret_registry_contract.call().contract_version()[:2] == raiden_contracts_version[:2]
 
 
-def test_register_secret_call(secret_registry, event_handler):
+def test_register_secret_call(secret_registry_contract, event_handler):
     with pytest.raises(ValidationError):
-        secret_registry.transact().registerSecret()
+        secret_registry_contract.transact().registerSecret()
     with pytest.raises(ValidationError):
-        secret_registry.transact().registerSecret(3)
+        secret_registry_contract.transact().registerSecret(3)
     with pytest.raises(ValidationError):
-        secret_registry.transact().registerSecret(0)
+        secret_registry_contract.transact().registerSecret(0)
     with pytest.raises(ValidationError):
-        secret_registry.transact().registerSecret('')
+        secret_registry_contract.transact().registerSecret('')
     with pytest.raises(ValidationError):
-        secret_registry.transact().registerSecret(fake_bytes(33))
+        secret_registry_contract.transact().registerSecret(fake_bytes(33))
 
-    assert secret_registry.call().registerSecret(fake_bytes(32)) is False
-    assert secret_registry.call().registerSecret(fake_bytes(10, '02')) is True
-    assert secret_registry.call().registerSecret(fake_bytes(32, '02')) is True
+    assert secret_registry_contract.call().registerSecret(fake_bytes(32)) is False
+    assert secret_registry_contract.call().registerSecret(fake_bytes(10, '02')) is True
+    assert secret_registry_contract.call().registerSecret(fake_bytes(32, '02')) is True
 
 
-def test_register_secret_return_value(secret_registry, get_accounts):
+def test_register_secret_return_value(secret_registry_contract, get_accounts):
     (A, B) = get_accounts(2)
     secret = b'secretsecretsecretsecretsecretse'
 
     # We use call here to make sure we would get the correct return value
     # even though this does not change the state
-    assert secret_registry.call({'from': A}).registerSecret(secret) is True
+    assert secret_registry_contract.call({'from': A}).registerSecret(secret) is True
 
-    secret_registry.transact({'from': A}).registerSecret(secret)
+    secret_registry_contract.transact({'from': A}).registerSecret(secret)
 
     # We use call here to get the return value
-    assert secret_registry.call({'from': A}).registerSecret(secret) is False
-    assert secret_registry.call({'from': B}).registerSecret(secret) is False
+    assert secret_registry_contract.call({'from': A}).registerSecret(secret) is False
+    assert secret_registry_contract.call({'from': B}).registerSecret(secret) is False
 
 
-def test_register_secret(secret_registry, get_accounts, get_block):
+def test_register_secret(secret_registry_contract, get_accounts, get_block):
     (A, B) = get_accounts(2)
     secret = b'secretsecretsecretsecretsecretse'
     secret2 = b'secretsecretsecretsecretsecretss'
     secrethash = Web3.sha3(secret)
 
-    assert secret_registry.call().secrethash_to_block(secrethash) == 0
-    assert secret_registry.call().getSecretRevealBlockHeight(secrethash) == 0
+    assert secret_registry_contract.call().secrethash_to_block(secrethash) == 0
+    assert secret_registry_contract.call().getSecretRevealBlockHeight(secrethash) == 0
 
-    txn_hash = secret_registry.transact({'from': A}).registerSecret(secret)
+    txn_hash = secret_registry_contract.transact({'from': A}).registerSecret(secret)
 
-    assert secret_registry.call().secrethash_to_block(secrethash) == get_block(txn_hash)
-    assert secret_registry.call().getSecretRevealBlockHeight(secrethash) == get_block(txn_hash)
+    assert secret_registry_contract.call().secrethash_to_block(secrethash) == get_block(txn_hash)
+    assert secret_registry_contract.call().getSecretRevealBlockHeight(
+        secrethash
+    ) == get_block(txn_hash)
 
     # A should be able to register any number of secrets
-    secret_registry.transact({'from': A}).registerSecret(secret2)
+    secret_registry_contract.transact({'from': A}).registerSecret(secret2)
 
 
-def test_events(secret_registry, event_handler):
+def test_events(secret_registry_contract, event_handler):
     secret = b'secretsecretsecretsecretsecretse'
     secrethash = Web3.sha3(secret)
-    ev_handler = event_handler(secret_registry)
+    ev_handler = event_handler(secret_registry_contract)
 
-    txn_hash = secret_registry.transact().registerSecret(secret)
+    txn_hash = secret_registry_contract.transact().registerSecret(secret)
 
     ev_handler.add(txn_hash, E_SECRET_REVEALED, check_secret_revealed(secrethash))
     ev_handler.check()

--- a/raiden_contracts/tests/test_token_network.py
+++ b/raiden_contracts/tests/test_token_network.py
@@ -7,19 +7,25 @@ def test_version(token_network):
     assert token_network.call().contract_version()[:2] == raiden_contracts_version[:2]
 
 
-def test_constructor_call(web3, get_token_network, custom_token, secret_registry, get_accounts):
+def test_constructor_call(
+        web3,
+        get_token_network,
+        custom_token,
+        secret_registry_contract,
+        get_accounts
+):
     A = get_accounts(1)[0]
     chain_id = int(web3.version.network)
     with pytest.raises(TypeError):
         get_token_network([])
     with pytest.raises(TypeError):
-        get_token_network([3, secret_registry.address, chain_id])
+        get_token_network([3, secret_registry_contract.address, chain_id])
     with pytest.raises(TypeError):
-        get_token_network([0, secret_registry.address, chain_id])
+        get_token_network([0, secret_registry_contract.address, chain_id])
     with pytest.raises(TypeError):
-        get_token_network(['', secret_registry.address, chain_id])
+        get_token_network(['', secret_registry_contract.address, chain_id])
     with pytest.raises(TypeError):
-        get_token_network([fake_address, secret_registry.address, chain_id])
+        get_token_network([fake_address, secret_registry_contract.address, chain_id])
     with pytest.raises(TypeError):
         get_token_network([custom_token.address, 3, chain_id])
     with pytest.raises(TypeError):
@@ -29,16 +35,18 @@ def test_constructor_call(web3, get_token_network, custom_token, secret_registry
     with pytest.raises(TypeError):
         get_token_network([custom_token.address, fake_address, chain_id])
     with pytest.raises(TypeError):
-        get_token_network([custom_token.address, secret_registry.address, ''])
+        get_token_network([custom_token.address, secret_registry_contract.address, ''])
     with pytest.raises(TypeError):
-        get_token_network([custom_token.address, secret_registry.address, -3])
+        get_token_network([custom_token.address, secret_registry_contract.address, -3])
 
     with pytest.raises(TransactionFailed):
-        get_token_network([empty_address, secret_registry.address, chain_id])
+        get_token_network([empty_address, secret_registry_contract.address, chain_id])
     with pytest.raises(TransactionFailed):
-        get_token_network([A, secret_registry.address, chain_id])
+        get_token_network([A, secret_registry_contract.address, chain_id])
     with pytest.raises(TransactionFailed):
-        get_token_network([secret_registry.address, secret_registry.address, chain_id])
+        get_token_network(
+            [secret_registry_contract.address, secret_registry_contract.address, chain_id]
+        )
 
     with pytest.raises(TransactionFailed):
         get_token_network([custom_token.address, empty_address, chain_id])
@@ -46,22 +54,22 @@ def test_constructor_call(web3, get_token_network, custom_token, secret_registry
         get_token_network([custom_token.address, A, chain_id])
 
     with pytest.raises(TransactionFailed):
-        get_token_network([custom_token.address, secret_registry.address, 0])
+        get_token_network([custom_token.address, secret_registry_contract.address, 0])
 
-    get_token_network([custom_token.address, secret_registry.address, chain_id])
+    get_token_network([custom_token.address, secret_registry_contract.address, chain_id])
 
 
 def test_constructor_not_registered(
         custom_token,
-        secret_registry,
-        token_network_registry,
+        secret_registry_contract,
+        token_network_registry_contract,
         token_network_external
 ):
     token_network = token_network_external
     assert token_network.call().token() == custom_token.address
-    assert token_network.call().secret_registry() == secret_registry.address
-    assert token_network.call().chain_id() == token_network_registry.call().chain_id()
+    assert token_network.call().secret_registry() == secret_registry_contract.address
+    assert token_network.call().chain_id() == token_network_registry_contract.call().chain_id()
 
-    assert token_network_registry.call().token_to_token_networks(
+    assert token_network_registry_contract.call().token_to_token_networks(
         custom_token.address
     ) == empty_address

--- a/raiden_contracts/tests/test_token_network_registry.py
+++ b/raiden_contracts/tests/test_token_network_registry.py
@@ -10,11 +10,17 @@ from raiden_contracts.utils.events import check_token_network_created
 from web3.exceptions import ValidationError
 
 
-def test_version(token_network_registry):
-    assert token_network_registry.call().contract_version()[:2] == raiden_contracts_version[:2]
+def test_version(token_network_registry_contract):
+    assert (token_network_registry_contract.call().contract_version()[:2]
+            == raiden_contracts_version[:2])
 
 
-def test_constructor_call(web3, get_token_network_registry, secret_registry, get_accounts):
+def test_constructor_call(
+        web3,
+        get_token_network_registry,
+        secret_registry_contract,
+        get_accounts
+):
     A = get_accounts(1)[0]
     chain_id = int(web3.version.network)
     with pytest.raises(TypeError):
@@ -28,11 +34,11 @@ def test_constructor_call(web3, get_token_network_registry, secret_registry, get
     with pytest.raises(TypeError):
         get_token_network_registry([fake_address, chain_id])
     with pytest.raises(TypeError):
-        get_token_network_registry([secret_registry.address, ''])
+        get_token_network_registry([secret_registry_contract.address, ''])
     with pytest.raises(TypeError):
-        get_token_network_registry([secret_registry.address, '1'])
+        get_token_network_registry([secret_registry_contract.address, '1'])
     with pytest.raises(TypeError):
-        get_token_network_registry([secret_registry.address, -3])
+        get_token_network_registry([secret_registry_contract.address, -3])
 
     with pytest.raises(TransactionFailed):
         get_token_network_registry([empty_address, chain_id])
@@ -40,62 +46,71 @@ def test_constructor_call(web3, get_token_network_registry, secret_registry, get
         get_token_network_registry([A, chain_id])
 
     with pytest.raises(TransactionFailed):
-        get_token_network_registry([secret_registry.address, 0])
+        get_token_network_registry([secret_registry_contract.address, 0])
 
-    get_token_network_registry([secret_registry.address, chain_id])
+    get_token_network_registry([secret_registry_contract.address, chain_id])
 
 
-def test_constructor_call_state(web3, get_token_network_registry, secret_registry):
+def test_constructor_call_state(web3, get_token_network_registry, secret_registry_contract):
     chain_id = int(web3.version.network)
 
-    registry = get_token_network_registry([secret_registry.address, chain_id])
-    assert secret_registry.address == registry.call().secret_registry_address()
+    registry = get_token_network_registry([secret_registry_contract.address, chain_id])
+    assert secret_registry_contract.address == registry.call().secret_registry_address()
     assert chain_id == registry.call().chain_id()
 
 
-def test_create_erc20_token_network_call(token_network_registry, custom_token, get_accounts):
+def test_create_erc20_token_network_call(
+        token_network_registry_contract,
+        custom_token,
+        get_accounts
+):
     A = get_accounts(1)[0]
-    fake_token_contract = token_network_registry.address
+    fake_token_contract = token_network_registry_contract.address
     with pytest.raises(ValidationError):
-        token_network_registry.transact().createERC20TokenNetwork()
+        token_network_registry_contract.transact().createERC20TokenNetwork()
     with pytest.raises(ValidationError):
-        token_network_registry.transact().createERC20TokenNetwork(3)
+        token_network_registry_contract.transact().createERC20TokenNetwork(3)
     with pytest.raises(ValidationError):
-        token_network_registry.transact().createERC20TokenNetwork(0)
+        token_network_registry_contract.transact().createERC20TokenNetwork(0)
     with pytest.raises(ValidationError):
-        token_network_registry.transact().createERC20TokenNetwork('')
+        token_network_registry_contract.transact().createERC20TokenNetwork('')
     with pytest.raises(ValidationError):
-        token_network_registry.transact().createERC20TokenNetwork(fake_address)
+        token_network_registry_contract.transact().createERC20TokenNetwork(fake_address)
 
     with pytest.raises(TransactionFailed):
-        token_network_registry.transact().createERC20TokenNetwork(empty_address)
+        token_network_registry_contract.transact().createERC20TokenNetwork(empty_address)
     with pytest.raises(TransactionFailed):
-        token_network_registry.transact().createERC20TokenNetwork(A)
+        token_network_registry_contract.transact().createERC20TokenNetwork(A)
     with pytest.raises(TransactionFailed):
-        token_network_registry.transact().createERC20TokenNetwork(fake_token_contract)
+        token_network_registry_contract.transact().createERC20TokenNetwork(fake_token_contract)
 
-    token_network_registry.transact().createERC20TokenNetwork(custom_token.address)
+    token_network_registry_contract.transact().createERC20TokenNetwork(custom_token.address)
 
 
 def test_create_erc20_token_network(
         register_token_network,
-        token_network_registry,
+        token_network_registry_contract,
         custom_token,
         get_accounts
 ):
-    assert token_network_registry.call().token_to_token_networks(
+    assert token_network_registry_contract.call().token_to_token_networks(
         custom_token.address) == empty_address
 
     token_network = register_token_network(custom_token.address)
 
     assert token_network.call().token() == custom_token.address
-    secret_registry_address = token_network_registry.call().secret_registry_address()
+    secret_registry_address = token_network_registry_contract.call().secret_registry_address()
     assert token_network.call().secret_registry() == secret_registry_address
-    assert token_network.call().chain_id() == token_network_registry.call().chain_id()
+    assert token_network.call().chain_id() == token_network_registry_contract.call().chain_id()
 
 
-def test_events(register_token_network, token_network_registry, custom_token, event_handler):
-    ev_handler = event_handler(token_network_registry)
+def test_events(
+        register_token_network,
+        token_network_registry_contract,
+        custom_token,
+        event_handler
+):
+    ev_handler = event_handler(token_network_registry_contract)
 
     new_token_network = register_token_network(custom_token.address)
 


### PR DESCRIPTION
- moves contract fixtures from `raiden-libs` to `raiden-contracts`
- also fixes fixture names
- do not merge until other repos are ready for the change!