### PR TITLE
Fix contract compilation with `py-solc` >= 2.2.0

### DIFF
--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -64,7 +64,7 @@ class ContractManager:
         """Compile contract and return JSON containing abi and bytecode"""
         contract_json = compile_files(
             [self.get_contract_path(contract_name)[0]],
-            output_values=('abi', 'bin'),
+            output_values=('abi', 'bin', 'ast'),
             import_remappings=self.get_mappings(),
             optimize=False
         )
@@ -116,7 +116,7 @@ class ContractManager:
         try:
             res = compile_files(
                 files,
-                output_values=('abi', 'bin'),
+                output_values=('abi', 'bin', 'ast'),
                 import_remappings=map_dirs,
                 optimize=False
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ click
 rlp>=1.0.0
 coincurve>=7.1.0,<8.0
 web3>=4.0.0
-py-solc==2.1.0
+py-solc>=3.0.0


### PR DESCRIPTION
- adds `ast` output to compile options to make `py-solc` happy