### PR TITLE
Fix upcoming solc 0.5.0 breaking changes

### DIFF
--- a/raiden_contracts/contracts/EndpointRegistry.sol
+++ b/raiden_contracts/contracts/EndpointRegistry.sol
@@ -71,7 +71,7 @@ contract EndpointRegistry{
 
     function equals(string a, string b) internal pure returns (bool result)
     {
-        if (keccak256(a) == keccak256(b)) {
+        if (keccak256(abi.encodePacked(a)) == keccak256(abi.encodePacked(b))) {
             return true;
         }
 

--- a/raiden_contracts/contracts/MonitoringService.sol
+++ b/raiden_contracts/contracts/MonitoringService.sol
@@ -139,7 +139,10 @@ contract MonitoringService is Utils {
         );
         require(raiden_node_address == non_closing_participant);
 
-        bytes32 reward_identifier = keccak256(channel_identifier, token_network_address);
+        bytes32 reward_identifier = keccak256(abi.encodePacked(
+            channel_identifier,
+            token_network_address
+        ));
 
         // Get the Reward struct for the correct channel
         Reward storage reward = rewards[reward_identifier];
@@ -230,7 +233,10 @@ contract MonitoringService is Utils {
             closing_participant,
             non_closing_participant
         );
-        bytes32 reward_identifier = keccak256(channel_identifier, token_network_address);
+        bytes32 reward_identifier = keccak256(abi.encodePacked(
+            channel_identifier,
+            token_network_address
+        ));
 
         // Only allowed to claim, if channel is settled
         // Channel is settled if it's data has been deleted
@@ -286,13 +292,13 @@ contract MonitoringService is Utils {
         internal
         returns (address signature_address)
     {
-        bytes32 message_hash = keccak256(
+        bytes32 message_hash = keccak256(abi.encodePacked(
             channel_identifier,
             reward_amount,
             token_network_address,
             chain_id,
             nonce
-        );
+        ));
 
         signature_address = ECVerify.ecverify(message_hash, signature);
     }

--- a/raiden_contracts/contracts/SecretRegistry.sol
+++ b/raiden_contracts/contracts/SecretRegistry.sol
@@ -22,7 +22,7 @@ contract SecretRegistry {
     /// @param secret The secret used to lock the hash time lock.
     /// @return true if secret was registered, false if the secret was already registered.
     function registerSecret(bytes32 secret) public returns (bool) {
-        bytes32 secrethash = keccak256(secret);
+        bytes32 secrethash = keccak256(abi.encodePacked(secret));
         if (secret == 0x0 || secrethash_to_block[secrethash] > 0) {
             return false;
         }

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -721,9 +721,9 @@ contract TokenNetwork is Utils {
         // Lexicographic order of the channel addresses
         // This limits the number of channels that can be opened between two nodes to 1.
         if (participant < partner) {
-            return keccak256(participant, partner);
+            return keccak256(abi.encodePacked(participant, partner));
         } else {
-            return keccak256(partner, participant);
+            return keccak256(abi.encodePacked(partner, participant));
         }
     }
 
@@ -798,11 +798,11 @@ contract TokenNetwork is Utils {
         }
 
         // Make sure the hash of the provided state is the same as the stored balance_hash
-        return participant.balance_hash == keccak256(
+        return participant.balance_hash == keccak256(abi.encodePacked(
             transferred_amount,
             locked_amount,
             locksroot
-        );
+        ));
     }
 
     /// @dev Returns the channel specific data.
@@ -887,14 +887,14 @@ contract TokenNetwork is Utils {
         internal
         returns (address signature_address)
     {
-        bytes32 message_hash = keccak256(
+        bytes32 message_hash = keccak256(abi.encodePacked(
             balance_hash,
             nonce,
             additional_hash,
             channel_identifier,
             address(this),
             chain_id
-        );
+        ));
 
         signature_address = ECVerify.ecverify(message_hash, signature);
     }
@@ -911,7 +911,7 @@ contract TokenNetwork is Utils {
         internal
         returns (address signature_address)
     {
-        bytes32 message_hash = keccak256(
+        bytes32 message_hash = keccak256(abi.encodePacked(
             balance_hash,
             nonce,
             additional_hash,
@@ -919,7 +919,7 @@ contract TokenNetwork is Utils {
             address(this),
             chain_id,
             closing_signature
-        );
+        ));
 
         signature_address = ECVerify.ecverify(message_hash, non_closing_signature);
     }
@@ -936,7 +936,7 @@ contract TokenNetwork is Utils {
         internal
         returns (address signature_address)
     {
-        bytes32 message_hash = keccak256(
+        bytes32 message_hash = keccak256(abi.encodePacked(
             participant1,
             participant1_balance,
             participant2,
@@ -944,7 +944,7 @@ contract TokenNetwork is Utils {
             channel_identifier,
             address(this),
             chain_id
-        );
+        ));
 
         signature_address = ECVerify.ecverify(message_hash, signature);
     }
@@ -959,13 +959,13 @@ contract TokenNetwork is Utils {
         internal
         returns (address signature_address)
     {
-        bytes32 message_hash = keccak256(
+        bytes32 message_hash = keccak256(abi.encodePacked(
             participant,
             total_withdraw,
             channel_identifier,
             address(this),
             chain_id
-        );
+        ));
 
         signature_address = ECVerify.ecverify(message_hash, signature);
     }
@@ -1038,9 +1038,9 @@ contract TokenNetwork is Utils {
                 if (merkle_layer[i] == merkle_layer[i + 1]) {
                     lockhash = merkle_layer[i];
                 } else if (merkle_layer[i] < merkle_layer[i + 1]) {
-                    lockhash = keccak256(merkle_layer[i], merkle_layer[i + 1]);
+                    lockhash = keccak256(abi.encodePacked(merkle_layer[i], merkle_layer[i + 1]));
                 } else {
-                    lockhash = keccak256(merkle_layer[i + 1], merkle_layer[i]);
+                    lockhash = keccak256(abi.encodePacked(merkle_layer[i + 1], merkle_layer[i]));
                 }
                 merkle_layer[i / 2] = lockhash;
             }
@@ -1074,7 +1074,7 @@ contract TokenNetwork is Utils {
         }
 
         // Calculate the lockhash for computing the merkle root
-        lockhash = keccak256(expiration_block, locked_amount, secrethash);
+        lockhash = keccak256(abi.encodePacked(expiration_block, locked_amount, secrethash));
 
         // Check if the lock's secret was revealed in the SecretRegistry
         // The secret must have been revealed in the SecretRegistry contract before the lock's

--- a/raiden_contracts/contracts/test/HumanStandardToken.sol
+++ b/raiden_contracts/contracts/test/HumanStandardToken.sol
@@ -62,5 +62,5 @@ contract HumanStandardToken is StandardToken {
         return true;
     }
 
-    function () public { revert(); }
+    function () external { revert(); }
 }


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden-contracts/issues/86

- fallback functions must be `external` (https://github.com/ethereum/solidity/blob/develop/Changelog.md#0417-2017-09-21)
- `keccak256` can only be used with a single `bytes` argument; `abi.encodePacked` can be used to tightly pack arguments (https://github.com/ethereum/solidity/blob/develop/Changelog.md#0424-2018-05-16)