### PR TITLE
Raiden integration: update ChannelManager

### DIFF
--- a/raiden_contracts/cm_test/test_contract_manager.py
+++ b/raiden_contracts/cm_test/test_contract_manager.py
@@ -17,7 +17,7 @@ def contract_manager_meta(contracts_path):
 
     abi = manager.get_event_abi('TokenNetwork', 'ChannelClosed')
     assert isinstance(abi, dict)
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         manager.get_event_abi('TokenNetwork', 'NonExistant')
 
 

--- a/raiden_contracts/tests/fixtures/token.py
+++ b/raiden_contracts/tests/fixtures/token.py
@@ -39,6 +39,6 @@ def deploy_token_contract(deploy_tester_contract):
 
 
 @pytest.fixture
-def standard_token_contract(deploy_token_contract):
-    """Deployed HumanStandardToken contract"""
-    return deploy_token_contract(1000000, 10, 'TT', 'TTK')
+def standard_token_contract(custom_token):
+    """Deployed CustomToken contract"""
+    return custom_token

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,11 @@ class CompileContracts(Command):
         pass
 
     def run(self):
+        try:
+            from solc import compile_files  # noqa
+        except ModuleNotFoundError:
+            print('py-solc is not installed, skipping contracts compilation')
+            return
         from raiden_contracts.contract_manager import CONTRACT_MANAGER
         compiled = CONTRACT_MANAGER.precompile_contracts('raiden_contracts/contracts/', [])
         with open(COMPILED_CONTRACTS, 'w') as compiled_json:


### PR DESCRIPTION
- fixes exception that is being raised when CM is initialized with a  single directory as its constructor argument
- better filtering of files that will be compiled
- removes duplicate token fixture