### PR TITLE
Fix settlement calculations

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -91,12 +91,17 @@ contract TokenNetwork is Utils {
         uint256 settle_timeout
     );
 
-    event ChannelNewDeposit(bytes32 indexed channel_identifier, address indexed participant, uint256
-    total_deposit);
+    event ChannelNewDeposit(
+        bytes32 indexed channel_identifier,
+        address indexed participant,
+        uint256 total_deposit
+    );
 
     // withdrawn_amount is the total amount withdrawn by the participant from the channel
-    event ChannelWithdraw(bytes32 indexed channel_identifier, address indexed participant, uint256
-    total_withdraw);
+    event ChannelWithdraw(
+        bytes32 indexed channel_identifier,
+        address indexed participant, uint256 total_withdraw
+    );
 
     event ChannelClosed(bytes32 indexed channel_identifier, address indexed closing_participant);
 
@@ -107,11 +112,16 @@ contract TokenNetwork is Utils {
         uint256 returned_tokens
     );
 
-    event NonClosingBalanceProofUpdated(bytes32 indexed channel_identifier, address indexed
-    closing_participant);
+    event NonClosingBalanceProofUpdated(
+        bytes32 indexed channel_identifier,
+        address indexed closing_participant
+    );
 
-    event ChannelSettled(bytes32 indexed channel_identifier, uint256 participant1_amount, uint256
-    participant2_amount);
+    event ChannelSettled(
+        bytes32 indexed channel_identifier,
+        uint256 participant1_amount,
+        uint256 participant2_amount
+    );
 
     /*
      * Modifiers

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -597,8 +597,9 @@ contract TokenNetwork is Utils {
             participant2_amount = 0;
         }
 
-        require(participant1_amount <= total_available_deposit);
-        require(participant2_amount <= total_available_deposit);
+        // This should never happen:
+        assert(participant1_amount <= total_available_deposit);
+        assert(participant2_amount <= total_available_deposit);
         assert(total_available_deposit == (
             participant1_amount +
             participant2_amount +

--- a/raiden_contracts/tests/fixtures/channel_test_values.py
+++ b/raiden_contracts/tests/fixtures/channel_test_values.py
@@ -8,15 +8,51 @@ ChannelValues = namedtuple('ChannelValues', [
     'locked'
 ])
 
+
 channel_settle_test_values = [
+    # both balance proofs provided are valid
     (
-        ChannelValues(deposit=40, withdrawn=10, transferred=26, locked=6),
-        ChannelValues(deposit=35, withdrawn=5, transferred=24, locked=4),
-        True  # settleChannel transaction should pass
+        ChannelValues(deposit=40, withdrawn=10, transferred=20030, locked=6),
+        ChannelValues(deposit=35, withdrawn=5, transferred=20020, locked=4)
     ),
+    # participant1 does not provide a balance proof
     (
-        ChannelValues(deposit=10, withdrawn=10, transferred=26, locked=6),
-        ChannelValues(deposit=5, withdrawn=5, transferred=24, locked=4),
-        False  # settleChannel transaction should fail
+        ChannelValues(deposit=40, withdrawn=10, transferred=20030, locked=6),
+        ChannelValues(deposit=35, withdrawn=5, transferred=0, locked=0)
+    ),
+    # participant2 does not provide a balance proof
+    (
+        ChannelValues(deposit=40, withdrawn=10, transferred=0, locked=0),
+        ChannelValues(deposit=35, withdrawn=5, transferred=20020, locked=4)
+    ),
+    # neither participants provide balance proofs
+    (
+        ChannelValues(deposit=40, withdrawn=10, transferred=0, locked=0),
+        ChannelValues(deposit=35, withdrawn=5, transferred=0, locked=0)
+    ),
+    # both balance proofs provided are valid
+    (
+        ChannelValues(deposit=40, withdrawn=10, transferred=30, locked=6),
+        ChannelValues(deposit=35, withdrawn=5, transferred=20, locked=4)
+    ),
+    # participant1 does not provide a balance proof
+    (
+        ChannelValues(deposit=40, withdrawn=10, transferred=30, locked=6),
+        ChannelValues(deposit=35, withdrawn=5, transferred=0, locked=0)
+    ),
+    # participant2 does not provide a balance proof
+    (
+        ChannelValues(deposit=40, withdrawn=10, transferred=0, locked=0),
+        ChannelValues(deposit=35, withdrawn=5, transferred=20, locked=4)
+    ),
+    # all tokens have been withdrawn, locked amounts are 0
+    (
+        ChannelValues(deposit=10, withdrawn=10, transferred=30, locked=0),
+        ChannelValues(deposit=5, withdrawn=5, transferred=20, locked=0)
+    ),
+    # all tokens have been withdrawn, locked amounts are > 0
+    (
+        ChannelValues(deposit=10, withdrawn=10, transferred=30, locked=6),
+        ChannelValues(deposit=5, withdrawn=5, transferred=20, locked=4)
     )
 ]

--- a/raiden_contracts/tests/fixtures/channel_test_values.py
+++ b/raiden_contracts/tests/fixtures/channel_test_values.py
@@ -1,12 +1,21 @@
-from collections import namedtuple
+class ChannelValues():
+    def __init__(self, deposit=0, withdrawn=0, transferred=0, locked=0, locksroot=b''):
+        self.deposit = deposit
+        self.withdrawn = withdrawn
+        self.transferred = transferred
+        self.locked = locked
+        self.locksroot = locksroot
 
-
-ChannelValues = namedtuple('ChannelValues', [
-    'deposit',
-    'withdrawn',
-    'transferred',
-    'locked'
-])
+    def __repr__(self):
+        return (
+            'ChannelValues deposit:{} withdrawn:{} transferred:{} locked:{} locksroot:{}'
+        ).format(
+            self.deposit,
+            self.withdrawn,
+            self.transferred,
+            self.locked,
+            self.locksroot,
+        )
 
 
 channel_settle_test_values = [
@@ -15,12 +24,12 @@ channel_settle_test_values = [
         ChannelValues(deposit=40, withdrawn=10, transferred=20030, locked=6),
         ChannelValues(deposit=35, withdrawn=5, transferred=20020, locked=4)
     ),
-    # participant1 does not provide a balance proof
+    # participant1 does not provide a balance proof, locked amount ok
     (
-        ChannelValues(deposit=40, withdrawn=10, transferred=20030, locked=6),
+        ChannelValues(deposit=40, withdrawn=10, transferred=20030, locked=0),
         ChannelValues(deposit=35, withdrawn=5, transferred=0, locked=0)
     ),
-    # participant2 does not provide a balance proof
+    # participant2 does not provide a balance proof + bigger locked amount
     (
         ChannelValues(deposit=40, withdrawn=10, transferred=0, locked=0),
         ChannelValues(deposit=35, withdrawn=5, transferred=20020, locked=4)
@@ -30,12 +39,17 @@ channel_settle_test_values = [
         ChannelValues(deposit=40, withdrawn=10, transferred=0, locked=0),
         ChannelValues(deposit=35, withdrawn=5, transferred=0, locked=0)
     ),
+    # bigger locked amounts than what remains in the contract after settlement
+    (
+        ChannelValues(deposit=40, withdrawn=10, transferred=20030, locked=50000000),
+        ChannelValues(deposit=35, withdrawn=5, transferred=20020, locked=40000000)
+    ),
     # both balance proofs provided are valid
     (
         ChannelValues(deposit=40, withdrawn=10, transferred=30, locked=6),
         ChannelValues(deposit=35, withdrawn=5, transferred=20, locked=4)
     ),
-    # participant1 does not provide a balance proof
+    # participant1 does not provide a balance proof + locked amount too big
     (
         ChannelValues(deposit=40, withdrawn=10, transferred=30, locked=6),
         ChannelValues(deposit=35, withdrawn=5, transferred=0, locked=0)

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -65,7 +65,7 @@ def test_settle_channel_state(
         channel_test_values
 ):
     (A, B) = get_accounts(2)
-    (vals_A, vals_B, txn_successful) = channel_test_values
+    (vals_A, vals_B) = channel_test_values
     locksroot_A = fake_bytes(32, '02')
     locksroot_B = fake_bytes(32, '03')
     create_channel_and_deposit(A, B, vals_A.deposit, vals_B.deposit)
@@ -90,45 +90,33 @@ def test_settle_channel_state(
     pre_balance_B = custom_token.functions.balanceOf(B).call()
     pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
-    if txn_successful is True:
-        token_network.functions.settleChannel(
-            A,
-            vals_A.transferred,
-            vals_A.locked,
-            locksroot_A,
-            B,
-            vals_B.transferred,
-            vals_B.locked,
-            locksroot_B
-        ).transact({'from': A})
+    token_network.functions.settleChannel(
+        A,
+        vals_A.transferred,
+        vals_A.locked,
+        locksroot_A,
+        B,
+        vals_B.transferred,
+        vals_B.locked,
+        locksroot_B
+    ).transact({'from': A})
 
-        (A_amount, B_amount, locked_amount) = get_settlement_amounts(vals_A, vals_B)
+    # Calculate how much A and B should receive
+    (A_amount, B_amount, locked_amount) = get_settlement_amounts(vals_A, vals_B)
 
-        settle_state_tests(
-            A,
-            A_amount,
-            locksroot_A,
-            vals_A.locked,
-            B,
-            B_amount,
-            locksroot_B,
-            vals_B.locked,
-            pre_balance_A,
-            pre_balance_B,
-            pre_balance_contract
-        )
-    else:
-        with pytest.raises(TransactionFailed):
-            token_network.functions.settleChannel(
-                A,
-                vals_A.transferred,
-                vals_A.locked,
-                locksroot_A,
-                B,
-                vals_B.transferred,
-                vals_B.locked,
-                locksroot_B
-            ).transact({'from': A})
+    settle_state_tests(
+        A,
+        A_amount,
+        locksroot_A,
+        vals_A.locked,
+        B,
+        B_amount,
+        locksroot_B,
+        vals_B.locked,
+        pre_balance_A,
+        pre_balance_B,
+        pre_balance_contract
+    )
 
 
 def test_settle_channel_event(

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -1,5 +1,4 @@
 import pytest
-from eth_tester.exceptions import TransactionFailed
 from raiden_contracts.constants import (
     EVENT_CHANNEL_SETTLED,
     SETTLE_TIMEOUT_MIN,

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -5,7 +5,6 @@ from raiden_contracts.constants import (
 )
 from raiden_contracts.utils.events import check_channel_settled
 from raiden_contracts.tests.fixtures.channel_test_values import channel_settle_test_values
-from .utils import get_settlement_amounts
 from .fixtures.config import fake_hex, fake_bytes
 
 
@@ -65,8 +64,8 @@ def test_settle_channel_state(
 ):
     (A, B) = get_accounts(2)
     (vals_A, vals_B) = channel_test_values
-    locksroot_A = fake_bytes(32, '02')
-    locksroot_B = fake_bytes(32, '03')
+    vals_A.locksroot = fake_bytes(32, '02')
+    vals_B.locksroot = fake_bytes(32, '03')
     create_channel_and_deposit(A, B, vals_A.deposit, vals_B.deposit)
 
     withdraw_channel(A, vals_A.withdrawn, B)
@@ -76,11 +75,11 @@ def test_settle_channel_state(
         A,
         vals_A.transferred,
         vals_A.locked,
-        locksroot_A,
+        vals_A.locksroot,
         B,
         vals_B.transferred,
         vals_B.locked,
-        locksroot_B
+        vals_B.locksroot
     )
 
     web3.testing.mine(SETTLE_TIMEOUT_MIN)
@@ -93,25 +92,18 @@ def test_settle_channel_state(
         A,
         vals_A.transferred,
         vals_A.locked,
-        locksroot_A,
+        vals_A.locksroot,
         B,
         vals_B.transferred,
         vals_B.locked,
-        locksroot_B
+        vals_B.locksroot
     ).transact({'from': A})
-
-    # Calculate how much A and B should receive
-    (A_amount, B_amount, locked_amount) = get_settlement_amounts(vals_A, vals_B)
 
     settle_state_tests(
         A,
-        A_amount,
-        locksroot_A,
-        vals_A.locked,
+        vals_A,
         B,
-        B_amount,
-        locksroot_B,
-        vals_B.locked,
+        vals_B,
         pre_balance_A,
         pre_balance_B,
         pre_balance_contract

--- a/raiden_contracts/tests/utils.py
+++ b/raiden_contracts/tests/utils.py
@@ -21,6 +21,13 @@ PendingTransfersTree = namedtuple('PendingTransfersTree', [
     'locked_amount'
 ])
 
+SettlementValues = namedtuple('SettlementValues', [
+    'participant1_balance',
+    'participant2_balance',
+    'participant1_locked',
+    'participant2_locked',
+])
+
 
 def random_secret():
     secret = os.urandom(32)
@@ -129,10 +136,25 @@ def get_settlement_amounts(
     participant1_amount = min(participant1_amount, total_available_deposit)
     participant2_amount = total_available_deposit - participant1_amount
 
+    participant1_locked = min(participant1_amount, participant1.locked)
+    participant2_locked = min(participant2_amount, participant2.locked)
+
     participant1_amount = max(participant1_amount - participant1.locked, 0)
     participant2_amount = max(participant2_amount - participant2.locked, 0)
 
-    return (participant1_amount, participant2_amount, participant1.locked + participant2.locked)
+    assert total_available_deposit == (
+        participant1_amount +
+        participant2_amount +
+        participant1_locked +
+        participant2_locked
+    )
+
+    return SettlementValues(
+        participant1_balance=participant1_amount,
+        participant2_balance=participant2_amount,
+        participant1_locked=participant1_locked,
+        participant2_locked=participant2_locked,
+    )
 
 
 def get_unlocked_amount(secret_registry, merkle_tree_leaves):

--- a/raiden_contracts/tests/utils.py
+++ b/raiden_contracts/tests/utils.py
@@ -109,7 +109,9 @@ def get_settlement_amounts(
     """ Settlement algorithm
 
     Calculates the token amounts to be transferred to the channel participants when
-    a channel is settled
+    a channel is settled.
+
+    !!! Don't change this unless you really know what you are doing.
     """
     total_available_deposit = (
         participant1.deposit +
@@ -123,8 +125,8 @@ def get_settlement_amounts(
         participant1.withdrawn -
         participant1.transferred
     )
-    participant1_amount = min(participant1_amount, total_available_deposit)
     participant1_amount = max(participant1_amount, 0)
+    participant1_amount = min(participant1_amount, total_available_deposit)
     participant2_amount = total_available_deposit - participant1_amount
 
     participant1_amount = max(participant1_amount - participant1.locked, 0)


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden-contracts/issues/106

- fixes settlement calculations for cases in which no/old balance proofs are provided.
- initial tests that must be extended properly.

Notes:

`d1` = p1's deposit
`w1` = p1's withdrawn amount
`t1` = p1's transferred amount to p2
`t2` = p2's transferred amount to p1

```
p1_balance = d1 + t2 - w1 - t1
```

Problem cases:
```
t2 = [0, real_t2) -> p1 has provided no/old balance proof -> p1_balance = 0
t1 = [0, real_t1) -> p2 has provided no/old balance proof -> p1_balance = total_available_deposit
```