### PR TITLE
Fix settlement overflow on transferred amount

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -550,7 +550,7 @@ contract TokenNetwork is Utils {
         private
         returns (uint256, uint256, uint256, uint256)
     {
-        // Cases require attention:
+        // Cases that require attention:
         // case1. If participant1 does NOT provide a balance proof or provides an old balance proof.
         // participant2_transferred_amount can be [0, real_participant2_transferred_amount)
         // We need to punish participant1.
@@ -564,7 +564,7 @@ contract TokenNetwork is Utils {
         // we have the following check in settleChannel:
         // require(participant2_transferred_amount >= participant1_transferred_amount)
 
-        uint256 participant1_netted_transferred_amount;
+        uint256 participant1_net_transferred_amount;
         uint256 participant1_amount;
         uint256 participant2_amount;
         uint256 total_available_deposit;
@@ -579,18 +579,18 @@ contract TokenNetwork is Utils {
             participant2_state
         );
 
-        // Calculate the netted transferred amounts
+        // Calculate the net transferred amounts
         // We are sure this does not underflow
-        participant1_netted_transferred_amount = (
+        participant1_net_transferred_amount = (
             participant2_transferred_amount -
             participant1_transferred_amount
         );
 
         // case2. participant1_transferred_amount can be [0, real_participant1_transferred_amount)
-        // participant1_netted_transferred_amount is bigger than expected and can cause an overflow.
+        // participant1_net_transferred_amount is bigger than expected and can cause an overflow.
         // We just take the biggest amount that we can in this case.
         participant1_amount = failsafe_addition(
-            participant1_netted_transferred_amount,
+            participant1_net_transferred_amount,
             participant1_state.deposit
         );
 

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -22,6 +22,8 @@ contract TokenNetwork is Utils {
     // Chain ID as specified by EIP155 used in balance proof signatures to avoid replay attacks
     uint256 public chain_id;
 
+    uint256 constant public MAX_SAFE_UINT256 = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
+
     // channel_identifier => Channel, where the channel identifier is the keccak256 of the
     // addresses of the two participants
     mapping (bytes32 => Channel) public channels;
@@ -454,6 +456,8 @@ contract TokenNetwork is Utils {
     )
         public
     {
+        // Convention required in getSettleTransferAmounts
+        require(participant2_transferred_amount >= participant1_transferred_amount);
         bytes32 channel_identifier;
 
         channel_identifier = getChannelIdentifier(participant1, participant2);
@@ -544,6 +548,20 @@ contract TokenNetwork is Utils {
         private
         returns (uint256, uint256, uint256, uint256)
     {
+        // Cases require attention:
+        // case1. If participant1 does NOT provide a balance proof or provides an old balance proof.
+        // participant2_transferred_amount can be [0, real_participant2_transferred_amount)
+        // We need to punish participant1.
+        // case2. If participant2 does NOT provide a balance proof or provides an old balance proof.
+        // participant1_transferred_amount can be [0, real_participant1_transferred_amount)
+        // We need to punish participant2.
+        // case3. If neither participants provide a balance proof, we just subtract their
+        // withdrawn amounts from their deposits.
+
+        // case1 is solved by making sure we only have to handle case2 or case3:
+        require(participant2_transferred_amount >= participant1_transferred_amount);
+
+        uint256 participant1_netted_transferred_amount;
         uint256 participant1_amount;
         uint256 participant2_amount;
         uint256 total_available_deposit;
@@ -558,36 +576,28 @@ contract TokenNetwork is Utils {
             participant2_state
         );
 
-        participant1_amount = (
-            participant1_state.deposit +
+        // Calculate the netted transferred amounts
+        // We are sure this does not underflow
+        participant1_netted_transferred_amount = (
             participant2_transferred_amount -
-            participant1_state.withdrawn_amount -
             participant1_transferred_amount
         );
 
-        // There are 2 cases that require attention here:
-        // case1. If participant1 does NOT provide a balance proof or provides an old balance proof
-        // case2. If participant2 does NOT provide a balance proof or provides an old balance proof
-        // The issue is that we need to react differently in both cases. However, both cases have
-        // an end result of participant1_amount > total_available_deposit. Therefore:
+        // case2. participant1_transferred_amount can be [0, real_participant1_transferred_amount)
+        // participant1_netted_transferred_amount is bigger than expected and can cause an overflow.
+        // We just take the biggest amount that we can in this case.
+        participant1_amount = failsafe_addition(
+            participant1_netted_transferred_amount,
+            participant1_state.deposit
+        );
 
-        // case1: participant2_transferred_amount can be [0, real_participant2_transferred_amount)
-        // This can trigger an underflow -> participant1_amount > total_available_deposit
-        // We need to make participant1_amount = 0 in this case, otherwise it can be
-        // an attack vector. participant1 must lose all/some of its tokens if it does not
-        // provide a valid balance proof.
-        if (
-            (participant1_state.deposit + participant2_transferred_amount) <
-            (participant1_state.withdrawn_amount + participant1_transferred_amount)
-        ) {
-            participant1_amount = 0;
-        }
+        // Subtract already withdrawn amount
+        (participant1_amount, ) = failsafe_subtract(
+            participant1_amount,
+            participant1_state.withdrawn_amount
+        );
 
-        // case2: participant1_transferred_amount can be [0, real_participant1_transferred_amount)
-        // This means participant1_amount > total_available_deposit.
-        // We need to limit participant1_amount to total_available_deposit. It is fine if
-        // participant1 gets all the available tokens if participant2 has not provided a
-        // valid balance proof.
+        // case2. This means participant1_amount might be > total_available_deposit.
         participant1_amount = min(participant1_amount, total_available_deposit);
 
         // At this point `participant1_amount` is between [0, total_available_deposit],
@@ -595,21 +605,15 @@ contract TokenNetwork is Utils {
         participant2_amount = total_available_deposit - participant1_amount;
 
         // Handle old balance proofs with a high locked_amount
-        if (participant1_locked_amount <= participant1_amount) {
-            participant1_amount = participant1_amount - participant1_locked_amount;
-        }
-        else {
-            participant1_locked_amount = participant1_amount;
-            participant1_amount = 0;
-        }
+        (participant1_amount, participant1_locked_amount) = failsafe_subtract(
+            participant1_amount,
+            participant1_locked_amount
+        );
 
-        if (participant2_locked_amount <= participant2_amount) {
-            participant2_amount = participant2_amount - participant2_locked_amount;
-        }
-        else {
-            participant2_locked_amount = participant2_amount;
-            participant2_amount = 0;
-        }
+        (participant2_amount, participant2_locked_amount) = failsafe_subtract(
+            participant2_amount,
+            participant2_locked_amount
+        );
 
         // This should never happen:
         assert(participant1_amount <= total_available_deposit);
@@ -1159,5 +1163,35 @@ contract TokenNetwork is Utils {
     function max(uint256 a, uint256 b) pure internal returns (uint256)
     {
         return a > b ? a : b;
+    }
+
+    /// @dev Special subtraction function that does not fail when underflowing.
+    /// @param a Minuend
+    /// @param b Subtrahend
+    /// @return Minimum between the result of the subtraction and 0, the maximum subtrahend for which no underflow occurs.
+    function failsafe_subtract(uint256 a, uint256 b)
+        pure
+        internal
+        returns (uint256, uint256)
+    {
+        return a > b ? (a - b, b) : (0, a);
+    }
+
+    /// @dev Special addition function that does not fail when overflowing.
+    /// @param a Addend
+    /// @param b Addend
+    /// @return Maximum between the result of the addition or the maximum uint256 value.
+    function failsafe_addition(uint256 a, uint256 b)
+        pure
+        internal
+        returns (uint256)
+    {
+        uint256 sum = a + b;
+        if (sum >= a && sum >= b) {
+            return sum;
+        }
+        else {
+            return MAX_SAFE_UINT256;
+        }
     }
 }

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -434,6 +434,7 @@ contract TokenNetwork is Utils {
     /// @param participant1_locked_amount Amount of tokens owed by `participant1` to
     /// `participant2`, contained in locked transfers that will be retrieved by calling `unlock`
     /// after the channel is settled.
+    /// `participant1_locked_amount` MUST be <= `participant2_locked_amount`
     /// @param participant1_locksroot The latest known merkle root of the pending hash-time locks
     /// of `participant1`, used to validate the unlocked proofs.
     /// @param participant2 Other channel participant.
@@ -442,6 +443,7 @@ contract TokenNetwork is Utils {
     /// @param participant2_locked_amount Amount of tokens owed by `participant2` to
     /// `participant1`, contained in locked transfers that will be retrieved by calling `unlock`
     /// after the channel is settled.
+    /// `participant2_locked_amount` MUST be >= `participant1_locked_amount`
     /// @param participant2_locksroot The latest known merkle root of the pending hash-time locks
     /// of `participant2`, used to validate the unlocked proofs.
     function settleChannel(
@@ -559,7 +561,8 @@ contract TokenNetwork is Utils {
         // withdrawn amounts from their deposits.
 
         // case1 is solved by making sure we only have to handle case2 or case3:
-        require(participant2_transferred_amount >= participant1_transferred_amount);
+        // we have the following check in settleChannel:
+        // require(participant2_transferred_amount >= participant1_transferred_amount)
 
         uint256 participant1_netted_transferred_amount;
         uint256 participant1_amount;
@@ -1187,11 +1190,6 @@ contract TokenNetwork is Utils {
         returns (uint256)
     {
         uint256 sum = a + b;
-        if (sum >= a && sum >= b) {
-            return sum;
-        }
-        else {
-            return MAX_SAFE_UINT256;
-        }
+        return sum >= a ? sum : MAX_SAFE_UINT256;
     }
 }

--- a/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
+++ b/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
@@ -10,6 +10,10 @@ contract TokenNetworkInternalsTest is TokenNetwork {
 
     }
 
+    function get_max_safe_uint256() pure public returns (uint256) {
+        return uint256(0 - 1);
+    }
+
     function getMerkleRootAndUnlockedAmountPublic(bytes merkle_tree)
         view
         public

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -222,8 +222,16 @@ def create_settled_channel(
         )
 
         web3.testing.mine(settle_timeout)
-        participant1_values = ChannelBalanceHashData(transferred=transferred_amount1, locked=locked_amount1, locksroot=locksroot1)
-        participant2_values = ChannelBalanceHashData(transferred=transferred_amount2, locked=locked_amount2, locksroot=locksroot2)
+        participant1_values = ChannelBalanceHashData(
+            transferred=transferred_amount1,
+            locked=locked_amount1,
+            locksroot=locksroot1,
+        )
+        participant2_values = ChannelBalanceHashData(
+            transferred=transferred_amount2,
+            locked=locked_amount2,
+            locksroot=locksroot2,
+        )
 
         call_settle(token_network, participant1, participant1_values, participant2, participant2_values)
 

--- a/raiden_contracts/tests/fixtures/channel_test_values.py
+++ b/raiden_contracts/tests/fixtures/channel_test_values.py
@@ -1,3 +1,6 @@
+from raiden_contracts.tests.utils import MAX_UINT256
+
+
 class ChannelValues():
     def __init__(self, deposit=0, withdrawn=0, transferred=0, locked=0, locksroot=b''):
         self.deposit = deposit
@@ -68,5 +71,30 @@ channel_settle_test_values = [
     (
         ChannelValues(deposit=10, withdrawn=10, transferred=30, locked=6),
         ChannelValues(deposit=5, withdrawn=5, transferred=20, locked=4)
-    )
+    ),
+    # overflow on transferred amounts
+    (
+        ChannelValues(deposit=40, withdrawn=10, transferred=MAX_UINT256 - 5, locked=6),
+        ChannelValues(deposit=35, withdrawn=5, transferred=MAX_UINT256 - 15, locked=4)
+    ),
+    # overflow on transferred amount
+    (
+        ChannelValues(deposit=40, withdrawn=10, transferred=MAX_UINT256 - 5, locked=6),
+        ChannelValues(deposit=35, withdrawn=5, transferred=0, locked=4)
+    ),
+    # overflow on transferred amount
+    (
+        ChannelValues(deposit=40, withdrawn=10, transferred=0, locked=6),
+        ChannelValues(deposit=35, withdrawn=5, transferred=MAX_UINT256 - 15, locked=4)
+    ),
+    # overflow on transferred amount + old balance proof
+    (
+        ChannelValues(deposit=40, withdrawn=10, transferred=MAX_UINT256 - 5, locked=0),
+        ChannelValues(deposit=35, withdrawn=5, transferred=20020, locked=200200)
+    ),
+    # overflow on transferred amount + old balance proof, overflow on netted transfer + deposit
+    (
+        ChannelValues(deposit=40, withdrawn=10, transferred=MAX_UINT256 - 5, locked=0),
+        ChannelValues(deposit=35, withdrawn=5, transferred=20, locked=200200)
+    ),
 ]

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -342,14 +342,14 @@ def test_channel_unlock(
 
     # Settle the channel
     token_network.functions.settleChannel(
+        B,
+        5,
+        locked_amount2,
+        locksroot2,
         A,
         10,
         locked_amount1,
         locksroot1,
-        B,
-        5,
-        locked_amount2,
-        locksroot2
     ).transact({'from': A})
 
     pre_balance_A = custom_token.functions.balanceOf(A).call()

--- a/raiden_contracts/tests/test_monitoring_service.py
+++ b/raiden_contracts/tests/test_monitoring_service.py
@@ -2,6 +2,7 @@ import pytest
 from raiden_contracts.constants import EVENT_CHANNEL_CLOSED
 from raiden_contracts.utils.events import check_channel_closed
 from raiden_contracts.utils.sign import sign_reward_proof
+from raiden_contracts.utils.merkle import EMPTY_MERKLE_ROOT
 
 
 @pytest.fixture()
@@ -110,11 +111,11 @@ def test_msc_happy_path(
         B,                   # participant2
         10,                  # participant2_transferred_amount
         0,                   # participant2_locked_amount
-        b'\x00' * 32,        # participant2_locksroot
+        EMPTY_MERKLE_ROOT,        # participant2_locksroot
         A,                   # participant1
         20,                  # participant1_transferred_amount
         0,                   # participant1_locked_amount
-        b'\x00' * 32,        # participant1_locksroot
+        EMPTY_MERKLE_ROOT,        # participant1_locksroot
     ).transact()
     # 7) MS claims the reward
     monitoring_service_external.functions.claimReward(

--- a/raiden_contracts/tests/test_monitoring_service.py
+++ b/raiden_contracts/tests/test_monitoring_service.py
@@ -107,14 +107,14 @@ def test_msc_happy_path(
     # 6) channel is settled
     token_network.web3.testing.mine(8)
     token_network.functions.settleChannel(
-        A,                   # participant1
-        20,                  # participant1_transferred_amount
-        0,                   # participant1_locked_amount
-        b'\x00' * 32,        # participant1_locksroot
         B,                   # participant2
         10,                  # participant2_transferred_amount
         0,                   # participant2_locked_amount
         b'\x00' * 32,        # participant2_locksroot
+        A,                   # participant1
+        20,                  # participant1_transferred_amount
+        0,                   # participant1_locked_amount
+        b'\x00' * 32,        # participant1_locksroot
     ).transact()
     # 7) MS claims the reward
     monitoring_service_external.functions.claimReward(

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -129,8 +129,14 @@ def test_channel_cycle(
 
     web3.testing.mine(settle_timeout)
     txn_hash = token_network.functions.settleChannel(
-        B, 5, locked_amount2, locksroot2,
-        A, 10, locked_amount1, locksroot1,
+        B,
+        5,
+        locked_amount2,
+        locksroot2,
+        A,
+        10,
+        locked_amount1,
+        locksroot1,
     ).transact()
     print_gas(txn_hash, CONTRACT_TOKEN_NETWORK + '.settleChannel')
 

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -129,8 +129,8 @@ def test_channel_cycle(
 
     web3.testing.mine(settle_timeout)
     txn_hash = token_network.functions.settleChannel(
+        B, 5, locked_amount2, locksroot2,
         A, 10, locked_amount1, locksroot1,
-        B, 5, locked_amount2, locksroot2
     ).transact()
     print_gas(txn_hash, CONTRACT_TOKEN_NETWORK + '.settleChannel')
 


### PR DESCRIPTION
This should fix the overflow issue for the old `deposit + transferred_amount` approach, demonstrated in https://github.com/raiden-network/raiden-contracts/pull/116/files#diff-cf6314cb143087ba6788de239e94298aR7 and mentioned in the thread started here: https://github.com/raiden-network/raiden-contracts/issues/117#issuecomment-395758666 

TODO:
(update: the following is not necessary - detailed explanation in https://github.com/raiden-network/raiden-contracts/pull/123#pullrequestreview-128277844)
- if possible, create test that would trigger an underflow when subtracting the withdrawn amount, to test that we handle it correctly; think some more if this approach is fair.
```
        // Subtract already withdrawn amount
        (participant1_amount, ) = failsafe_subtract(
            participant1_amount,
            participant1_state.withdrawn_amount
        );
```