### PR TITLE
Add channel deposit overflow check & test

### DIFF
--- a/raiden_contracts/contracts/test/CustomToken.sol
+++ b/raiden_contracts/contracts/test/CustomToken.sol
@@ -66,12 +66,7 @@ contract CustomToken is StandardToken {
     }
 
     /// @notice Allows tokens to be minted and assigned to `msg.sender`
-    /// For `msg.value >= 100 finney`, the sender receives 50 tokens
-    function mint() public payable {
-        require(msg.value >= 100 finney);
-
-        // Assign 50 tokens to msg.sender
-        uint256 num = 50 * multiplier;
+    function mint(uint256 num) public {
         balances[msg.sender] += num;
         _total_supply += num;
 

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -45,7 +45,7 @@ def assign_tokens(owner, token_network, custom_token):
     def get(participant, deposit):
         balance = custom_token.functions.balanceOf(participant).call()
         owner_balance = custom_token.functions.balanceOf(owner).call()
-        amount = deposit - balance
+        amount = max(deposit - balance, 0)
         transfer_from_owner = min(amount, owner_balance)
 
         custom_token.functions.transfer(participant, transfer_from_owner).transact({'from': owner})

--- a/raiden_contracts/tests/test_monitoring_service.py
+++ b/raiden_contracts/tests/test_monitoring_service.py
@@ -2,7 +2,6 @@ import pytest
 from raiden_contracts.constants import EVENT_CHANNEL_CLOSED
 from raiden_contracts.utils.events import check_channel_closed
 from raiden_contracts.utils.sign import sign_reward_proof
-from eth_utils import denoms
 
 
 @pytest.fixture()
@@ -55,9 +54,9 @@ def test_msc_happy_path(
     (A, B, MS) = get_accounts(3)
     reward_amount = 10
     # mint some tokens
-    custom_token.functions.mint().transact({'from': MS, 'value': 100 * denoms.finney})
-    custom_token.functions.mint().transact({'from': A, 'value': 100 * denoms.finney})
-    custom_token.functions.mint().transact({'from': B, 'value': 100 * denoms.finney})
+    custom_token.functions.mint(50).transact({'from': MS})
+    custom_token.functions.mint(50).transact({'from': A})
+    custom_token.functions.mint(50).transact({'from': B})
     # register MS in the RaidenServiceBundle contract
     custom_token.functions.approve(raiden_service_bundle.address, 20).transact({'from': MS})
     raiden_service_bundle.functions.deposit(20).transact({'from': MS})

--- a/raiden_contracts/tests/test_token.py
+++ b/raiden_contracts/tests/test_token.py
@@ -1,7 +1,5 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
-from eth_utils import denoms
-from web3.exceptions import ValidationError
 
 
 def test_token_mint(web3, custom_token, get_accounts):
@@ -11,25 +9,17 @@ def test_token_mint(web3, custom_token, get_accounts):
     supply = token.functions.totalSupply().call()
 
     token_pre_balance = web3.eth.getBalance(token.address)
-
-    with pytest.raises(ValidationError):
-        token.functions.mint(3).transact({'from': A})
-
-    with pytest.raises(TransactionFailed):
-        token.functions.mint().transact({'from': A})
-
-    wei_value = 10**17 + 21000
     tokens = 50 * multiplier
-    token.functions.mint().transact({'from': A, 'value': wei_value})
+    token.functions.mint(tokens).transact({'from': A})
     assert token.functions.balanceOf(A).call() == tokens
     assert token.functions.totalSupply().call() == supply + tokens
-    assert web3.eth.getBalance(token.address) == token_pre_balance + wei_value
+    assert web3.eth.getBalance(token.address) == token_pre_balance
 
 
 def test_approve_transfer(web3, custom_token, get_accounts):
     (A, B) = get_accounts(2)
     token = custom_token
-    token.functions.mint().transact({'from': A, 'value': 100 * denoms.finney})
+    token.functions.mint(50).transact({'from': A})
     initial_balance_A = token.functions.balanceOf(A).call()
     initial_balance_B = token.functions.balanceOf(B).call()
     to_transfer = 20
@@ -46,18 +36,11 @@ def test_token_transfer_funds(web3, custom_token, get_accounts, txn_gas):
     assert multiplier > 0
     supply = token.functions.totalSupply().call()
     assert supply > 0
-    wei_value = 10**17 + 21000
 
     owner = custom_token.functions.owner_address().call()
 
     with pytest.raises(TransactionFailed):
         token.functions.transferFunds().transact({'from': owner})
 
-    token.functions.mint().transact({'from': A, 'value': wei_value})
-
-    owner_prebalance = web3.eth.getBalance(owner)
-
-    tx_hash = token.functions.transferFunds().transact({'from': owner})
-
-    assert web3.eth.getBalance(owner) == owner_prebalance + wei_value - txn_gas(tx_hash)
+    token.functions.mint(50).transact({'from': A})
     assert web3.eth.getBalance(token.address) == 0


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden-contracts/issues/122

When calling `setTotalDeposit`, make sure the two participant's deposits don't overflow when added. This is very important for the settlement calculations.