### PR TITLE
Fix how locked amounts are computed at settlement for old balance proof with high locked amount

### DIFF
--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -593,7 +593,8 @@ def create_withdraw_signatures(token_network, get_private_key):
 
 
 def call_settle(token_network, A, vals_A, B, vals_B):
-    assert vals_B.transferred >= vals_A.transferred
+    assert vals_B.transferred + vals_B.locked >= vals_A.transferred + vals_A.locked
+
     if vals_B.transferred != vals_A.transferred:
         with pytest.raises(TransactionFailed):
             token_network.functions.settleChannel(

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -15,18 +15,14 @@ from raiden_contracts.utils.sign import (
     sign_cooperative_settle_message,
     sign_withdraw_message
 )
-from raiden_contracts.tests.utils import get_settlement_amounts, get_onchain_settlement_amounts
+from raiden_contracts.tests.utils import (
+    get_settlement_amounts,
+    get_onchain_settlement_amounts,
+    ChannelValues,
+)
 from .token_network import *  # flake8: noqa
 from .secret_registry import *  # flake8: noqa
 from .config import fake_bytes
-from eth_utils import denoms
-
-
-ChannelBalanceHashData = namedtuple('ChannelBalanceHashData', [
-    'transferred',
-    'locked',
-    'locksroot',
-])
 
 
 @pytest.fixture()
@@ -129,13 +125,9 @@ def close_and_update_channel(
 ):
     def get(
             participant1,
-            transferred_amount1,
-            locked_amount1,
-            locksroot1,
+            participant1_values,
             participant2,
-            transferred_amount2,
-            locked_amount2,
-            locksroot2,
+            participant2_values,
     ):
         nonce1 = 5
         nonce2 = 7
@@ -147,19 +139,19 @@ def close_and_update_channel(
         balance_proof_1 = create_balance_proof(
             channel_identifier,
             participant1,
-            transferred_amount1,
-            locked_amount1,
+            participant1_values.transferred,
+            participant1_values.locked,
             nonce1,
-            locksroot1,
+            participant1_values.locksroot,
             additional_hash1
         )
         balance_proof_2 = create_balance_proof(
             channel_identifier,
             participant2,
-            transferred_amount2,
-            locked_amount2,
+            participant2_values.transferred,
+            participant2_values.locked,
             nonce2,
-            locksroot2,
+            participant2_values.locksroot,
             additional_hash2
         )
         balance_proof_update_signature_2 = create_balance_proof_update_signature(
@@ -174,7 +166,8 @@ def close_and_update_channel(
         ).transact({'from': participant1})
 
         token_network.functions.updateNonClosingBalanceProof(
-            participant1, participant2,
+            participant1,
+            participant2,
             *balance_proof_1,
             balance_proof_update_signature_2
         ).transact({'from': participant2})
@@ -197,41 +190,44 @@ def create_settled_channel(
             locksroot2,
             settle_timeout=SETTLE_TIMEOUT_MIN,
     ):
-        transferred_amount1 = 5
-        transferred_amount2 = 40
-        deposit1 = locked_amount1 + transferred_amount1 - 5
-        deposit2 = locked_amount2 + transferred_amount2 + 5
+        participant1_values = ChannelValues(
+            transferred=5,
+            locked=locked_amount1,
+            locksroot=locksroot1,
+        )
+        participant2_values = ChannelValues(
+            transferred=40,
+            locked=locked_amount2,
+            locksroot=locksroot2,
+        )
+
+        participant1_values.deposit = (
+            participant1_values.locked +
+            participant1_values.transferred -
+            5
+        )
+        participant2_values.deposit = (
+            participant2_values.locked +
+            participant2_values.transferred +
+            5
+        )
 
         channel_identifier = create_channel_and_deposit(
             participant1,
             participant2,
-            deposit1,
-            deposit2,
+            participant1_values.deposit,
+            participant2_values.deposit,
             settle_timeout
         )
 
         close_and_update_channel(
             participant1,
-            transferred_amount1,
-            locked_amount1,
-            locksroot1,
+            participant1_values,
             participant2,
-            transferred_amount2,
-            locked_amount2,
-            locksroot2
+            participant2_values,
         )
 
         web3.testing.mine(settle_timeout)
-        participant1_values = ChannelBalanceHashData(
-            transferred=transferred_amount1,
-            locked=locked_amount1,
-            locksroot=locksroot1,
-        )
-        participant2_values = ChannelBalanceHashData(
-            transferred=transferred_amount2,
-            locked=locked_amount2,
-            locksroot=locksroot2,
-        )
 
         call_settle(token_network, participant1, participant1_values, participant2, participant2_values)
 

--- a/raiden_contracts/tests/fixtures/channel_test_values.py
+++ b/raiden_contracts/tests/fixtures/channel_test_values.py
@@ -1,24 +1,4 @@
-from raiden_contracts.tests.utils import MAX_UINT256
-
-
-class ChannelValues():
-    def __init__(self, deposit=0, withdrawn=0, transferred=0, locked=0, locksroot=b''):
-        self.deposit = deposit
-        self.withdrawn = withdrawn
-        self.transferred = transferred
-        self.locked = locked
-        self.locksroot = locksroot
-
-    def __repr__(self):
-        return (
-            'ChannelValues deposit:{} withdrawn:{} transferred:{} locked:{} locksroot:{}'
-        ).format(
-            self.deposit,
-            self.withdrawn,
-            self.transferred,
-            self.locked,
-            self.locksroot,
-        )
+from raiden_contracts.tests.utils import MAX_UINT256, ChannelValues
 
 
 channel_settle_test_values = [

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -82,13 +82,9 @@ def test_settle_channel_state(
 
     close_and_update_channel(
         A,
-        vals_A.transferred,
-        vals_A.locked,
-        vals_A.locksroot,
+        vals_A,
         B,
-        vals_B.transferred,
-        vals_B.locked,
-        vals_B.locksroot
+        vals_B,
     )
 
     web3.testing.mine(SETTLE_TIMEOUT_MIN)

--- a/raiden_contracts/tests/utils.py
+++ b/raiden_contracts/tests/utils.py
@@ -30,12 +30,21 @@ SettlementValues = namedtuple('SettlementValues', [
 
 
 class ChannelValues():
-    def __init__(self, deposit=0, withdrawn=0, transferred=0, locked=0, locksroot=b''):
+    def __init__(
+            self,
+            deposit=0,
+            withdrawn=0,
+            transferred=0,
+            locked=0,
+            locksroot=b'',
+            additional_hash=b''
+    ):
         self.deposit = deposit
         self.withdrawn = withdrawn
         self.transferred = transferred
         self.locked = locked
         self.locksroot = locksroot
+        self.additional_hash = additional_hash
 
     def __repr__(self):
         return (

--- a/raiden_contracts/tests/utils.py
+++ b/raiden_contracts/tests/utils.py
@@ -187,7 +187,7 @@ def failsafe_add(a, b):
     a = a % (MAX_UINT256 + 1)
     b = b % (MAX_UINT256 + 1)
     sum = (a + b) % (MAX_UINT256 + 1)
-    if sum > a:
+    if sum >= a:
         return sum
     else:
         return MAX_UINT256

--- a/raiden_contracts/tests/utils.py
+++ b/raiden_contracts/tests/utils.py
@@ -29,6 +29,26 @@ SettlementValues = namedtuple('SettlementValues', [
 ])
 
 
+class ChannelValues():
+    def __init__(self, deposit=0, withdrawn=0, transferred=0, locked=0, locksroot=b''):
+        self.deposit = deposit
+        self.withdrawn = withdrawn
+        self.transferred = transferred
+        self.locked = locked
+        self.locksroot = locksroot
+
+    def __repr__(self):
+        return (
+            'ChannelValues deposit:{} withdrawn:{} transferred:{} locked:{} locksroot:{}'
+        ).format(
+            self.deposit,
+            self.withdrawn,
+            self.transferred,
+            self.locked,
+            self.locksroot,
+        )
+
+
 def random_secret():
     secret = os.urandom(32)
     return (Web3.soliditySha3(['bytes32'], [secret]), secret)

--- a/raiden_contracts/tests/utils.py
+++ b/raiden_contracts/tests/utils.py
@@ -146,21 +146,36 @@ def get_settlement_amounts(
         participant1.withdrawn -
         participant2.withdrawn
     )
-    participant1_amount = (
-        participant1.deposit +
-        participant2.transferred -
-        participant1.withdrawn -
-        participant1.transferred
+    participant1_max_transferred = min(
+        participant1.transferred + participant1.locked,
+        MAX_UINT256
     )
-    participant1_amount = max(participant1_amount, 0)
-    participant1_amount = min(participant1_amount, total_available_deposit)
-    participant2_amount = total_available_deposit - participant1_amount
+    participant2_max_transferred = min(
+        participant2.transferred + participant2.locked,
+        MAX_UINT256
+    )
+    participant1_max_amount_receivable = (
+        participant1.deposit +
+        participant2_max_transferred -
+        participant1_max_transferred -
+        participant1.withdrawn
+    )
 
-    participant1_locked = min(participant1_amount, participant1.locked)
-    participant2_locked = min(participant2_amount, participant2.locked)
+    participant1_max_amount_receivable = max(participant1_max_amount_receivable, 0)
+    participant1_max_amount_receivable = min(
+        participant1_max_amount_receivable,
+        total_available_deposit
+    )
+    participant2_max_amount_receivable = (
+        total_available_deposit -
+        participant1_max_amount_receivable
+    )
 
-    participant1_amount = max(participant1_amount - participant1.locked, 0)
-    participant2_amount = max(participant2_amount - participant2.locked, 0)
+    participant2_locked = min(participant2.locked, participant1_max_amount_receivable)
+    participant1_locked = min(participant1.locked, participant2_max_amount_receivable)
+
+    participant1_amount = participant1_max_amount_receivable - participant2_locked
+    participant2_amount = participant2_max_amount_receivable - participant1_locked
 
     assert total_available_deposit == (
         participant1_amount +
@@ -218,7 +233,10 @@ def get_onchain_settlement_amounts(
     !!! Don't change this unless you really know what you are doing.
     """
 
-    assert(participant2.transferred >= participant1.transferred)
+    assert(
+        participant2.transferred + participant2.locked >=
+        participant1.transferred + participant1.locked
+    )
 
     total_available_deposit = (
         participant1.deposit +
@@ -229,23 +247,29 @@ def get_onchain_settlement_amounts(
     # we assume that total_available_deposit does not overflow in settleChannel
     assert total_available_deposit <= MAX_UINT256
 
-    participant1_netted_amount = (participant2.transferred - participant1.transferred)
-    participant1_amount = failsafe_add(participant1_netted_amount, participant1.deposit)
+    participant1_max_transferred = failsafe_add(participant1.transferred, participant1.locked)
+    participant2_max_transferred = failsafe_add(participant2.transferred, participant2.locked)
 
-    (participant1_amount, _) = failsafe_sub(
-        participant1_amount,
-        participant1.withdrawn)
-    participant1_amount = min(participant1_amount, total_available_deposit)
-    participant2_amount = total_available_deposit - participant1_amount
+    assert participant1_max_transferred <= MAX_UINT256
+    assert participant2_max_transferred <= MAX_UINT256
 
-    (participant1_amount, participant1_locked_amount) = failsafe_sub(
-        participant1_amount,
-        participant1.locked
+    participant1_net_max_transferred = participant2_max_transferred - participant1_max_transferred
+
+    participant1_max_amount = failsafe_add(participant1_net_max_transferred, participant1.deposit)
+    (participant1_max_amount, _) = failsafe_sub(participant1_max_amount, participant1.withdrawn)
+
+    participant1_max_amount = min(participant1_max_amount, total_available_deposit)
+
+    participant2_max_amount = total_available_deposit - participant1_max_amount
+
+    (participant1_amount, participant2_locked_amount) = failsafe_sub(
+        participant1_max_amount,
+        participant2.locked
     )
 
-    (participant2_amount, participant2_locked_amount) = failsafe_sub(
-        participant2_amount,
-        participant2.locked
+    (participant2_amount, participant1_locked_amount) = failsafe_sub(
+        participant2_max_amount,
+        participant1.locked
     )
 
     assert total_available_deposit == (


### PR DESCRIPTION
Fix how locked amounts are computed at settlement

Fixes #127

```
P1 = participant1
D1 = deposit P1
W1 = withdrawn P1
T1 = transferred P1 -> P2
L1 = pending transfers P1 -> P2
A1 = amount to be received by P1 at settlement 

P2 = participant2
D2 = deposit P2
W2 = withdrawn P2
T2 = transferred P2 -> P1
L2 = pending transfers P2 -> P1
A2 = amount to be received by P2 at settlement

DC = D1 + D2 - W1 - W2 = current channel deposit
```

To simplify calculations, we artificially require the `settleChannel` arguments to be ordered:
```
T2 + L2 >= T1 + L1
```
https://github.com/raiden-network/raiden-contracts/blob/1046322d015a4ec06f6ad0b9961db194399f3563/raiden_contracts/contracts/TokenNetwork.sol#L882-L884

This comes from the way we compute the maximum receivable amount for `P1`
```
A1max = (T2 + L2) - (T1 + L1) + D1 - W1
```
https://github.com/raiden-network/raiden-contracts/blob/1046322d015a4ec06f6ad0b9961db194399f3563/raiden_contracts/contracts/TokenNetwork.sol#L889-L906

Note that we are including the locked amounts. 
These can be: 
- pending transfers that have not been finalized off-chain; we don't know at this point if the `secret`s have been registered or not, do we don't know if the locked amount will go entirely to the intended participant
- old pending transfers that have actually finalized on-chain and included in a newer balance proof; this is the case where cheating can be done - the participant can make sure to also register the `secret`s on-chain and use that later to try to withdraw more tokens - this attack is fixed by this PR, because:
```
A1max = min(A1max, DC)
A2max = DC - A1max
```
and `A1max` also contains `L2`. `A2max` contains `L1`.
https://github.com/raiden-network/raiden-contracts/blob/1046322d015a4ec06f6ad0b9961db194399f3563/raiden_contracts/contracts/TokenNetwork.sol#L599

We then subtract the locked amounts and bound them:
```
L2 = min(L2, A1max)
L1 = min(L1, A2max)
A1 = A1max - L2
A2 = A2max - L1
```
https://github.com/raiden-network/raiden-contracts/blob/1046322d015a4ec06f6ad0b9961db194399f3563/raiden_contracts/contracts/TokenNetwork.sol#L613-L623

And make sure we store the new locked amount in the contract and not the initial one.

**Tests**

Added tests that reverse balance proof values for `T1` and `L1` / `T2` and `L1` , and also provide random values for the locked amounts e.g. `L1 = randint(L1, L1 + T1)`, to simulate old balance proofs. All these cases are equivalent and should settle following this constraint:

```
A1 + L2 = A2 + L1
```