### PR TITLE
Use remappings with import

### DIFF
--- a/raiden_contracts/contracts/MonitoringService.sol
+++ b/raiden_contracts/contracts/MonitoringService.sol
@@ -1,10 +1,10 @@
 pragma solidity ^0.4.23;
 
-import "./Token.sol";
-import "./Utils.sol";
-import "./lib/ECVerify.sol";
-import "./TokenNetwork.sol";
-import "./RaidenServiceBundle.sol";
+import "raiden/Token.sol";
+import "raiden/Utils.sol";
+import "raiden/lib/ECVerify.sol";
+import "raiden/TokenNetwork.sol";
+import "raiden/RaidenServiceBundle.sol";
 
 contract MonitoringService is Utils {
 

--- a/raiden_contracts/contracts/RaidenServiceBundle.sol
+++ b/raiden_contracts/contracts/RaidenServiceBundle.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.23;
 
-import "./Token.sol";
-import "./Utils.sol";
+import "raiden/Token.sol";
+import "raiden/Utils.sol";
 
 contract RaidenServiceBundle is Utils {
     Token public token;

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.4.23;
 
-import "./Token.sol";
-import "./Utils.sol";
-import "./lib/ECVerify.sol";
-import "./SecretRegistry.sol";
+import "raiden/Token.sol";
+import "raiden/Utils.sol";
+import "raiden/lib/ECVerify.sol";
+import "raiden/SecretRegistry.sol";
 
 contract TokenNetwork is Utils {
 

--- a/raiden_contracts/contracts/TokenNetworkRegistry.sol
+++ b/raiden_contracts/contracts/TokenNetworkRegistry.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.4.23;
 
-import "./Utils.sol";
-import "./Token.sol";
-import "./TokenNetwork.sol";
+import "raiden/Utils.sol";
+import "raiden/Token.sol";
+import "raiden/TokenNetwork.sol";
 
 contract TokenNetworkRegistry is Utils {
 

--- a/raiden_contracts/contracts/test/CustomToken.sol
+++ b/raiden_contracts/contracts/test/CustomToken.sol
@@ -12,7 +12,7 @@ Machine-based, rapid creation of many tokens would not necessarily need these ex
 
 .*/
 
-import "./StandardToken.sol";
+import "test/StandardToken.sol";
 
 /// @title CustomToken
 contract CustomToken is StandardToken {

--- a/raiden_contracts/contracts/test/HumanStandardToken.sol
+++ b/raiden_contracts/contracts/test/HumanStandardToken.sol
@@ -12,7 +12,7 @@ Machine-based, rapid creation of many tokens would not necessarily need these ex
 .*/
 
 pragma solidity ^0.4.23;
-import "./StandardToken.sol";
+import "test/StandardToken.sol";
 
 contract HumanStandardToken is StandardToken {
     /* Public variables of the token */

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,10 @@ class CompileContracts(Command):
             print('py-solc is not installed, skipping contracts compilation')
             return
         from raiden_contracts.contract_manager import CONTRACT_MANAGER
-        compiled = CONTRACT_MANAGER.precompile_contracts('raiden_contracts/contracts/', [])
+        compiled = CONTRACT_MANAGER.precompile_contracts(
+            'raiden_contracts/contracts/',
+            CONTRACT_MANAGER.get_mappings(),
+        )
         with open(COMPILED_CONTRACTS, 'w') as compiled_json:
             compiled_json.write(json.dumps(compiled))
 


### PR DESCRIPTION
Since ContractManager already construct path remappings when invoking `solc`, this PR changes smart contracts to have them use `raiden/...` import path instead of `./`

Resolves https://github.com/raiden-network/raiden/issues/162