### PR TITLE
unit tests for TokenNetwork internals

### DIFF
--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -477,8 +477,10 @@ def create_balance_proof(token_network, get_private_key):
             locksroot=None,
             additional_hash=None,
             v=27,
-            signer=None
+            signer=None,
+            other_token_network=None
     ):
+        _token_network = other_token_network or token_network
         private_key = get_private_key(signer or participant)
         locksroot = locksroot or b'\x00' * 32
         additional_hash = additional_hash or b'\x00' * 32
@@ -487,8 +489,8 @@ def create_balance_proof(token_network, get_private_key):
 
         signature = sign_balance_proof(
             private_key,
-            token_network.address,
-            int(token_network.functions.chain_id().call()),
+            _token_network.address,
+            int(_token_network.functions.chain_id().call()),
             channel_identifier,
             balance_hash,
             nonce,
@@ -513,14 +515,16 @@ def create_balance_proof_update_signature(token_network, get_private_key):
             nonce,
             additional_hash,
             closing_signature,
-            v=27
+            v=27,
+            other_token_network=None
     ):
+        _token_network = other_token_network or token_network
         private_key = get_private_key(participant)
 
         non_closing_signature = sign_balance_proof_update_message(
             private_key,
-            token_network.address,
-            int(token_network.functions.chain_id().call()),
+            _token_network.address,
+            int(_token_network.functions.chain_id().call()),
             channel_identifier,
             balance_hash,
             nonce,
@@ -541,15 +545,17 @@ def create_cooperative_settle_signatures(token_network, get_private_key):
             participant1_balance,
             participant2_address,
             participant2_balance,
-            v=27
+            v=27,
+            other_token_network=None
     ):
+        _token_network = other_token_network or token_network
         signatures = []
         for participant in participants_to_sign:
             private_key = get_private_key(participant)
             signature = sign_cooperative_settle_message(
                 private_key,
-                token_network.address,
-                int(token_network.functions.chain_id().call()),
+                _token_network.address,
+                int(_token_network.functions.chain_id().call()),
                 channel_identifier,
                 participant1_address,
                 participant1_balance,

--- a/raiden_contracts/tests/test_channel_withdraw.py
+++ b/raiden_contracts/tests/test_channel_withdraw.py
@@ -14,43 +14,6 @@ from raiden_contracts.constants import (
 from .utils import MAX_UINT256
 
 
-def test_withdraw_signature(
-        token_network_test,
-        create_channel_and_deposit,
-        get_accounts,
-        create_withdraw_signatures,
-):
-    (A, B) = get_accounts(2)
-    deposit_A = 5
-    deposit_B = 7
-    withdraw_A = 3
-    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
-
-    (signature_A, signature_B) = create_withdraw_signatures(
-        [A, B],
-        channel_identifier,
-        A,
-        withdraw_A,
-        token_network_test.address,
-    )
-
-    recovered_address_A = token_network_test.functions.recoverAddressFromWithdrawMessagePublic(
-        channel_identifier,
-        A,
-        withdraw_A,
-        signature_A,
-    ).call()
-    assert recovered_address_A == A
-
-    recovered_address_B = token_network_test.functions.recoverAddressFromWithdrawMessagePublic(
-        channel_identifier,
-        A,
-        withdraw_A,
-        signature_B,
-    ).call()
-    assert recovered_address_B == B
-
-
 def test_withdraw_call(
         token_network,
         create_channel_and_deposit,

--- a/raiden_contracts/tests/test_unit_internals.py
+++ b/raiden_contracts/tests/test_unit_internals.py
@@ -1,0 +1,338 @@
+# -*- coding: utf-8 -*-
+
+from itertools import chain, product
+
+import pytest
+from eth_tester.constants import UINT256_MIN, UINT256_MAX
+from eth_tester.exceptions import TransactionFailed
+
+from raiden_contracts.tests.fixtures import fake_bytes
+from web3.exceptions import ValidationError
+
+from raiden_contracts.tests.fixtures.config import fake_hex
+
+
+def test_min_uses_usigned(token_network_test):
+    """ Min cannot be called with negative values. """
+    INVALID_VALUES = [-UINT256_MAX, -1]
+    VALID_VALUES = [UINT256_MIN, UINT256_MAX, UINT256_MAX]
+
+    all_invalid = chain(
+        product(VALID_VALUES, INVALID_VALUES),
+        product(INVALID_VALUES, VALID_VALUES),
+    )
+
+    for a, b in all_invalid:
+        with pytest.raises(ValidationError):
+            token_network_test.functions.minPublic(a, b).call()
+
+
+def test_max_uses_usigned(token_network_test):
+
+    INVALID_VALUES = [-UINT256_MAX, -1]
+    VALID_VALUES = [UINT256_MIN, UINT256_MAX, UINT256_MAX]
+
+    all_invalid = chain(
+        product(VALID_VALUES, INVALID_VALUES),
+        product(INVALID_VALUES, VALID_VALUES),
+    )
+    for a, b in all_invalid:
+        with pytest.raises(ValidationError):
+            token_network_test.functions.maxPublic(a, b).call()
+
+
+def test_min(token_network_test):
+
+    VALUES = [UINT256_MIN, 1, UINT256_MAX, UINT256_MAX]
+    for a, b in product(VALUES, VALUES):
+        assert token_network_test.functions.minPublic(a, b).call() == min(a, b)
+
+
+def test_max(token_network_test):
+
+    VALUES = [UINT256_MIN, 1, UINT256_MAX, UINT256_MAX]
+    for a, b in product(VALUES, VALUES):
+        assert token_network_test.functions.maxPublic(a, b).call() == max(a, b)
+
+
+def test_verifyWithdrawSignatures(
+        token_network_test,
+        create_withdraw_signatures,
+        get_accounts
+):
+
+    (A, B) = get_accounts(2)
+    fake_signature = fake_bytes(64)
+    channel_identifier = fake_hex(32)
+    (signature_A, signature_B) = create_withdraw_signatures(
+        [A, B],
+        channel_identifier,
+        A,
+        1,
+        token_network_test.address
+    )
+    token_network_test.functions.verifyWithdrawSignaturesPublic(
+        channel_identifier,
+        A,
+        B,
+        1,
+        signature_A,
+        signature_B
+    ).call()
+
+    with pytest.raises(TransactionFailed):
+        token_network_test.functions.verifyWithdrawSignaturesPublic(
+            channel_identifier,
+            A,
+            B,
+            3,
+            signature_B,
+            signature_A
+        ).call()
+    with pytest.raises(TransactionFailed):
+        token_network_test.functions.verifyWithdrawSignaturesPublic(
+            channel_identifier,
+            A,
+            B,
+            3,
+            signature_A,
+            fake_signature
+        ).call()
+    with pytest.raises(TransactionFailed):
+        token_network_test.functions.verifyWithdrawSignaturesPublic(
+            channel_identifier,
+            A,
+            B,
+            3,
+            fake_signature,
+            signature_B
+        ).call()
+
+
+def test_recoverAddressFromWithdrawMessage(
+        token_network_test,
+        create_withdraw_signatures,
+        create_channel_and_deposit,
+        get_accounts
+):
+    (A, B) = get_accounts(2)
+    fake_signature = fake_bytes(64)
+    deposit_A = 5
+    deposit_B = 7
+    withdraw_A = 3
+    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
+    (signature_A, signature_B) = create_withdraw_signatures(
+        [A, B],
+        channel_identifier,
+        A,
+        withdraw_A,
+        token_network_test.address
+    )
+
+    recovered_address_A = token_network_test.functions.recoverAddressFromWithdrawMessagePublic(
+        channel_identifier,
+        A,
+        withdraw_A,
+        signature_A
+    ).call()
+    assert recovered_address_A == A
+
+    recovered_address_B = token_network_test.functions.recoverAddressFromWithdrawMessagePublic(
+        channel_identifier,
+        A,
+        withdraw_A,
+        signature_B
+    ).call()
+    assert recovered_address_B == B
+
+    with pytest.raises(TransactionFailed):
+        token_network_test.functions.recoverAddressFromWithdrawMessagePublic(
+            channel_identifier,
+            A,
+            withdraw_A,
+            fake_signature
+        ).call()
+
+    wrong_participant = token_network_test.functions.recoverAddressFromWithdrawMessagePublic(
+        channel_identifier,
+        B,
+        withdraw_A,
+        signature_A
+    ).call()
+    assert recovered_address_A != wrong_participant
+
+    wrong_withdraw_value = token_network_test.functions.recoverAddressFromWithdrawMessagePublic(
+        channel_identifier,
+        A,
+        1,
+        signature_A
+    ).call()
+
+    assert recovered_address_A != wrong_withdraw_value
+
+    wrong_signature = token_network_test.functions.recoverAddressFromWithdrawMessagePublic(
+        channel_identifier,
+        A,
+        withdraw_A,
+        signature_B
+    ).call()
+
+    assert recovered_address_A != wrong_signature
+
+
+def test_recoverAddressFromBalanceProof(
+        token_network_test,
+        create_balance_proof,
+        get_accounts
+):
+    (A, B) = get_accounts(2)
+
+    channel_identifier = fake_bytes(32)
+    balance_proof = create_balance_proof(
+        channel_identifier,
+        A,
+        other_token_network=token_network_test
+    )
+
+    balance_proof_wrong_token_network = create_balance_proof(
+        channel_identifier,
+        A,
+    )
+
+    balance_proof_wrong_signer = create_balance_proof(
+        channel_identifier,
+        A,
+        signer=B,
+        other_token_network=token_network_test
+    )
+
+    assert A == token_network_test.functions.recoverAddressFromBalanceProofPublic(
+        channel_identifier, *balance_proof).call()
+
+    assert A != token_network_test.functions.recoverAddressFromBalanceProofPublic(
+        channel_identifier, *balance_proof_wrong_token_network).call()
+
+    assert B == token_network_test.functions.recoverAddressFromBalanceProofPublic(
+        channel_identifier,
+        *balance_proof_wrong_signer
+    ).call()
+
+
+def test_recoverAddressFromBalanceProofUpdate(
+        token_network_test,
+        create_balance_proof,
+        create_balance_proof_update_signature,
+        get_accounts
+):
+
+    (A, B) = get_accounts(2)
+
+    channel_identifier = fake_bytes(32)
+    balance_proof = create_balance_proof(
+        channel_identifier,
+        A,
+        other_token_network=token_network_test
+    )
+    balance_proof_update_signature = create_balance_proof_update_signature(
+        B,
+        channel_identifier,
+        *balance_proof,
+        other_token_network=token_network_test
+    )
+
+    balance_proof_update_signature_wrong_token_network = create_balance_proof_update_signature(
+        B,
+        channel_identifier,
+        *balance_proof,
+    )
+
+    balance_proof_signed_B = create_balance_proof(
+        channel_identifier,
+        B,
+        other_token_network=token_network_test
+    )
+    balance_proof_update_signature_wrong_signer = create_balance_proof_update_signature(
+        B,
+        channel_identifier,
+        *balance_proof_signed_B,
+    )
+
+    assert B == token_network_test.functions.recoverAddressFromBalanceProofUpdateMessagePublic(
+        channel_identifier, *balance_proof, balance_proof_update_signature).call()
+
+    assert B != token_network_test.functions.recoverAddressFromBalanceProofUpdateMessagePublic(
+        channel_identifier,
+        *balance_proof,
+        balance_proof_update_signature_wrong_token_network
+    ).call()
+
+    assert B != token_network_test.functions.recoverAddressFromBalanceProofUpdateMessagePublic(
+        channel_identifier,
+        *balance_proof,
+        balance_proof_update_signature_wrong_signer
+    ).call()
+
+
+def test_recoverAddressFromCooperativeSettleSignature(
+        token_network_test,
+        create_cooperative_settle_signatures,
+        get_accounts
+):
+    (A, B) = get_accounts(2)
+    channel_identifier = fake_bytes(32)
+    fake_signature = fake_bytes(64)
+
+    (signature_A, signature_B) = create_cooperative_settle_signatures(
+        [A, B],
+        channel_identifier,
+        A,
+        0,
+        B,
+        0,
+        other_token_network=token_network_test
+    )
+    assert A == token_network_test.functions.recoverAddressFromCooperativeSettleSignaturePublic(
+        channel_identifier,
+        A,
+        0,
+        B,
+        0,
+        signature_A
+    ).call()
+
+    assert B == token_network_test.functions.recoverAddressFromCooperativeSettleSignaturePublic(
+        channel_identifier,
+        A,
+        0,
+        B,
+        0,
+        signature_B
+    ).call()
+
+    assert B != token_network_test.functions.recoverAddressFromCooperativeSettleSignaturePublic(
+        channel_identifier,
+        A,
+        0,
+        B,
+        0,
+        signature_A
+    ).call()
+
+    assert A != token_network_test.functions.recoverAddressFromCooperativeSettleSignaturePublic(
+        channel_identifier,
+        A,
+        0,
+        B,
+        0,
+        signature_B
+    ).call()
+
+    with pytest.raises(TransactionFailed):
+        token_network_test.functions.recoverAddressFromCooperativeSettleSignaturePublic(
+            channel_identifier,
+            A,
+            0,
+            B,
+            0,
+            fake_signature
+        ).call()

--- a/raiden_contracts/tests/unit/test_unit_internals.py
+++ b/raiden_contracts/tests/unit/test_unit_internals.py
@@ -58,7 +58,7 @@ def test_max(token_network_test):
 def test_verifyWithdrawSignatures(
         token_network_test,
         create_withdraw_signatures,
-        get_accounts
+        get_accounts,
 ):
 
     (A, B) = get_accounts(2)
@@ -69,7 +69,7 @@ def test_verifyWithdrawSignatures(
         channel_identifier,
         A,
         1,
-        token_network_test.address
+        token_network_test.address,
     )
     token_network_test.functions.verifyWithdrawSignaturesPublic(
         channel_identifier,
@@ -77,7 +77,7 @@ def test_verifyWithdrawSignatures(
         B,
         1,
         signature_A,
-        signature_B
+        signature_B,
     ).call()
 
     with pytest.raises(TransactionFailed):
@@ -87,7 +87,7 @@ def test_verifyWithdrawSignatures(
             B,
             3,
             signature_B,
-            signature_A
+            signature_A,
         ).call()
     with pytest.raises(TransactionFailed):
         token_network_test.functions.verifyWithdrawSignaturesPublic(
@@ -96,7 +96,7 @@ def test_verifyWithdrawSignatures(
             B,
             3,
             signature_A,
-            fake_signature
+            fake_signature,
         ).call()
     with pytest.raises(TransactionFailed):
         token_network_test.functions.verifyWithdrawSignaturesPublic(
@@ -105,7 +105,7 @@ def test_verifyWithdrawSignatures(
             B,
             3,
             fake_signature,
-            signature_B
+            signature_B,
         ).call()
 
 
@@ -113,7 +113,7 @@ def test_recoverAddressFromWithdrawMessage(
         token_network_test,
         create_withdraw_signatures,
         create_channel_and_deposit,
-        get_accounts
+        get_accounts,
 ):
     (A, B) = get_accounts(2)
     fake_signature = fake_bytes(64)
@@ -126,14 +126,14 @@ def test_recoverAddressFromWithdrawMessage(
         channel_identifier,
         A,
         withdraw_A,
-        token_network_test.address
+        token_network_test.address,
     )
 
     recovered_address_A = token_network_test.functions.recoverAddressFromWithdrawMessagePublic(
         channel_identifier,
         A,
         withdraw_A,
-        signature_A
+        signature_A,
     ).call()
     assert recovered_address_A == A
 
@@ -141,7 +141,7 @@ def test_recoverAddressFromWithdrawMessage(
         channel_identifier,
         A,
         withdraw_A,
-        signature_B
+        signature_B,
     ).call()
     assert recovered_address_B == B
 
@@ -150,14 +150,14 @@ def test_recoverAddressFromWithdrawMessage(
             channel_identifier,
             A,
             withdraw_A,
-            fake_signature
+            fake_signature,
         ).call()
 
     wrong_participant = token_network_test.functions.recoverAddressFromWithdrawMessagePublic(
         channel_identifier,
         B,
         withdraw_A,
-        signature_A
+        signature_A,
     ).call()
     assert recovered_address_A != wrong_participant
 
@@ -165,7 +165,7 @@ def test_recoverAddressFromWithdrawMessage(
         channel_identifier,
         A,
         1,
-        signature_A
+        signature_A,
     ).call()
 
     assert recovered_address_A != wrong_withdraw_value
@@ -174,7 +174,7 @@ def test_recoverAddressFromWithdrawMessage(
         channel_identifier,
         A,
         withdraw_A,
-        signature_B
+        signature_B,
     ).call()
 
     assert recovered_address_A != wrong_signature
@@ -183,7 +183,7 @@ def test_recoverAddressFromWithdrawMessage(
 def test_recoverAddressFromBalanceProof(
         token_network_test,
         create_balance_proof,
-        get_accounts
+        get_accounts,
 ):
     (A, B) = get_accounts(2)
 
@@ -191,7 +191,7 @@ def test_recoverAddressFromBalanceProof(
     balance_proof = create_balance_proof(
         channel_identifier,
         A,
-        other_token_network=token_network_test
+        other_token_network=token_network_test,
     )
 
     balance_proof_wrong_token_network = create_balance_proof(
@@ -199,30 +199,30 @@ def test_recoverAddressFromBalanceProof(
         A,
     )
 
-    balance_proof_wrong_signer = create_balance_proof(
+    balance_proof_other_signer = create_balance_proof(
         channel_identifier,
         A,
         signer=B,
-        other_token_network=token_network_test
+        other_token_network=token_network_test,
     )
 
     assert A == token_network_test.functions.recoverAddressFromBalanceProofPublic(
         channel_identifier, *balance_proof).call()
 
-    assert A != token_network_test.functions.recoverAddressFromBalanceProofPublic(
-        channel_identifier, *balance_proof_wrong_token_network).call()
-
     assert B == token_network_test.functions.recoverAddressFromBalanceProofPublic(
         channel_identifier,
-        *balance_proof_wrong_signer
+        *balance_proof_other_signer,
     ).call()
+
+    assert A != token_network_test.functions.recoverAddressFromBalanceProofPublic(
+        channel_identifier, *balance_proof_wrong_token_network).call()
 
 
 def test_recoverAddressFromBalanceProofUpdate(
         token_network_test,
         create_balance_proof,
         create_balance_proof_update_signature,
-        get_accounts
+        get_accounts,
 ):
 
     (A, B) = get_accounts(2)
@@ -231,13 +231,13 @@ def test_recoverAddressFromBalanceProofUpdate(
     balance_proof = create_balance_proof(
         channel_identifier,
         A,
-        other_token_network=token_network_test
+        other_token_network=token_network_test,
     )
     balance_proof_update_signature = create_balance_proof_update_signature(
         B,
         channel_identifier,
         *balance_proof,
-        other_token_network=token_network_test
+        other_token_network=token_network_test,
     )
 
     balance_proof_update_signature_wrong_token_network = create_balance_proof_update_signature(
@@ -249,7 +249,7 @@ def test_recoverAddressFromBalanceProofUpdate(
     balance_proof_signed_B = create_balance_proof(
         channel_identifier,
         B,
-        other_token_network=token_network_test
+        other_token_network=token_network_test,
     )
     balance_proof_update_signature_wrong_signer = create_balance_proof_update_signature(
         B,
@@ -263,20 +263,20 @@ def test_recoverAddressFromBalanceProofUpdate(
     assert B != token_network_test.functions.recoverAddressFromBalanceProofUpdateMessagePublic(
         channel_identifier,
         *balance_proof,
-        balance_proof_update_signature_wrong_token_network
+        balance_proof_update_signature_wrong_token_network,
     ).call()
 
     assert B != token_network_test.functions.recoverAddressFromBalanceProofUpdateMessagePublic(
         channel_identifier,
         *balance_proof,
-        balance_proof_update_signature_wrong_signer
+        balance_proof_update_signature_wrong_signer,
     ).call()
 
 
 def test_recoverAddressFromCooperativeSettleSignature(
         token_network_test,
         create_cooperative_settle_signatures,
-        get_accounts
+        get_accounts,
 ):
     (A, B) = get_accounts(2)
     channel_identifier = fake_bytes(32)
@@ -289,7 +289,7 @@ def test_recoverAddressFromCooperativeSettleSignature(
         0,
         B,
         0,
-        other_token_network=token_network_test
+        other_token_network=token_network_test,
     )
     assert A == token_network_test.functions.recoverAddressFromCooperativeSettleSignaturePublic(
         channel_identifier,
@@ -297,7 +297,7 @@ def test_recoverAddressFromCooperativeSettleSignature(
         0,
         B,
         0,
-        signature_A
+        signature_A,
     ).call()
 
     assert B == token_network_test.functions.recoverAddressFromCooperativeSettleSignaturePublic(
@@ -306,7 +306,7 @@ def test_recoverAddressFromCooperativeSettleSignature(
         0,
         B,
         0,
-        signature_B
+        signature_B,
     ).call()
 
     assert B != token_network_test.functions.recoverAddressFromCooperativeSettleSignaturePublic(
@@ -315,7 +315,7 @@ def test_recoverAddressFromCooperativeSettleSignature(
         0,
         B,
         0,
-        signature_A
+        signature_A,
     ).call()
 
     assert A != token_network_test.functions.recoverAddressFromCooperativeSettleSignaturePublic(
@@ -324,7 +324,7 @@ def test_recoverAddressFromCooperativeSettleSignature(
         0,
         B,
         0,
-        signature_B
+        signature_B,
     ).call()
 
     with pytest.raises(TransactionFailed):
@@ -334,5 +334,5 @@ def test_recoverAddressFromCooperativeSettleSignature(
             0,
             B,
             0,
-            fake_signature
+            fake_signature,
         ).call()


### PR DESCRIPTION
Contribution to #92, fixes #129. The unit tests from /raiden have so far been moved to raiden-contracts according to this mapping: 


```
**raiden/test_auxiliary_netting_channel -> raiden-contracts/test_unit_internals**

test_min_uses_usigned -> test_unit_internals.test_min_uses_usigned
test_max_uses_unsigned -> test_unit_internals.test_min_uses_usigned
test_min -> test_unit_internals.test_min
test_max -> test_unit_internals.test_max

test_recoverAddressFromSignature -> test_unit_internals.test_recoverAddressFromBalanceProof,
                                 -> test_recoverAddressFromBalanceProofUpdateMessage, 
                                 -> test_recoverAddressFromCooperativeSettleSignature,                     
                                 -> test_recoverAddressFromWithdrawMessage

 test_merkle_proof_one_lock -> computeMerkleRoot does not exist anymore, removed
 test_merkle_proof -->                       --- " ---
 test_merkle_proof_missing_byte ->           --- " ---
 test_signature_split ->                     --- " ---

```
