### PR TITLE
Fix locksroot & locked amount storage after balance proofs are updated

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -829,8 +829,6 @@ contract TokenNetwork is Utils {
         public
         returns (bytes32 key)
     {
-        require(channel_identifier != 0x0);
-        require(participant != 0x0);
         require(locksroot != 0x0);
 
         key = keccak256(abi.encodePacked(channel_identifier, participant, locksroot));

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -32,9 +32,15 @@ contract TokenNetwork is Utils {
     mapping (bytes32 => Channel) public channels;
 
     // We keep the unlock data in a separate mapping to allow channel data structures to be
-    // removed when settling. If there are locked transfers, we need to store data needed to
-    // unlock them at a later time. Key is the channel_identifier.
-    mapping(bytes32 => UnlockData) channel_identifier_to_unlock_data;
+    // removed when settling uncooperatively. If there are locked pending transfers, we need to
+    // store data needed to unlock them at a later time.
+    // The key is `keccak256(channel_identifier + participant_address + locksroot)`
+    // The value is the total amount of tokens locked in the pending transfers corresponding to
+    // the `locksroot`, that were sent by `participant_address` to his partner from the channel
+    // represented by the `channel_identifier`.
+    // Note that the assumption is that no two locksroots can be the same due to having different
+    // values for the secrethash of each lock, combined with different `expiration` values.
+    mapping(bytes32 => uint256) locksroot_identifier_to_locked_amount;
 
     struct Participant {
         // Total amount of token transferred to this smart contract through the
@@ -57,16 +63,6 @@ contract TokenNetwork is Utils {
         // Monotonically increasing counter of the off-chain transfers, provided along
         // with the balance_hash
         uint256 nonce;
-    }
-
-    struct UnlockData {
-        // Data provided when uncooperatively settling the channel, used to unlock locked
-        // transfers at a later point in time. The key is the merkle tree root of all pending
-        // transfers. The value is the total amount of tokens locked in the pending transfers.
-        // Note that we store all locksroots for both participants here, with the assumption that
-        // no two locksroots can be the same due to having different values for
-        // the secrethash of each lock.
-        mapping (bytes32 => uint256) locksroot_to_locked_amount;
     }
 
     struct Channel {
@@ -536,11 +532,13 @@ contract TokenNetwork is Utils {
         // Store balance data needed for `unlock`
         updateUnlockData(
             channel_identifier,
+            participant1,
             participant1_locked_amount,
             participant1_locksroot
         );
         updateUnlockData(
             channel_identifier,
+            participant2,
             participant2_locked_amount,
             participant2_locksroot
         );
@@ -654,11 +652,14 @@ contract TokenNetwork is Utils {
         );
     }
 
-    /// @notice Unlocks all locked off-chain transfers and sends the locked tokens to the
-    /// participant. Anyone can call unlock on behalf of a channel participant.
-    /// @param participant Address of the participant who will receive the unlocked tokens.
-    /// @param partner Address of the participant who owes the locked tokens.
-    /// @param merkle_tree_leaves The entire merkle tree of pending transfers.
+    /// @notice Unlocks all pending off-chain transfers from `partner` to `participant` and sends
+    /// the locked tokens corresponding to locks with secrets registered on-chain to the
+    /// `participant`. Locked tokens corresponding to locks where the secret was not revelead
+    /// on-chain will return to the `partner`. Anyone can call unlock.
+    /// @param participant Address who will receive the unlocked tokens.
+    /// @param partner Address who sent the pending transfers.
+    /// @param merkle_tree_leaves The entire merkle tree of pending transfers that `partner`
+    /// sent to `participant`.
     function unlock(
         address participant,
         address partner,
@@ -669,6 +670,7 @@ contract TokenNetwork is Utils {
         require(merkle_tree_leaves.length > 0);
 
         bytes32 channel_identifier;
+        bytes32 unlock_key;
         bytes32 computed_locksroot;
         uint256 unlocked_amount;
         uint256 locked_amount;
@@ -680,13 +682,15 @@ contract TokenNetwork is Utils {
         // corresponding to the locked transfers with secrets revealed on chain.
         (computed_locksroot, unlocked_amount) = getMerkleRootAndUnlockedAmount(merkle_tree_leaves);
 
-        // The partner must have a non-empty locksroot that must be the same as
+        // The partner must have a non-empty locksroot on-chain that must be the same as
         // the computed locksroot.
-        UnlockData storage unlock_data = channel_identifier_to_unlock_data[channel_identifier];
-
         // Get the amount of tokens that have been left in the contract, to account for the
-        // pending transfers.
-        locked_amount = unlock_data.locksroot_to_locked_amount[computed_locksroot];
+        // pending transfers `partner` -> `participant`.
+        unlock_key = getLocksrootIdentifier(channel_identifier, partner, computed_locksroot);
+        locked_amount = locksroot_identifier_to_locked_amount[unlock_key];
+
+        // If the locksroot does not exist, then the locked_amount will be 0. Transaction must fail
+        require(locked_amount > 0);
 
         // Make sure we don't transfer more tokens than previously reserved in the smart contract.
         unlocked_amount = min(unlocked_amount, locked_amount);
@@ -695,7 +699,7 @@ contract TokenNetwork is Utils {
         returned_tokens = locked_amount - unlocked_amount;
 
         // Remove partner's unlock data
-        delete unlock_data.locksroot_to_locked_amount[computed_locksroot];
+        delete locksroot_identifier_to_locked_amount[unlock_key];
 
         // Transfer the unlocked tokens to the participant. unlocked_amount can be 0
         if (unlocked_amount > 0) {
@@ -816,6 +820,22 @@ contract TokenNetwork is Utils {
         }
     }
 
+    function getLocksrootIdentifier(
+        bytes32 channel_identifier,
+        address participant,
+        bytes32 locksroot
+    )
+        pure
+        public
+        returns (bytes32 key)
+    {
+        require(channel_identifier != 0x0);
+        require(participant != 0x0);
+        require(locksroot != 0x0);
+
+        key = keccak256(abi.encodePacked(channel_identifier, participant, locksroot));
+    }
+
     function updateBalanceProofData(
         Channel storage channel,
         address participant,
@@ -836,6 +856,7 @@ contract TokenNetwork is Utils {
 
     function updateUnlockData(
         bytes32 channel_identifier,
+        address participant,
         uint256 locked_amount,
         bytes32 locksroot
     )
@@ -846,8 +867,8 @@ contract TokenNetwork is Utils {
             return;
         }
 
-        UnlockData storage unlock_data = channel_identifier_to_unlock_data[channel_identifier];
-        unlock_data.locksroot_to_locked_amount[locksroot] = locked_amount;
+        bytes32 key = getLocksrootIdentifier(channel_identifier, participant, locksroot);
+        locksroot_identifier_to_locked_amount[key] = locked_amount;
     }
 
     function getChannelAvailableDeposit(
@@ -999,7 +1020,8 @@ contract TokenNetwork is Utils {
     /// @dev Returns the locked amount of tokens for a given locksroot.
     /// @param participant1 Address of a channel participant.
     /// @param participant2 Address of the other channel participant.
-    /// @return The amount of tokens locked in the contract.
+    /// @return The amount of tokens that `participant1` has locked in the contract to account for
+    /// his pending transfers to `participant2`.
     function getParticipantLockedAmount(
         address participant1,
         address participant2,
@@ -1010,10 +1032,12 @@ contract TokenNetwork is Utils {
         returns (uint256)
     {
         bytes32 channel_identifier;
-        channel_identifier = getChannelIdentifier(participant1, participant2);
-        UnlockData storage unlock_data = channel_identifier_to_unlock_data[channel_identifier];
+        bytes32 unlock_key;
 
-        return unlock_data.locksroot_to_locked_amount[locksroot];
+        channel_identifier = getChannelIdentifier(participant1, participant2);
+        unlock_key = getLocksrootIdentifier(channel_identifier, participant1, locksroot);
+
+        return locksroot_identifier_to_locked_amount[unlock_key];
     }
 
     /*

--- a/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
+++ b/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
@@ -41,6 +41,7 @@ contract TokenNetworkInternalsTest is TokenNetwork {
 
     function updateUnlockDataPublic(
         bytes32 channel_identifier,
+        address participant,
         uint256 locked_amount,
         bytes32 locksroot
     )
@@ -48,6 +49,7 @@ contract TokenNetworkInternalsTest is TokenNetwork {
     {
        return updateUnlockData(
             channel_identifier,
+            participant,
             locked_amount,
             locksroot
         );

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -374,7 +374,7 @@ def settle_state_tests(token_network, cooperative_settle_state_tests):
         assert locked_amount1 == settlement.participant1_locked
         assert locked_amount1 == on_chain_settlement.participant1_locked
 
-        locked_amount2 = token_network.functions.getParticipantLockedAmount(A, B, values_B.locksroot).call()
+        locked_amount2 = token_network.functions.getParticipantLockedAmount(B, A, values_B.locksroot).call()
         assert locked_amount2 == settlement.participant2_locked
         assert locked_amount2 == on_chain_settlement.participant2_locked
 

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -986,6 +986,20 @@ def test_reverse_participants_unlock(
             pending_transfers_tree_B.packed_transfers,
         ).transact({'from': B})
 
+    with pytest.raises(TransactionFailed):
+        token_network.functions.unlock(
+            A,
+            A,
+            pending_transfers_tree_A.packed_transfers,
+        ).transact({'from': A})
+
+    with pytest.raises(TransactionFailed):
+        token_network.functions.unlock(
+            B,
+            B,
+            pending_transfers_tree_B.packed_transfers,
+        ).transact({'from': B})
+
     # Someone trying to unlock B's locksroot & locked amount on behalf of A MUST succeed
     token_network.functions.unlock(
         A,

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -96,10 +96,16 @@ def test_unlock_wrong_locksroot(
 
     with pytest.raises(TransactionFailed):
         token_network.functions.unlock(
-            A,
             B,
+            A,
             pending_transfers_tree_A_fake.packed_transfers,
         ).call()
+
+    token_network.functions.unlock(
+        B,
+        A,
+        pending_transfers_tree_A.packed_transfers,
+    ).call()
 
 
 def test_channel_unlock_bigger_locked_amount(
@@ -642,15 +648,15 @@ def test_unlock_fails_with_partial_merkle_proof(
         packed_transfers_tampered = get_packed_transfers(tuple(pending_transfers), types)
         with pytest.raises(TransactionFailed):
             token_network.functions.unlock(
-                A,
                 B,
+                A,
                 packed_transfers_tampered,
             ).transact({'from': A})
 
     # Unlock with full merkle tree does work
     token_network.functions.unlock(
-        A,
         B,
+        A,
         pending_transfers_tree.packed_transfers,
     ).transact({'from': A})
 
@@ -690,15 +696,15 @@ def test_unlock_tampered_merkle_proof_fails(
         packed_transfers_tampered = get_packed_transfers(tuple(pending_transfers), types)
         with pytest.raises(TransactionFailed):
             token_network.functions.unlock(
-                A,
                 B,
+                A,
                 packed_transfers_tampered,
             ).transact({'from': A})
 
     # Unlock with correct merkle tree does work
     token_network.functions.unlock(
-        A,
         B,
+        A,
         pending_transfers_tree.packed_transfers,
     ).transact({'from': A})
 
@@ -830,16 +836,16 @@ def test_unlock_twice_fails(
         settle_timeout,
     )
     token_network.functions.unlock(
-        A,
         B,
+        A,
         pending_transfers_tree_1.packed_transfers,
     ).transact({'from': A})
 
     # Calling unlock twice does not work
     with pytest.raises(TransactionFailed):
         token_network.functions.unlock(
-            A,
             B,
+            A,
             pending_transfers_tree_1.packed_transfers,
         ).transact({'from': A})
 


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden-contracts/issues/157

Previously, the `locksroot` was not linked to the participant address that it belonged to. This allowed any of the two participants to claim the locked token amounts corresponding to that `locksrooot`. Or event 1 participant to `unlock` both `locksroot`s from the two balance proofs.

This commit is simplifying the storage of the data needed to unlock the pending transfers and links the `locksroot` to a participant's address, by just using:

```
mapping(bytes32 => uint256) locksroot_identifier_to_locked_amount;
```
where the key is `keccak256(abi.encodePacked(channel_identifier, participant, locksroot));`
and the value is the `locked_amount`

The business logic is: `locksroot` is the merkle tree root of the pending transfers that `participant` has sent to his channel `partner`, where the channel is referenced by `channel_identifier`

This way, it does not matter who sends the `unlock` transaction, because the smart contract is aware of who should receive:
- the unlocked tokens (locks with secrets revealed on-chain) -> the `partner` will receive them
- the tokens corresponding to locks that don't have secrets revealed on-chain -> they will be returned to the `participant`

Notes:

```
function getParticipantLockedAmount(
        address participant1,
        address participant2,
        bytes32 locksroot
    )
```
will return `locksroot` of the merkle tree of pending transfers that `participant1` has sent to `participant2`

```
function unlock(
        address participant,
        address partner,
        bytes merkle_tree_leaves
    )
```
`merkle_tree_leaves` contains the locks data corresponding to the merkle tree of pending transfers that `partner` has sent to `participant`. 

 