### PR TITLE
Fix web3 dependency on missing eth-pm==0.1.0-alpha.17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
 rlp>=1.0.0
 coincurve>=7.1.0,<8.0
-web3>=4.2.1
+web3>=4.2.1,<4.4.0
 py-solc>=3.0.0


### PR DESCRIPTION
> Could not find a version that satisfies the requirement eth-pm==0.1.0-alpha.17

Seems `eth-pm==0.1.0-alpha.17` is missing. `web3 < 4.4.0` does not have an `eth-pm` dependency.

Same issue as https://github.com/ethereum/web3.py/issues/940