### PR TITLE
Add channel counter - fix replay attack on reopened channels

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -29,17 +29,22 @@ contract TokenNetwork is Utils {
 
     uint256 public deposit_limit;
 
-    // channel_identifier => Channel, where the channel identifier is the keccak256 of the
-    // addresses of the two participants
+    uint256 public channel_counter;
+
+    // channel_identifier => Channel
+    // channel identifier is the keccak256(keccak256(lexicographic order of participant addresses), channel_counter)
     mapping (bytes32 => Channel) public channels;
+
+    // This is needed to enforce one channel per pair of participants
+    // The key is keccak256(participant1_address, participant2_address)
+    mapping (bytes32 => uint256) public participants_hash_to_channel_counter;
 
     // We keep the unlock data in a separate mapping to allow channel data structures to be
     // removed when settling uncooperatively. If there are locked pending transfers, we need to
     // store data needed to unlock them at a later time.
-    // The key is `keccak256(channel_identifier + participant_address + locksroot)`
+    // The key is `keccak256(participants_hash + participant_address + locksroot)`
     // The value is the total amount of tokens locked in the pending transfers corresponding to
-    // the `locksroot`, that were sent by `participant_address` to his partner from the channel
-    // represented by the `channel_identifier`.
+    // the `locksroot`, that were sent by `participant_address` to his channel partner.
     // Note that the assumption is that no two locksroots can be the same due to having different
     // values for the secrethash of each lock, combined with different `expiration` values.
     mapping(bytes32 => uint256) locksroot_identifier_to_locked_amount;
@@ -116,8 +121,9 @@ contract TokenNetwork is Utils {
     event ChannelClosed(bytes32 indexed channel_identifier, address indexed closing_participant);
 
     event ChannelUnlocked(
-        bytes32 indexed channel_identifier,
         address indexed participant,
+        address indexed partner,
+        bytes32 indexed locksroot,
         uint256 unlocked_amount,
         uint256 returned_tokens
     );
@@ -205,6 +211,18 @@ contract TokenNetwork is Utils {
         public
         returns (bytes32)
     {
+        channel_counter += 1;
+
+        // Set the channel counter
+        bytes32 pair_hash = getParticipantsHash(participant1, participant2);
+
+        // There must only be one channel opened between two participants at any moment in time.
+        require(participants_hash_to_channel_counter[pair_hash] == 0);
+
+        participants_hash_to_channel_counter[pair_hash] = channel_counter;
+
+        // Get the channel identifier after setting the counter
+        // getChannelIdentifier uses the counter to calculate the identifier
         bytes32 channel_identifier = getChannelIdentifier(participant1, participant2);
         Channel storage channel = channels[channel_identifier];
 
@@ -487,8 +505,10 @@ contract TokenNetwork is Utils {
     )
         public
     {
+        bytes32 pair_hash;
         bytes32 channel_identifier;
 
+        pair_hash = getParticipantsHash(participant1, participant2);
         channel_identifier = getChannelIdentifier(participant1, participant2);
         Channel storage channel = channels[channel_identifier];
 
@@ -541,16 +561,20 @@ contract TokenNetwork is Utils {
         delete channel.participants[participant2];
         delete channels[channel_identifier];
 
+        // Remove the pair's channel counter
+        delete participants_hash_to_channel_counter[pair_hash];
+
+
         // Store balance data needed for `unlock`
         updateUnlockData(
-            channel_identifier,
             participant1,
+            participant2,
             participant1_locked_amount,
             participant1_locksroot
         );
         updateUnlockData(
-            channel_identifier,
             participant2,
+            participant1,
             participant2_locked_amount,
             participant2_locksroot
         );
@@ -698,7 +722,7 @@ contract TokenNetwork is Utils {
         // the computed locksroot.
         // Get the amount of tokens that have been left in the contract, to account for the
         // pending transfers `partner` -> `participant`.
-        unlock_key = getLocksrootIdentifier(channel_identifier, partner, computed_locksroot);
+        unlock_key = getLocksrootIdentifier(partner, participant, computed_locksroot);
         locked_amount = locksroot_identifier_to_locked_amount[unlock_key];
 
         // If the locksroot does not exist, then the locked_amount will be 0. Transaction must fail
@@ -723,7 +747,7 @@ contract TokenNetwork is Utils {
             require(token.transfer(partner, returned_tokens));
         }
 
-        emit ChannelUnlocked(channel_identifier, participant, unlocked_amount, returned_tokens);
+        emit ChannelUnlocked(participant, partner, computed_locksroot, unlocked_amount, returned_tokens);
 
         // Channel must be settled and channel data deleted
         require(channels[channel_identifier].state == 0);
@@ -813,6 +837,22 @@ contract TokenNetwork is Utils {
     /// @param partner Address of the channel partner.
     /// @return Unique identifier for the channel.
     function getChannelIdentifier(address participant, address partner)
+        view
+        public
+        returns (bytes32)
+    {
+        require(participant != 0x0);
+        require(partner != 0x0);
+
+        // Participant addresses must be different
+        require(participant != partner);
+
+        bytes32 pair_hash = getParticipantsHash(participant, partner);
+        uint256 counter = participants_hash_to_channel_counter[pair_hash];
+        return keccak256(abi.encodePacked(pair_hash, counter));
+    }
+
+    function getParticipantsHash(address participant, address partner)
         pure
         public
         returns (bytes32)
@@ -833,8 +873,8 @@ contract TokenNetwork is Utils {
     }
 
     function getLocksrootIdentifier(
-        bytes32 channel_identifier,
         address participant,
+        address partner,
         bytes32 locksroot
     )
         pure
@@ -843,7 +883,10 @@ contract TokenNetwork is Utils {
     {
         require(locksroot != 0x0);
 
-        key = keccak256(abi.encodePacked(channel_identifier, participant, locksroot));
+        bytes32 participants_hash = getParticipantsHash(participant, partner);
+
+        // Get the locksroot corresponding to the pending transfers participant -> partner
+        key = keccak256(abi.encodePacked(participants_hash, participant, locksroot));
     }
 
     function updateBalanceProofData(
@@ -865,8 +908,8 @@ contract TokenNetwork is Utils {
     }
 
     function updateUnlockData(
-        bytes32 channel_identifier,
         address participant,
+        address partner,
         uint256 locked_amount,
         bytes32 locksroot
     )
@@ -877,7 +920,7 @@ contract TokenNetwork is Utils {
             return;
         }
 
-        bytes32 key = getLocksrootIdentifier(channel_identifier, participant, locksroot);
+        bytes32 key = getLocksrootIdentifier(participant, partner, locksroot);
         locksroot_identifier_to_locked_amount[key] = locked_amount;
     }
 
@@ -1045,7 +1088,7 @@ contract TokenNetwork is Utils {
         bytes32 unlock_key;
 
         channel_identifier = getChannelIdentifier(participant1, participant2);
-        unlock_key = getLocksrootIdentifier(channel_identifier, participant1, locksroot);
+        unlock_key = getLocksrootIdentifier(participant1, participant2, locksroot);
 
         return locksroot_identifier_to_locked_amount[unlock_key];
     }

--- a/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
+++ b/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
@@ -40,16 +40,16 @@ contract TokenNetworkInternalsTest is TokenNetwork {
     }
 
     function updateUnlockDataPublic(
-        bytes32 channel_identifier,
         address participant,
+        address partner,
         uint256 locked_amount,
         bytes32 locksroot
     )
         public
     {
        return updateUnlockData(
-            channel_identifier,
             participant,
+            partner,
             locked_amount,
             locksroot
         );

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -247,7 +247,7 @@ def reveal_secrets(web3, secret_registry_contract):
 
 
 @pytest.fixture()
-def cooperative_settle_state_tests(custom_token, token_network):
+def common_settle_state_tests(custom_token, token_network):
     def get(
             A,
             balance_A,
@@ -341,7 +341,7 @@ def updateBalanceProof_state_tests(token_network, get_block):
 
 
 @pytest.fixture()
-def settle_state_tests(token_network, cooperative_settle_state_tests):
+def settle_state_tests(token_network, common_settle_state_tests):
     def get(
             A,
             values_A,
@@ -356,7 +356,7 @@ def settle_state_tests(token_network, cooperative_settle_state_tests):
         # Calculate how much A and B receive according to onchain computation
         on_chain_settlement = get_onchain_settlement_amounts(values_A, values_B)
 
-        cooperative_settle_state_tests(
+        common_settle_state_tests(
             A,
             settlement.participant1_balance,
             B,
@@ -365,7 +365,7 @@ def settle_state_tests(token_network, cooperative_settle_state_tests):
             pre_account_balance_B,
             pre_balance_contract
         )
-        cooperative_settle_state_tests(
+        common_settle_state_tests(
             A,
             on_chain_settlement.participant1_balance,
             B,

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -266,6 +266,10 @@ def cooperative_settle_state_tests(custom_token, token_network):
         assert balance_contract == pre_balance_contract - balance_A - balance_B
 
         # Make sure channel data has been removed
+        assert token_network.functions.participants_hash_to_channel_counter(
+            get_participants_hash(A, B)
+        ).call() == 0
+
         (_, settle_block_number, state) = token_network.functions.getChannelInfo(A, B).call()
         assert settle_block_number == 0  # settle_block_number
         assert state == CHANNEL_STATE_NONEXISTENT  # state
@@ -378,10 +382,6 @@ def settle_state_tests(token_network, cooperative_settle_state_tests):
         locked_amount2 = token_network.functions.getParticipantLockedAmount(B, A, values_B.locksroot).call()
         assert locked_amount2 == settlement.participant2_locked
         assert locked_amount2 == on_chain_settlement.participant2_locked
-
-        assert token_network.functions.participants_hash_to_channel_counter(
-            get_participants_hash(A, B)
-        ).call() == 0
 
     return get
 

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -19,6 +19,7 @@ from raiden_contracts.tests.utils import (
     get_settlement_amounts,
     get_onchain_settlement_amounts,
     ChannelValues,
+    get_participants_hash
 )
 from .token_network import *  # flake8: noqa
 from .secret_registry import *  # flake8: noqa
@@ -377,6 +378,10 @@ def settle_state_tests(token_network, cooperative_settle_state_tests):
         locked_amount2 = token_network.functions.getParticipantLockedAmount(B, A, values_B.locksroot).call()
         assert locked_amount2 == settlement.participant2_locked
         assert locked_amount2 == on_chain_settlement.participant2_locked
+
+        assert token_network.functions.participants_hash_to_channel_counter(
+            get_participants_hash(A, B)
+        ).call() == 0
 
     return get
 

--- a/raiden_contracts/tests/test_channel_close.py
+++ b/raiden_contracts/tests/test_channel_close.py
@@ -11,6 +11,8 @@ from raiden_contracts.constants import (
 )
 from raiden_contracts.utils.events import check_channel_closed
 from .fixtures.config import fake_bytes, fake_hex
+from raiden_contracts.tests.utils import ChannelValues
+from raiden_contracts.utils.merkle import EMPTY_MERKLE_ROOT
 
 
 def test_close_nonexistent_channel(
@@ -310,6 +312,61 @@ def test_close_channel_event_no_offchain_transfers(
 
     ev_handler.add(txn_hash, EVENT_CHANNEL_CLOSED, check_channel_closed(channel_identifier, A))
     ev_handler.check()
+
+
+def test_close_replay_reopened_channel(
+        web3,
+        get_accounts,
+        token_network,
+        create_channel,
+        channel_deposit,
+        create_balance_proof,
+):
+    (A, B) = get_accounts(2)
+    nonce = 3
+    values_A = ChannelValues(
+        deposit=10,
+        transferred=0,
+        locked=0,
+        locksroot=EMPTY_MERKLE_ROOT,
+    )
+    values_B = ChannelValues(
+        deposit=20,
+        transferred=15,
+        locked=0,
+        locksroot=EMPTY_MERKLE_ROOT,
+    )
+    channel_identifier1 = create_channel(A, B)[0]
+    channel_deposit(B, values_B.deposit, A)
+
+    balance_proof_B = create_balance_proof(
+        channel_identifier1,
+        B,
+        values_B.transferred,
+        values_B.locked,
+        nonce,
+        values_B.locksroot,
+    )
+    token_network.functions.closeChannel(B, *balance_proof_B).transact({'from': A})
+    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN)
+    token_network.functions.settleChannel(
+        A,
+        values_A.transferred,
+        values_A.locked,
+        values_A.locksroot,
+        B,
+        values_B.transferred,
+        values_B.locked,
+        values_B.locksroot,
+    ).transact({'from': A})
+
+    # Reopen the channel and make sure we cannot use the old balance proof
+    channel_identifier2 = create_channel(A, B)[0]
+    channel_deposit(B, values_B.deposit, A)
+
+    assert channel_identifier1 != channel_identifier2
+    with pytest.raises(TransactionFailed):
+        token_network.functions.closeChannel(B, *balance_proof_B).transact({'from': A})
 
 
 def test_close_channel_event(

--- a/raiden_contracts/tests/test_channel_close.py
+++ b/raiden_contracts/tests/test_channel_close.py
@@ -368,6 +368,17 @@ def test_close_replay_reopened_channel(
     with pytest.raises(TransactionFailed):
         token_network.functions.closeChannel(B, *balance_proof_B).transact({'from': A})
 
+    # Balance proof with correct channel_identifier must work
+    balance_proof_B2 = create_balance_proof(
+        channel_identifier2,
+        B,
+        values_B.transferred,
+        values_B.locked,
+        nonce,
+        values_B.locksroot,
+    )
+    token_network.functions.closeChannel(B, *balance_proof_B2).transact({'from': A})
+
 
 def test_close_channel_event(
         get_accounts,

--- a/raiden_contracts/tests/test_channel_cooperative_settle.py
+++ b/raiden_contracts/tests/test_channel_cooperative_settle.py
@@ -547,6 +547,24 @@ def test_cooperative_close_replay_reopened_channel(
             signature_A,
         ).transact({'from': B})
 
+    # Signed message with the correct channel identifier must work
+    (signature_A2, signature_B2) = create_cooperative_settle_signatures(
+        [A, B],
+        channel_identifier2,
+        B,
+        balance_B,
+        A,
+        balance_A,
+    )
+    token_network.functions.cooperativeSettle(
+        B,
+        balance_B,
+        A,
+        balance_A,
+        signature_B2,
+        signature_A2,
+    ).transact({'from': B})
+
 
 def test_cooperative_settle_channel_event(
         get_accounts,

--- a/raiden_contracts/tests/test_channel_cooperative_settle.py
+++ b/raiden_contracts/tests/test_channel_cooperative_settle.py
@@ -11,7 +11,7 @@ def test_cooperative_settle_channel_call(
         create_channel_and_deposit,
         get_accounts,
         create_cooperative_settle_signatures,
-        cooperative_settle_state_tests,
+        common_settle_state_tests,
 ):
     (A, B, C) = get_accounts(3)
     deposit_A = 20
@@ -182,7 +182,7 @@ def test_cooperative_settle_channel_0(
         create_channel_and_deposit,
         get_accounts,
         create_cooperative_settle_signatures,
-        cooperative_settle_state_tests,
+        common_settle_state_tests,
 ):
     (A, B, C) = get_accounts(3)
     deposit_A = 20
@@ -214,7 +214,7 @@ def test_cooperative_settle_channel_0(
         signature_B,
     ).transact({'from': C})
 
-    cooperative_settle_state_tests(
+    common_settle_state_tests(
         A,
         balance_A,
         B,
@@ -231,7 +231,7 @@ def test_cooperative_settle_channel_00(
         create_channel_and_deposit,
         get_accounts,
         create_cooperative_settle_signatures,
-        cooperative_settle_state_tests,
+        common_settle_state_tests,
 ):
     (A, B, C) = get_accounts(3)
     deposit_A = 0
@@ -263,7 +263,7 @@ def test_cooperative_settle_channel_00(
         signature_B,
     ).transact({'from': C})
 
-    cooperative_settle_state_tests(
+    common_settle_state_tests(
         A,
         balance_A,
         B,
@@ -280,7 +280,7 @@ def test_cooperative_settle_channel_state(
         create_channel_and_deposit,
         get_accounts,
         create_cooperative_settle_signatures,
-        cooperative_settle_state_tests,
+        common_settle_state_tests,
 ):
     (A, B, C) = get_accounts(3)
     deposit_A = 20
@@ -313,7 +313,7 @@ def test_cooperative_settle_channel_state(
         signature_B,
     ).transact({'from': C})
 
-    cooperative_settle_state_tests(
+    common_settle_state_tests(
         A,
         balance_A,
         B,
@@ -331,7 +331,7 @@ def test_cooperative_settle_channel_state_withdraw(
         withdraw_channel,
         get_accounts,
         create_cooperative_settle_signatures,
-        cooperative_settle_state_tests,
+        common_settle_state_tests,
 ):
     (A, B, C) = get_accounts(3)
     deposit_A = 20
@@ -368,7 +368,7 @@ def test_cooperative_settle_channel_state_withdraw(
         signature_B,
     ).transact({'from': C})
 
-    cooperative_settle_state_tests(
+    common_settle_state_tests(
         A,
         balance_A,
         B,
@@ -386,7 +386,7 @@ def test_cooperative_settle_channel_bigger_withdraw(
         withdraw_channel,
         get_accounts,
         create_cooperative_settle_signatures,
-        cooperative_settle_state_tests,
+        common_settle_state_tests,
 ):
     (A, B, C) = get_accounts(3)
     deposit_A = 20
@@ -427,7 +427,7 @@ def test_cooperative_settle_channel_wrong_balances(
         create_channel_and_deposit,
         get_accounts,
         create_cooperative_settle_signatures,
-        cooperative_settle_state_tests,
+        common_settle_state_tests,
 ):
     (A, B, C) = get_accounts(3)
     deposit_A = 20
@@ -504,7 +504,6 @@ def test_cooperative_close_replay_reopened_channel(
         create_cooperative_settle_signatures,
 ):
     (A, B) = get_accounts(2)
-    nonce = 3
     deposit_A = 15
     deposit_B = 10
     balance_A = 2
@@ -523,7 +522,7 @@ def test_cooperative_close_replay_reopened_channel(
         balance_A,
     )
 
-    txn_hash = token_network.functions.cooperativeSettle(
+    token_network.functions.cooperativeSettle(
         B,
         balance_B,
         A,
@@ -539,7 +538,7 @@ def test_cooperative_close_replay_reopened_channel(
 
     assert channel_identifier1 != channel_identifier2
     with pytest.raises(TransactionFailed):
-        txn_hash = token_network.functions.cooperativeSettle(
+        token_network.functions.cooperativeSettle(
             B,
             balance_B,
             A,

--- a/raiden_contracts/tests/test_channel_open.py
+++ b/raiden_contracts/tests/test_channel_open.py
@@ -174,9 +174,8 @@ def test_reopen_channel(
     token_network.functions.openChannel(A, B, settle_timeout).transact()
     channel_identifier1 = token_network.functions.getChannelIdentifier(A, B).call()
     channel_counter1 = token_network.functions.participants_hash_to_channel_counter(
-        get_participants_hash(A, B)
+        get_participants_hash(A, B),
     ).call()
-
 
     # Opening twice fails
     with pytest.raises(TransactionFailed):
@@ -214,7 +213,7 @@ def test_reopen_channel(
     token_network.functions.openChannel(A, B, settle_timeout).transact()
     assert token_network.functions.getChannelIdentifier(A, B).call() != channel_identifier1
     assert token_network.functions.participants_hash_to_channel_counter(
-        get_participants_hash(A, B)
+        get_participants_hash(A, B),
     ).call() == channel_counter1 + 1
 
     (_, settle_block_number, state) = token_network.functions.getChannelInfo(A, B).call()

--- a/raiden_contracts/tests/test_channel_open.py
+++ b/raiden_contracts/tests/test_channel_open.py
@@ -10,6 +10,7 @@ from raiden_contracts.constants import (
 from raiden_contracts.utils.events import check_channel_opened
 from .fixtures.config import EMPTY_ADDRESS, FAKE_ADDRESS, fake_bytes
 from web3.exceptions import ValidationError
+from .utils import get_channel_identifier, get_participants_hash
 
 
 def test_open_channel_call(token_network, get_accounts):
@@ -53,6 +54,59 @@ def test_max_1_channel(token_network, get_accounts, create_channel):
         token_network.functions.openChannel(A, B, TEST_SETTLE_TIMEOUT_MIN).transact()
     with pytest.raises(TransactionFailed):
         token_network.functions.openChannel(B, A, TEST_SETTLE_TIMEOUT_MIN).transact()
+
+
+def test_participants_hash(token_network, get_accounts):
+    (A, B) = get_accounts(2)
+
+    AB_hash = get_participants_hash(A, B)
+    assert token_network.functions.getParticipantsHash(A, B).call() == AB_hash
+
+
+def test_counter(token_network, get_accounts, create_channel):
+    (A, B, C, D) = get_accounts(4)
+
+    AB_hash = token_network.functions.getParticipantsHash(A, B).call()
+    BC_hash = token_network.functions.getParticipantsHash(B, C).call()
+    CD_hash = token_network.functions.getParticipantsHash(C, D).call()
+
+    assert token_network.functions.channel_counter().call() == 0
+    assert token_network.functions.participants_hash_to_channel_counter(AB_hash).call() == 0
+    assert token_network.functions.participants_hash_to_channel_counter(BC_hash).call() == 0
+    assert token_network.functions.participants_hash_to_channel_counter(CD_hash).call() == 0
+
+    channel_identifier_no_channel = get_channel_identifier(A, B, 0)
+    assert token_network.functions.getChannelIdentifier(
+        A,
+        B,
+    ).call() == channel_identifier_no_channel
+    create_channel(A, B)
+    channel_identifier = get_channel_identifier(A, B, 1)
+    assert token_network.functions.channel_counter().call() == 1
+    assert token_network.functions.participants_hash_to_channel_counter(AB_hash).call() == 1
+    assert token_network.functions.getChannelIdentifier(A, B).call() == channel_identifier
+
+    channel_identifier_no_channel = get_channel_identifier(B, C, 0)
+    assert token_network.functions.getChannelIdentifier(
+        B,
+        C,
+    ).call() == channel_identifier_no_channel
+    create_channel(B, C)
+    channel_identifier = get_channel_identifier(B, C, 2)
+    assert token_network.functions.channel_counter().call() == 2
+    assert token_network.functions.participants_hash_to_channel_counter(BC_hash).call() == 2
+    assert token_network.functions.getChannelIdentifier(B, C).call() == channel_identifier
+
+    channel_identifier_no_channel = get_channel_identifier(C, D, 0)
+    assert token_network.functions.getChannelIdentifier(
+        C,
+        D,
+    ).call() == channel_identifier_no_channel
+    create_channel(C, D)
+    channel_identifier = get_channel_identifier(C, D, 3)
+    assert token_network.functions.channel_counter().call() == 3
+    assert token_network.functions.participants_hash_to_channel_counter(CD_hash).call() == 3
+    assert token_network.functions.getChannelIdentifier(C, D).call() == channel_identifier
 
 
 def test_open_channel_state(token_network, get_accounts):

--- a/raiden_contracts/tests/test_channel_open.py
+++ b/raiden_contracts/tests/test_channel_open.py
@@ -209,7 +209,7 @@ def test_reopen_channel(
         locksroot,
     ).transact({'from': A})
 
-    # Reopening the channel should work if channel is settled
+    # Reopening the channel should work iff channel is settled
     token_network.functions.openChannel(A, B, settle_timeout).transact()
     assert token_network.functions.getChannelIdentifier(A, B).call() != channel_identifier1
     assert token_network.functions.participants_hash_to_channel_counter(

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -872,7 +872,7 @@ def test_channel_unlock_with_a_large_expiration(
         web3,
         [1, 3, 5],
         [2, 4],
-        settle_timeout + 100
+        settle_timeout + 100,
     )
     values_B.locksroot = pending_transfers_tree.merkle_root
     values_B.locked = get_locked_amount(pending_transfers_tree.transfers)
@@ -1028,7 +1028,7 @@ def test_unlock_channel_event(
     )
 
     # Create channel and deposit
-    channel_identifier = create_channel(A, B, settle_timeout)[0]
+    create_channel(A, B, settle_timeout)[0]
     channel_deposit(A, values_A.deposit, B)
     channel_deposit(B, values_B.deposit, A)
 
@@ -1037,7 +1037,7 @@ def test_unlock_channel_event(
         web3,
         [1, 3, 5],
         [2, 4],
-        settle_timeout + 100
+        settle_timeout + 100,
     )
     values_B.locksroot = pending_transfers_tree.merkle_root
     values_B.locked = get_locked_amount(pending_transfers_tree.transfers)

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -53,15 +53,12 @@ def test_merkle_root(
         get_accounts,
         token_network_test,
         secret_registry_contract,
+        reveal_secrets,
 ):
     (A, B) = get_accounts(2)
     pending_transfers_tree = get_pending_transfers_tree(web3, [1, 3, 5], [2, 8, 3])
 
-    for lock in pending_transfers_tree.unlockable:
-        secret_registry_contract.functions.registerSecret(lock[3]).transact({'from': A})
-        assert secret_registry_contract.functions.getSecretRevealBlockHeight(
-            lock[2],
-        ).call() == web3.eth.blockNumber
+    reveal_secrets(A, pending_transfers_tree.unlockable)
 
     (locksroot, unlocked_amount) = token_network_test.functions.getMerkleRootAndUnlockedAmountPublic(  # noqa
         pending_transfers_tree.packed_transfers,
@@ -284,6 +281,7 @@ def test_channel_unlock(
         channel_deposit,
         get_accounts,
         close_and_update_channel,
+        reveal_secrets,
         event_handler,
 ):
     (A, B) = get_accounts(2)
@@ -311,11 +309,7 @@ def test_channel_unlock(
     values_B.locked = get_locked_amount(pending_transfers_tree.transfers)
 
     # Reveal secrets before settlement window ends
-    for lock in pending_transfers_tree.unlockable:
-        secret_registry_contract.functions.registerSecret(lock[3]).transact({'from': A})
-        assert secret_registry_contract.functions.getSecretRevealBlockHeight(
-            lock[2],
-        ).call() == web3.eth.blockNumber
+    reveal_secrets(A, pending_transfers_tree.unlockable)
 
     close_and_update_channel(
         A,
@@ -449,6 +443,7 @@ def test_channel_unlock_expired_lock_refunds(
         create_channel,
         channel_deposit,
         get_accounts,
+        reveal_secrets,
         close_and_update_channel,
 ):
     (A, B) = get_accounts(2)
@@ -486,11 +481,7 @@ def test_channel_unlock_expired_lock_refunds(
     web3.testing.mine(max_lock_expiration)
 
     # Secrets are revealed before settlement window, but after expiration
-    for lock in pending_transfers_tree.unlockable:
-        secret_registry_contract.functions.registerSecret(lock[3]).transact({'from': A})
-        assert secret_registry_contract.functions.getSecretRevealBlockHeight(
-            lock[2],
-        ).call() == web3.eth.blockNumber
+    reveal_secrets(A, pending_transfers_tree.unlockable)
 
     close_and_update_channel(
         A,
@@ -533,6 +524,7 @@ def test_channel_unlock_before_settlement_fails(
         channel_deposit,
         get_accounts,
         close_and_update_channel,
+        reveal_secrets,
 ):
     (A, B) = get_accounts(2)
     settle_timeout = 8
@@ -559,11 +551,7 @@ def test_channel_unlock_before_settlement_fails(
     values_B.locked = get_locked_amount(pending_transfers_tree.transfers)
 
     # Reveal secrets before settlement window ends
-    for lock in pending_transfers_tree.unlockable:
-        secret_registry_contract.functions.registerSecret(lock[3]).transact({'from': A})
-        assert secret_registry_contract.functions.getSecretRevealBlockHeight(
-            lock[2],
-        ).call() == web3.eth.blockNumber
+    reveal_secrets(A, pending_transfers_tree.unlockable)
 
     close_and_update_channel(
         A,
@@ -748,11 +736,7 @@ def test_channel_unlock_both_participants(
     values_B.locked = get_locked_amount(pending_transfers_tree_B.transfers)
 
     # Reveal B's secrets before settlement window ends
-    for lock in pending_transfers_tree_B.unlockable:
-        secret_registry_contract.functions.registerSecret(lock[3]).transact({'from': B})
-        assert secret_registry_contract.functions.getSecretRevealBlockHeight(
-            lock[2],
-        ).call() == web3.eth.blockNumber
+    reveal_secrets(B, pending_transfers_tree_B.unlockable)
 
     close_and_update_channel(
         A,
@@ -862,6 +846,7 @@ def test_channel_unlock_with_a_large_expiration(
         channel_deposit,
         get_accounts,
         close_and_update_channel,
+        reveal_secrets,
 ):
     (A, B) = get_accounts(2)
     settle_timeout = 8
@@ -893,11 +878,7 @@ def test_channel_unlock_with_a_large_expiration(
     values_B.locked = get_locked_amount(pending_transfers_tree.transfers)
 
     # Reveal secrets before settlement window ends
-    for lock in pending_transfers_tree.unlockable:
-        secret_registry_contract.functions.registerSecret(lock[3]).transact({'from': A})
-        assert secret_registry_contract.functions.getSecretRevealBlockHeight(
-            lock[2],
-        ).call() == web3.eth.blockNumber
+    reveal_secrets(A, pending_transfers_tree.unlockable)
 
     close_and_update_channel(
         A,
@@ -1029,6 +1010,7 @@ def test_unlock_channel_event(
         channel_deposit,
         get_accounts,
         close_and_update_channel,
+        reveal_secrets,
         event_handler,
 ):
     (A, B) = get_accounts(2)
@@ -1061,11 +1043,7 @@ def test_unlock_channel_event(
     values_B.locked = get_locked_amount(pending_transfers_tree.transfers)
 
     # Reveal secrets before settlement window ends
-    for lock in pending_transfers_tree.unlockable:
-        secret_registry_contract.functions.registerSecret(lock[3]).transact({'from': A})
-        assert secret_registry_contract.functions.getSecretRevealBlockHeight(
-            lock[2],
-        ).call() == web3.eth.blockNumber
+    reveal_secrets(A, pending_transfers_tree.unlockable)
 
     close_and_update_channel(
         A,

--- a/raiden_contracts/tests/test_channel_update_transfer.py
+++ b/raiden_contracts/tests/test_channel_update_transfer.py
@@ -918,6 +918,28 @@ def test_update_replay_reopened_channel(
             balance_proof_update_signature_A,
         ).transact({'from': A})
 
+    # Correct channel_identifier must work
+    balance_proof_B2 = create_balance_proof(
+        channel_identifier2,
+        B,
+        values_B.transferred,
+        values_B.locked,
+        nonce_B,
+        values_B.locksroot,
+    )
+    balance_proof_update_signature_A2 = create_balance_proof_update_signature(
+        A,
+        channel_identifier2,
+        *balance_proof_B2,
+    )
+
+    token_network.functions.updateNonClosingBalanceProof(
+        B,
+        A,
+        *balance_proof_B2,
+        balance_proof_update_signature_A2,
+    ).transact({'from': A})
+
 
 def test_update_channel_event(
         get_accounts,

--- a/raiden_contracts/tests/test_channel_update_transfer.py
+++ b/raiden_contracts/tests/test_channel_update_transfer.py
@@ -11,6 +11,8 @@ from raiden_contracts.constants import (
 )
 from raiden_contracts.utils.events import check_transfer_updated
 from .fixtures.config import fake_bytes, EMPTY_ADDRESS
+from raiden_contracts.tests.utils import ChannelValues
+from raiden_contracts.utils.merkle import EMPTY_MERKLE_ROOT
 
 
 def test_update_call(
@@ -826,6 +828,95 @@ def test_updateNonClosingBalanceProof_signature_on_invalid_arguments(
         *balance_proof_valid,
         balance_proof_update_signature,
     ).transact({'from': B})
+
+
+def test_update_replay_reopened_channel(
+        web3,
+        get_accounts,
+        token_network,
+        create_channel,
+        channel_deposit,
+        create_balance_proof,
+        create_balance_proof_update_signature,
+):
+    (A, B) = get_accounts(2)
+    nonce_A = 0
+    nonce_B = 5
+    values_A = ChannelValues(
+        deposit=10,
+        transferred=0,
+        locked=0,
+        locksroot=EMPTY_MERKLE_ROOT,
+    )
+    values_B = ChannelValues(
+        deposit=20,
+        transferred=15,
+        locked=0,
+        locksroot=EMPTY_MERKLE_ROOT,
+    )
+
+    channel_identifier1 = create_channel(A, B)[0]
+    channel_deposit(B, values_B.deposit, A)
+    balance_proof_B = create_balance_proof(
+        channel_identifier1,
+        B,
+        values_B.transferred,
+        values_B.locked,
+        nonce_B,
+        values_B.locksroot,
+    )
+    balance_proof_update_signature_A = create_balance_proof_update_signature(
+        A,
+        channel_identifier1,
+        *balance_proof_B,
+    )
+
+    token_network.functions.closeChannel(
+        A,
+        fake_bytes(32),
+        nonce_A,
+        fake_bytes(32),
+        fake_bytes(64),
+    ).transact({'from': B})
+
+    token_network.functions.updateNonClosingBalanceProof(
+        B,
+        A,
+        *balance_proof_B,
+        balance_proof_update_signature_A,
+    ).transact({'from': A})
+
+    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN)
+    token_network.functions.settleChannel(
+        A,
+        values_A.transferred,
+        values_A.locked,
+        values_A.locksroot,
+        B,
+        values_B.transferred,
+        values_B.locked,
+        values_B.locksroot,
+    ).transact({'from': A})
+
+    # Reopen the channel and make sure we cannot use the old balance proof
+    channel_identifier2 = create_channel(A, B)[0]
+    channel_deposit(B, values_B.deposit, A)
+    token_network.functions.closeChannel(
+        A,
+        fake_bytes(32),
+        nonce_A,
+        fake_bytes(32),
+        fake_bytes(64),
+    ).transact({'from': B})
+
+    assert channel_identifier1 != channel_identifier2
+    with pytest.raises(TransactionFailed):
+        token_network.functions.updateNonClosingBalanceProof(
+            B,
+            A,
+            *balance_proof_B,
+            balance_proof_update_signature_A,
+        ).transact({'from': A})
 
 
 def test_update_channel_event(

--- a/raiden_contracts/tests/test_channel_withdraw.py
+++ b/raiden_contracts/tests/test_channel_withdraw.py
@@ -499,6 +499,21 @@ def test_withdraw_replay_reopened_channel(
             signature_B_for_A,
         ).transact({'from': A})
 
+    # Signed message with correct channel_identifier must work
+    (signature_A_for_A2, signature_B_for_A2) = create_withdraw_signatures(
+        [A, B],
+        channel_identifier2,
+        A,
+        withdraw_A,
+    )
+    token_network.functions.setTotalWithdraw(
+        A,
+        withdraw_A,
+        B,
+        signature_A_for_A2,
+        signature_B_for_A2,
+    ).transact({'from': A})
+
 
 def test_withdraw_event(
         token_network,

--- a/raiden_contracts/tests/test_monitoring_service.py
+++ b/raiden_contracts/tests/test_monitoring_service.py
@@ -37,6 +37,7 @@ def create_reward_proof(token_network, get_private_key):
     return get
 
 
+@pytest.mark.skip(reason='Monitoring Service implementation delayed to another milestone')
 def test_msc_happy_path(
     token_network,
     monitoring_service_external,

--- a/raiden_contracts/tests/utils.py
+++ b/raiden_contracts/tests/utils.py
@@ -5,7 +5,8 @@ from collections import namedtuple
 from web3 import Web3
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN
 from raiden_contracts.utils.merkle import compute_merkle_tree, get_merkle_root
-from eth_abi import encode_abi
+from eth_abi import encode_abi, encode_single
+from eth_utils import keccak, to_canonical_address
 
 
 MAX_UINT256 = 2 ** 256 - 1
@@ -314,3 +315,15 @@ def get_unlocked_amount(secret_registry, merkle_tree_leaves):
 
 def get_locked_amount(pending_transfers):
     return reduce((lambda x, y: x + y[1]), pending_transfers, 0)
+
+
+def get_channel_identifier(A, B, counter):
+    pair_hash = get_participants_hash(A, B)
+    counter = encode_single('uint256', counter)
+    return keccak(pair_hash + counter)
+
+
+def get_participants_hash(A, B):
+    A = to_canonical_address(A)
+    B = to_canonical_address(B)
+    return keccak(A + B) if A < B else keccak(B + A)

--- a/raiden_contracts/tests/utils.py
+++ b/raiden_contracts/tests/utils.py
@@ -120,7 +120,6 @@ def get_pending_transfers_tree(
 
     merkle_tree = compute_merkle_tree(hashed_pending_transfers)
     merkle_root = get_merkle_root(merkle_tree)
-    merkle_root = '0x' + merkle_root.hex()
     packed_transfers = get_packed_transfers(pending_transfers, types)
     locked_amount = get_locked_amount(pending_transfers)
 

--- a/raiden_contracts/utils/events.py
+++ b/raiden_contracts/utils/events.py
@@ -58,10 +58,11 @@ def check_channel_closed(channel_identifier, closing_participant):
     return get
 
 
-def check_channel_unlocked(channel_identifier, participant, unlocked_amount, returned_tokens):
+def check_channel_unlocked(participant, partner, locksroot, unlocked_amount, returned_tokens):
     def get(event):
-        assert event['args']['channel_identifier'] == channel_identifier
         assert event['args']['participant'] == participant
+        assert event['args']['partner'] == partner
+        assert event['args']['locksroot'] == locksroot
         assert event['args']['unlocked_amount'] == unlocked_amount
         assert event['args']['returned_tokens'] == returned_tokens
     return get


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden-contracts/issues/141

The issue described a replay attack possible after reopening a settled channel. Old balance proofs could have been used to cheat, because there was way to differentiate between the old and new signed messages.

Two options were discussed:
1. Adding the block number at which the channel was opened in the signed messages
2. Making `channel_identifier` unique with either adding the `open_block_number` or an increasing nonce (counter)

**Option 1:**
- saving `open_block_number` in the channel state
- adding `open_block_number` to all signed messages
- adding `open_block_number` to all channel events
-> this also means changes to the Raiden client

**Option 2** (suggested by @hackaugusto):
- add a global channel counter that increases after each channel creation
- `channel_identifier` must include the participant addresses and the channel counter
-> minimal changes in the Raiden client

Tried both options, Option 2 seems the best one (minimal changes to `TokenNetwork` ABI). Raiden client changes are minimal. Gas costs are similar.

**Implementation:**
- added `uint256 public channel_counter;` - global counter for all channels, starts with `1`
- `channel_identifier` is `keccak256(keccak256(lexicographic order of participant addresses), channel_counter)`
- added a mapping `mapping (bytes32 => uint256) public participants_hash_to_channel_counter;` to check if a channel exists. 
- remove `participants_hash_to_channel_counter` entry for a channel after settlement
- `ChannelUnlocked` event - remove `channel_identifier`, add `locksroot` to arguments, because `channel_identifier` is invalid after settlement

