### PR TITLE
Update web3 dependency to >=4.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
 rlp>=1.0.0
 coincurve>=7.1.0,<8.0
-web3>=4.2.1,<4.4.0
+web3>=4.4.1
 py-solc>=3.0.0


### PR DESCRIPTION
Version `4.4.0` triggered `Could not find a version that satisfies the requirement eth-pm==0.1.0-alpha.17`. This was fixed in `4.4.1`, as suggested in https://github.com/raiden-network/raiden-contracts/pull/161#issuecomment-401444925