### PR TITLE
Prevent needless recompilation of precompiled contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ venv/
 # editors
 .vscode/
 
+raiden_contracts/data/contracts.json.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,34 @@
-dist: trusty
+dist: xenial
 sudo: true
-language: generic
+language: python
+python:
+  - '3.6'
 
+env:
+  global:
+    - TEST_TYPE=raiden_contracts
+    - SOLC_URL='https://github.com/ethereum/solidity/releases/download/v0.4.23/solc-static-linux'
+    - SOLC_VERSION='v0.4.23'
 
-jobs:
-  include:
-    - language: python
-      python: '3.5'
-      env:
-        - TEST_TYPE=raiden_contracts
-        - SOLC_URL='https://github.com/ethereum/solidity/releases/download/v0.4.23/solc-static-linux'
-        - SOLC_VERSION='v0.4.23'
+cache:
+  pip: true
+  directories:
+    - $HOME/.cache/pip
 
-      cache:
-        pip: true
-        directories:
-          - $HOME/.cache/pip
+before_install:
+  - mkdir -p $HOME/.bin
+  - export PATH=$PATH:$HOME/.bin
+  - ./.travis/download_solc.sh
 
-      before_install:
-            - mkdir -p $HOME/.bin
-            - export PATH=$PATH:$HOME/.bin
-            - ./.travis/download_solc.sh
+install:
+  - pip install -U pip wheel coveralls "coverage<4.4"
+  - pip install pytest-travis-fold
+  - pip install -r requirements-dev.txt
+  - pip install pytest-xdist pytest-sugar
+  - python setup.py compile_contracts
 
-      install:
-        - pip install -U pip wheel coveralls "coverage<4.4"
-        - pip install pytest-travis-fold
-        - pip install -r requirements-dev.txt
-        - pip install pytest-xdist pytest-sugar
-        - python setup.py compile_contracts
+before_script:
+  - flake8 raiden_contracts/
 
-      before_script:
-        - flake8 raiden_contracts/
-
-      script:
-        - coverage run --source raiden_contracts/ -m py.test -Wd --travis-fold=always -n auto -v $TEST_TYPE
+script:
+  - coverage run --source raiden_contracts/ -m py.test -Wd --travis-fold=always -n 2 -v $TEST_TYPE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include requirements.txt
-include raiden_contracts/data/contracts.json
+include raiden_contracts/data/contracts.json.gz
 recursive-include raiden_contracts/contracts/ *
 recursive-include raiden_contracts/contracts/test *

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ except ImportError:
     from distutils.core import setup
 
 import os
-import json
 from setuptools import Command
 from setuptools.command.build_py import build_py
 from setuptools.command.sdist import sdist
@@ -52,11 +51,15 @@ class CompileContracts(Command):
         pass
 
     def run(self):
+        # This is a workaround to stop a possibly existing invalid
+        # precompiled `contracts.json` from preventing us from compiling a new one
+        os.environ['_RAIDEN_CONTRACT_MANAGER_SKIP_PRECOMPILED'] = '1'
         from raiden_contracts.contract_manager import (
             ContractManager,
             CONTRACTS_PRECOMPILED_PATH,
             CONTRACTS_SOURCE_DIRS,
         )
+
         try:
             from solc import compile_files  # noqa
         except ModuleNotFoundError:


### PR DESCRIPTION
Previously `setup.py` would always trigger a recompilation of `contracts.json`. Even when installing from an `sdist` (where no `solc` might be available). This defeats the purpose of having the precompiled archive in the first place.

This adds a checksum to the precompiled `contracts.json` in order to prevent recompilation attempts in cases where the existing archive already exists.

Also changes the contracts storage to gzipped JSON to save space (~250k vs. 25k).

Also also switches Travis to Python 3.6 to be in line with the other Raiden repos.

Fixes #179