### PR TITLE
Add helper for scenario player to CustomToken

### DIFF
--- a/raiden_contracts/contracts/test/CustomToken.sol
+++ b/raiden_contracts/contracts/test/CustomToken.sol
@@ -65,14 +65,19 @@ contract CustomToken is StandardToken {
         _total_supply = initial_supply;
     }
 
-    /// @notice Allows tokens to be minted and assigned to `msg.sender`
+    /// @notice Allows `num` tokens to be minted and assigned to `msg.sender`
     function mint(uint256 num) public {
-        balances[msg.sender] += num;
+        mintFor(num, msg.sender);
+    }
+
+    /// @notice Allows `num` tokens to be minted and assigned to `target`
+    function mintFor(uint256 num, address target) public {
+        balances[target] += num;
         _total_supply += num;
 
-        emit Minted(msg.sender, num);
+        emit Minted(target, num);
 
-        require(balances[msg.sender] >= num);
+        require(balances[target] >= num);
         assert(_total_supply >= num);
     }
 

--- a/raiden_contracts/tests/test_token.py
+++ b/raiden_contracts/tests/test_token.py
@@ -9,10 +9,18 @@ def test_token_mint(web3, custom_token, get_accounts):
     supply = token.functions.totalSupply().call()
 
     token_pre_balance = web3.eth.getBalance(token.address)
-    tokens = 50 * multiplier
-    token.functions.mint(tokens).transact({'from': A})
-    assert token.functions.balanceOf(A).call() == tokens
-    assert token.functions.totalSupply().call() == supply + tokens
+    tokens_a = 50 * multiplier
+    token.functions.mint(tokens_a).transact({'from': A})
+    assert token.functions.balanceOf(A).call() == tokens_a
+    assert token.functions.balanceOf(B).call() == 0
+    assert token.functions.totalSupply().call() == supply + tokens_a
+    assert web3.eth.getBalance(token.address) == token_pre_balance
+
+    tokens_b = 50 * multiplier
+    token.functions.mintFor(tokens_b, B).transact({'from': A})
+    assert token.functions.balanceOf(A).call() == tokens_a
+    assert token.functions.balanceOf(B).call() == tokens_b
+    assert token.functions.totalSupply().call() == supply + tokens_a + tokens_b
     assert web3.eth.getBalance(token.address) == token_pre_balance
 
 


### PR DESCRIPTION
Adds a `mintFor()` method to the `CustomToken` test contract which will be used by the testnet scenario player.