### PR TITLE
Settle unlock tests refactor

### DIFF
--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -255,7 +255,7 @@ def create_settled_channel(
 @pytest.fixture()
 def reveal_secrets(web3, secret_registry_contract):
     def get(tx_from, transfers):
-        for (expiration, amount, secrethash, secret) in transfers:
+        for (expiration, _, secrethash, secret) in transfers:
             assert web3.eth.blockNumber < expiration
             secret_registry_contract.functions.registerSecret(secret).transact({'from': tx_from})
             assert secret_registry_contract.functions.getSecretRevealBlockHeight(secrethash).call() == web3.eth.blockNumber

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -254,9 +254,11 @@ def create_settled_channel(
 @pytest.fixture()
 def reveal_secrets(web3, secret_registry_contract):
     def get(tx_from, transfers):
-        for (_, _, secrethash, secret) in transfers:
+        for (expiration, amount, secrethash, secret) in transfers:
+            assert web3.eth.blockNumber < expiration
             secret_registry_contract.functions.registerSecret(secret).transact({'from': tx_from})
             assert secret_registry_contract.functions.getSecretRevealBlockHeight(secrethash).call() == web3.eth.blockNumber
+
     return get
 
 

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -706,7 +706,7 @@ def create_withdraw_signatures(token_network, get_private_key):
 def call_settle(token_network, channel_identifier, A, vals_A, B, vals_B):
     A_total_transferred = vals_A.transferred + vals_A.locked
     B_total_transferred = vals_B.transferred + vals_B.locked
-    assert B_total_transferred >= B_total_transferred
+    assert B_total_transferred >= A_total_transferred
 
     if B_total_transferred != B_total_transferred:
         with pytest.raises(TransactionFailed):

--- a/raiden_contracts/tests/fixtures/channel_test_values.py
+++ b/raiden_contracts/tests/fixtures/channel_test_values.py
@@ -3,61 +3,308 @@ from raiden_contracts.tests.utils import MAX_UINT256, ChannelValues
 
 # We must cover the edge cases documented in
 # https://github.com/raiden-network/raiden-contracts/issues/188
+# The scope is to make sure that if someone uses an old balance proof, this cannot be used as
+# an attack to steal tokens.
+# For invalid balance proofs (created and signed with an unofficial Raiden client),
+# we cannot determine and guarantee corectness. There are specific constraints that the
+# Raiden client must enforce that guarantee correctness.
+
+# For all valid last balance proofs provided we will programatically construct a suit of balance
+# proof pairs that could be used for attacks (documented edge cases).
+# We can also specify the balance proof pairs that are not `valid last` (edge cases) manually.
+# We will test if the end result of using the `valid last` balance proof is the same as in the
+# edge cases, or that the attacker gets punished.
 channel_settle_test_values = [
-    # both balance proofs provided are valid
+    {
+        'valid_last': (
+            ChannelValues(
+                deposit=35,
+                withdrawn=5,
+                transferred=20020,
+                claimable_locked=3,
+                unclaimable_locked=1,
+            ),
+            ChannelValues(
+                deposit=40,
+                withdrawn=10,
+                transferred=20030,
+                claimable_locked=4,
+                unclaimable_locked=2,
+            ),
+        ),
+        # participant2 provides a valid but old balance proof of participant1
+        'old_last': [
+            # participant2 does not send participant1's balance proof
+            ChannelValues(
+                deposit=35,
+                withdrawn=5,
+                transferred=0,
+                claimable_locked=0,
+                unclaimable_locked=0,
+            ),
+            # participant2 provides an old participant1 balance proof with a smaller
+            # transferred amount
+            ChannelValues(
+                deposit=35,
+                withdrawn=5,
+                transferred=10000,
+                claimable_locked=3,
+                unclaimable_locked=1,
+            ),
+            # participant2 provides an old participant1 balance proof with a smaller
+            # claimable locked amount
+            ChannelValues(
+                deposit=35,
+                withdrawn=5,
+                transferred=20020,
+                claimable_locked=0,
+                unclaimable_locked=1,
+            ),
+            # participant2 provides an old participant1 balance proof with a smaller
+            # unclaimable locked amount
+            ChannelValues(
+                deposit=35,
+                withdrawn=5,
+                transferred=20020,
+                claimable_locked=3,
+                unclaimable_locked=0,
+            ),
+            # participant2 provides an old participant1 balance proof with a smaller transferred
+            # & claimable locked amount
+            ChannelValues(
+                deposit=35,
+                withdrawn=5,
+                transferred=10000,
+                claimable_locked=0,
+                unclaimable_locked=1,
+            ),
+            # participant2 provides an old participant1 balance proof will all values smaller
+            ChannelValues(
+                deposit=35,
+                withdrawn=5,
+                transferred=10000,
+                claimable_locked=0,
+                unclaimable_locked=0,
+            ),
+            # participant2 provides an old participant1 balance proof, but with the same
+            # transferred + claimable_locked
+            # This should have the same final participant balances as the valid last balance proofs
+            # locked amount cannot be bigger than the available deposit at that time
+            # 18 is the maximum locked amount that can happen with valid balance proofs
+            ChannelValues(
+                deposit=35,
+                withdrawn=5,
+                transferred=20006,
+                claimable_locked=17,
+                unclaimable_locked=1,
+            ),
+            # participant2 provides an old participant1 balance proof, with a higher
+            # unclaimable locked amount can happen if expired transfers are removed
+            # from the merkle tree
+            # ChannelValues(
+            #     deposit=35,
+            #     withdrawn=5,
+            #     transferred=20020,
+            #     claimable_locked=3,
+            #     unclaimable_locked=12,
+            # ),
+            # participant2 provides an old participant1 balance proof with a higher
+            # claimable locked amount, but lower transferred + claimable_locked
+            # A higher claimable locked amount can happen even if the locked tokens are
+            # eventually claimed off-chain (become transferred amount).
+            # This is because we can register secrets on-chain at any point in time.
+            ChannelValues(
+                deposit=35,
+                withdrawn=5,
+                transferred=10020,
+                claimable_locked=17,
+                unclaimable_locked=1,
+            ),
+            # participant2 provides an old participant1 balance proof with a higher
+            # unclaimable locked amount and a higher claimable locked amount but lower
+            # transferred + claimable_locked
+            ChannelValues(
+                deposit=35,
+                withdrawn=5,
+                transferred=10020,
+                claimable_locked=17,
+                unclaimable_locked=10,
+            ),
+        ],
+        # participant1 provides a valid but old participant2 balance proof
+        # these examples must maintain the same order of calculating the balances
+        # imposed by tranferred2 + locked2 >= transferred1 + locked1
+        'last_old': [
+            # participant1 provides an old participant2 balance proof with a smaller
+            # transferred amount
+            ChannelValues(
+                deposit=40,
+                withdrawn=10,
+                transferred=20020,
+                claimable_locked=4,
+                unclaimable_locked=2,
+            ),
+            # participant1 provides an old participant2 balance proof with a smaller
+            # claimable locked amount
+            ChannelValues(
+                deposit=40,
+                withdrawn=10,
+                transferred=20030,
+                claimable_locked=0,
+                unclaimable_locked=2,
+            ),
+            # participant1 provides an old participant2 balance proof with a smaller
+            # unclaimable locked amount
+            ChannelValues(
+                deposit=40,
+                withdrawn=10,
+                transferred=20030,
+                claimable_locked=4,
+                unclaimable_locked=0,
+            ),
+            # participant1 provides an old participant2 balance proof with a smaller transferred
+            # & claimable locked amount
+            ChannelValues(
+                deposit=40,
+                withdrawn=10,
+                transferred=20022,
+                claimable_locked=0,
+                unclaimable_locked=2,
+            ),
+            # participant1 provides an old participant2 balance proof will all values smaller
+            ChannelValues(
+                deposit=40,
+                withdrawn=10,
+                transferred=20024,
+                claimable_locked=0,
+                unclaimable_locked=0,
+            ),
+            # participant1 provides an old participant2 balance proof, but with the same
+            # transferred + claimable_locked
+            # This should have the same final participant balances as the valid last balance proofs
+            ChannelValues(
+                deposit=40,
+                withdrawn=10,
+                transferred=19994,
+                claimable_locked=40,
+                unclaimable_locked=2,
+            ),
+            # participant1 provides an old participant2 balance proof, with a higher
+            # unclaimable locked amount
+            # can happen if expired transfers are removed from the merkle tree
+            ChannelValues(
+                deposit=40,
+                withdrawn=10,
+                transferred=20030,
+                claimable_locked=4,
+                unclaimable_locked=20,
+            ),
+            # participant1 provides an old participant2 balance proof with a higher
+            # claimable locked amount,
+            # but lower transferred + claimable_locked
+            # A higher claimable locked amount can happen even if the locked tokens are
+            # eventually claimed off-chain (become transferred amount).
+            # This is because we can register secrets on-chain at any point in time.
+            ChannelValues(
+                deposit=40,
+                withdrawn=10,
+                transferred=19990,
+                claimable_locked=40,
+                unclaimable_locked=2,
+            ),
+            # participant1 provides an old participant2 balance proof with a higher
+            # unclaimable locked amount and a higher claimable locked amount but lower
+            # transferred + claimable_locked
+            ChannelValues(
+                deposit=40,
+                withdrawn=10,
+                transferred=19990,
+                claimable_locked=40,
+                unclaimable_locked=10,
+            ),
+        ],
+    },
+    {
+        # neither participants provide balance proofs
+        'valid_last': (
+            ChannelValues(
+                deposit=40,
+                withdrawn=10,
+                transferred=0,
+                claimable_locked=0,
+                unclaimable_locked=0,
+            ),
+            ChannelValues(
+                deposit=35,
+                withdrawn=5,
+                transferred=0,
+                claimable_locked=0,
+                unclaimable_locked=0,
+            ),
+        ),
+    },
+    {
+        # both balance proofs provided are valid
+        'valid_last': (
+            ChannelValues(
+                deposit=35,
+                withdrawn=5,
+                transferred=20,
+                claimable_locked=4,
+                unclaimable_locked=0,
+            ),
+            ChannelValues(
+                deposit=40,
+                withdrawn=10,
+                transferred=30,
+                claimable_locked=4,
+                unclaimable_locked=2,
+            ),
+        ),
+    },
+    {
+        # Participants have withdrawn all their tokens already
+        'valid_last': (
+            ChannelValues(
+                deposit=5,
+                withdrawn=15,
+                transferred=20,
+                claimable_locked=0,
+                unclaimable_locked=0,
+            ),
+            ChannelValues(
+                deposit=20,
+                withdrawn=10,
+                transferred=30,
+                claimable_locked=0,
+                unclaimable_locked=0,
+            ),
+        ),
+    },
+    {
+        # Participants have withdrawn all their finalized transfer tokens except locked,
+        'valid_last': (
+            ChannelValues(
+                deposit=5,
+                withdrawn=5,
+                transferred=20,
+                claimable_locked=4,
+                unclaimable_locked=1,
+            ),
+            ChannelValues(
+                deposit=25,
+                withdrawn=5,
+                transferred=30,
+                claimable_locked=2,
+                unclaimable_locked=3,
+            ),
+        ),
+    },
+]
+
+channel_settle_invalid_test_values = [
     (
-        ChannelValues(
-            deposit=35,
-            withdrawn=5,
-            transferred=20020,
-            claimable_locked=3,
-            unclaimable_locked=1,
-        ),
-        ChannelValues(
-            deposit=40,
-            withdrawn=10,
-            transferred=20030,
-            claimable_locked=4,
-            unclaimable_locked=2,
-        ),
-    ),
-    # participant2 does not provide a balance proof, locked amount ok
-    (
-        ChannelValues(
-            deposit=35,
-            withdrawn=5,
-            transferred=0,
-            claimable_locked=0,
-            unclaimable_locked=0,
-        ),
-        ChannelValues(
-            deposit=40,
-            withdrawn=10,
-            transferred=20030,
-            claimable_locked=0,
-            unclaimable_locked=0,
-        ),
-    ),
-    # participant2 does not provide a balance proof + bigger locked amount
-    # neither participants provide balance proofs
-    (
-        ChannelValues(
-            deposit=40,
-            withdrawn=10,
-            transferred=0,
-            claimable_locked=0,
-            unclaimable_locked=0,
-        ),
-        ChannelValues(
-            deposit=35,
-            withdrawn=5,
-            transferred=0,
-            claimable_locked=0,
-            unclaimable_locked=0,
-        ),
-    ),
-    # bigger locked amounts than what remains in the contract after settlement
-    (
+        # bigger locked amounts than what remains in the contract after settlement
         ChannelValues(
             deposit=35,
             withdrawn=5,
@@ -71,23 +318,6 @@ channel_settle_test_values = [
             transferred=20030,
             claimable_locked=10000000,
             unclaimable_locked=40000000,
-        ),
-    ),
-    # both balance proofs provided are valid
-    (
-        ChannelValues(
-            deposit=35,
-            withdrawn=5,
-            transferred=20,
-            claimable_locked=4,
-            unclaimable_locked=0,
-        ),
-        ChannelValues(
-            deposit=40,
-            withdrawn=10,
-            transferred=30,
-            claimable_locked=4,
-            unclaimable_locked=2,
         ),
     ),
     # participant2 does not provide a balance proof + locked amount too big
@@ -107,24 +337,24 @@ channel_settle_test_values = [
             unclaimable_locked=2,
         ),
     ),
-    # participant2 does not provide a balance proof
+    # Participants have withdrawn all their finalized transfer tokens already,
+    # only locked tokens left
     (
         ChannelValues(
-            deposit=40,
+            deposit=5,
             withdrawn=10,
-            transferred=0,
-            claimable_locked=0,
-            unclaimable_locked=0,
-        ),
-        ChannelValues(
-            deposit=35,
-            withdrawn=5,
             transferred=20,
-            claimable_locked=3,
+            claimable_locked=4,
             unclaimable_locked=1,
         ),
+        ChannelValues(
+            deposit=20,
+            withdrawn=5,
+            transferred=30,
+            claimable_locked=2,
+            unclaimable_locked=3,
+        ),
     ),
-    # all tokens have been withdrawn, locked amounts are 0
     (
         ChannelValues(
             deposit=5,
@@ -141,7 +371,6 @@ channel_settle_test_values = [
             unclaimable_locked=0,
         ),
     ),
-    # all tokens have been withdrawn, locked amounts are > 0
     (
         ChannelValues(
             deposit=5,
@@ -209,7 +438,7 @@ channel_settle_test_values = [
             unclaimable_locked=3,
         ),
     ),
-    # overflow on transferred amount + old balance proof
+    # overflow on transferred amount
     (
         ChannelValues(
             deposit=35,
@@ -225,9 +454,8 @@ channel_settle_test_values = [
             claimable_locked=0,
             unclaimable_locked=0,
         ),
-
     ),
-    # overflow on transferred amount + old balance proof, overflow on netted transfer + deposit
+    # overflow on transferred amount, overflow on netted transfer + deposit
     (
         ChannelValues(
             deposit=35,

--- a/raiden_contracts/tests/fixtures/channel_test_values.py
+++ b/raiden_contracts/tests/fixtures/channel_test_values.py
@@ -4,78 +4,242 @@ from raiden_contracts.tests.utils import MAX_UINT256, ChannelValues
 channel_settle_test_values = [
     # both balance proofs provided are valid
     (
-        ChannelValues(deposit=35, withdrawn=5, transferred=20020, locked=4),
-        ChannelValues(deposit=40, withdrawn=10, transferred=20030, locked=6),
+        ChannelValues(
+            deposit=35,
+            withdrawn=5,
+            transferred=20020,
+            claimable_locked=3,
+            unclaimable_locked=1,
+        ),
+        ChannelValues(
+            deposit=40,
+            withdrawn=10,
+            transferred=20030,
+            claimable_locked=4,
+            unclaimable_locked=2,
+        ),
     ),
     # participant2 does not provide a balance proof, locked amount ok
     (
-        ChannelValues(deposit=35, withdrawn=5, transferred=0, locked=0),
-        ChannelValues(deposit=40, withdrawn=10, transferred=20030, locked=0),
+        ChannelValues(
+            deposit=35,
+            withdrawn=5,
+            transferred=0,
+            claimable_locked=0,
+            unclaimable_locked=0,
+        ),
+        ChannelValues(
+            deposit=40,
+            withdrawn=10,
+            transferred=20030,
+            claimable_locked=0,
+            unclaimable_locked=0,
+        ),
     ),
     # participant2 does not provide a balance proof + bigger locked amount
-    (
-        ChannelValues(deposit=40, withdrawn=10, transferred=0, locked=0),
-        ChannelValues(deposit=35, withdrawn=5, transferred=20020, locked=4),
-    ),
     # neither participants provide balance proofs
     (
-        ChannelValues(deposit=40, withdrawn=10, transferred=0, locked=0),
-        ChannelValues(deposit=35, withdrawn=5, transferred=0, locked=0),
+        ChannelValues(
+            deposit=40,
+            withdrawn=10,
+            transferred=0,
+            claimable_locked=0,
+            unclaimable_locked=0,
+        ),
+        ChannelValues(
+            deposit=35,
+            withdrawn=5,
+            transferred=0,
+            claimable_locked=0,
+            unclaimable_locked=0,
+        ),
     ),
     # bigger locked amounts than what remains in the contract after settlement
     (
-        ChannelValues(deposit=35, withdrawn=5, transferred=20020, locked=40000000),
-        ChannelValues(deposit=40, withdrawn=10, transferred=20030, locked=50000000),
+        ChannelValues(
+            deposit=35,
+            withdrawn=5,
+            transferred=20020,
+            claimable_locked=30000000,
+            unclaimable_locked=10000000,
+        ),
+        ChannelValues(
+            deposit=40,
+            withdrawn=10,
+            transferred=20030,
+            claimable_locked=10000000,
+            unclaimable_locked=40000000,
+        ),
     ),
     # both balance proofs provided are valid
     (
-        ChannelValues(deposit=35, withdrawn=5, transferred=20, locked=4),
-        ChannelValues(deposit=40, withdrawn=10, transferred=30, locked=6),
+        ChannelValues(
+            deposit=35,
+            withdrawn=5,
+            transferred=20,
+            claimable_locked=4,
+            unclaimable_locked=0,
+        ),
+        ChannelValues(
+            deposit=40,
+            withdrawn=10,
+            transferred=30,
+            claimable_locked=4,
+            unclaimable_locked=2,
+        ),
     ),
     # participant2 does not provide a balance proof + locked amount too big
     (
-        ChannelValues(deposit=35, withdrawn=5, transferred=0, locked=0),
-        ChannelValues(deposit=40, withdrawn=10, transferred=30, locked=6),
+        ChannelValues(
+            deposit=35,
+            withdrawn=5,
+            transferred=0,
+            claimable_locked=0,
+            unclaimable_locked=0,
+        ),
+        ChannelValues(
+            deposit=40,
+            withdrawn=10,
+            transferred=30,
+            claimable_locked=4,
+            unclaimable_locked=2,
+        ),
     ),
     # participant2 does not provide a balance proof
     (
-        ChannelValues(deposit=40, withdrawn=10, transferred=0, locked=0),
-        ChannelValues(deposit=35, withdrawn=5, transferred=20, locked=4),
+        ChannelValues(
+            deposit=40,
+            withdrawn=10,
+            transferred=0,
+            claimable_locked=0,
+            unclaimable_locked=0,
+        ),
+        ChannelValues(
+            deposit=35,
+            withdrawn=5,
+            transferred=20,
+            claimable_locked=3,
+            unclaimable_locked=1,
+        ),
     ),
     # all tokens have been withdrawn, locked amounts are 0
     (
-        ChannelValues(deposit=5, withdrawn=5, transferred=20, locked=0),
-        ChannelValues(deposit=10, withdrawn=10, transferred=30, locked=0),
+        ChannelValues(
+            deposit=5,
+            withdrawn=5,
+            transferred=20,
+            claimable_locked=0,
+            unclaimable_locked=0,
+        ),
+        ChannelValues(
+            deposit=10,
+            withdrawn=10,
+            transferred=30,
+            claimable_locked=0,
+            unclaimable_locked=0,
+        ),
     ),
     # all tokens have been withdrawn, locked amounts are > 0
     (
-        ChannelValues(deposit=5, withdrawn=5, transferred=20, locked=4),
-        ChannelValues(deposit=10, withdrawn=10, transferred=30, locked=6),
+        ChannelValues(
+            deposit=5,
+            withdrawn=5,
+            transferred=20,
+            claimable_locked=1,
+            unclaimable_locked=3,
+        ),
+        ChannelValues(
+            deposit=10,
+            withdrawn=10,
+            transferred=30,
+            claimable_locked=2,
+            unclaimable_locked=4,
+        ),
     ),
     # overflow on transferred amounts
     (
-        ChannelValues(deposit=35, withdrawn=5, transferred=MAX_UINT256 - 15, locked=4),
-        ChannelValues(deposit=40, withdrawn=10, transferred=MAX_UINT256 - 5, locked=6),
+        ChannelValues(
+            deposit=35,
+            withdrawn=5,
+            transferred=MAX_UINT256 - 15,
+            claimable_locked=3,
+            unclaimable_locked=1,
+        ),
+        ChannelValues(
+            deposit=40,
+            withdrawn=10,
+            transferred=MAX_UINT256 - 5,
+            claimable_locked=5,
+            unclaimable_locked=1,
+        ),
     ),
     # overflow on transferred amount
     (
-        ChannelValues(deposit=35, withdrawn=5, transferred=0, locked=4),
-        ChannelValues(deposit=40, withdrawn=10, transferred=MAX_UINT256 - 5, locked=6),
+        ChannelValues(
+            deposit=35,
+            withdrawn=5,
+            transferred=0,
+            claimable_locked=4,
+            unclaimable_locked=0,
+        ),
+        ChannelValues(
+            deposit=40,
+            withdrawn=10,
+            transferred=MAX_UINT256 - 5,
+            claimable_locked=0,
+            unclaimable_locked=6,
+        ),
     ),
     # overflow on transferred amount
     (
-        ChannelValues(deposit=40, withdrawn=10, transferred=0, locked=6),
-        ChannelValues(deposit=35, withdrawn=5, transferred=MAX_UINT256 - 15, locked=4),
+        ChannelValues(
+            deposit=40,
+            withdrawn=10,
+            transferred=0,
+            claimable_locked=6,
+            unclaimable_locked=0,
+        ),
+        ChannelValues(
+            deposit=35,
+            withdrawn=5,
+            transferred=MAX_UINT256 - 15,
+            claimable_locked=1,
+            unclaimable_locked=3,
+        ),
     ),
     # overflow on transferred amount + old balance proof
     (
-        ChannelValues(deposit=35, withdrawn=5, transferred=20020, locked=200200),
-        ChannelValues(deposit=40, withdrawn=10, transferred=MAX_UINT256 - 5, locked=0),
+        ChannelValues(
+            deposit=35,
+            withdrawn=5,
+            transferred=20020,
+            claimable_locked=200000,
+            unclaimable_locked=200,
+        ),
+        ChannelValues(
+            deposit=40,
+            withdrawn=10,
+            transferred=MAX_UINT256 - 5,
+            claimable_locked=0,
+            unclaimable_locked=0,
+        ),
 
     ),
     # overflow on transferred amount + old balance proof, overflow on netted transfer + deposit
     (
-        ChannelValues(deposit=35, withdrawn=5, transferred=20, locked=200200),
-        ChannelValues(deposit=40, withdrawn=10, transferred=MAX_UINT256 - 5, locked=0),
+        ChannelValues(
+            deposit=35,
+            withdrawn=5,
+            transferred=20,
+            claimable_locked=200,
+            unclaimable_locked=200000,
+        ),
+        ChannelValues(
+            deposit=40,
+            withdrawn=10,
+            transferred=MAX_UINT256 - 5,
+            claimable_locked=0,
+            unclaimable_locked=0,
+        ),
     ),
 ]

--- a/raiden_contracts/tests/fixtures/channel_test_values.py
+++ b/raiden_contracts/tests/fixtures/channel_test_values.py
@@ -1,6 +1,8 @@
 from raiden_contracts.tests.utils import MAX_UINT256, ChannelValues
 
 
+# We must cover the edge cases documented in
+# https://github.com/raiden-network/raiden-contracts/issues/188
 channel_settle_test_values = [
     # both balance proofs provided are valid
     (

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -109,10 +109,11 @@ def test_settle_channel_state(
     vals_A.locksroot = pending_transfers_tree_A.merkle_root
     vals_B.locksroot = pending_transfers_tree_B.merkle_root
 
-    create_channel_and_deposit(A, B, vals_A.deposit, vals_B.deposit)
-    withdraw_channel(A, vals_A.withdrawn, B)
-    withdraw_channel(B, vals_B.withdrawn, A)
+    channel_identifier = create_channel_and_deposit(A, B, vals_A.deposit, vals_B.deposit)
+    withdraw_channel(channel_identifier, A, vals_A.withdrawn, B)
+    withdraw_channel(channel_identifier, B, vals_B.withdrawn, A)
     close_and_update_channel(
+        channel_identifier,
         A,
         vals_A,
         B,
@@ -125,10 +126,11 @@ def test_settle_channel_state(
     pre_balance_B = custom_token.functions.balanceOf(B).call()
     pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
-    call_settle(token_network, A, vals_A, B, vals_B)
+    call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
 
     # Balance & state tests
     settle_state_tests(
+        channel_identifier,
         A,
         vals_A,
         B,

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -1,7 +1,3 @@
-import pytest
-from copy import deepcopy
-from random import randint
-
 from raiden_contracts.utils.merkle import get_merkle_root
 
 from raiden_contracts.constants import (
@@ -90,14 +86,14 @@ def test_settle_channel_state(
         withdrawn=10,
         transferred=20020,
         claimable_locked=3,
-        unclaimable_locked=4
+        unclaimable_locked=4,
     )
     vals_B = ChannelValues(
         deposit=35,
         withdrawn=5,
         transferred=20030,
         claimable_locked=2,
-        unclaimable_locked=3
+        unclaimable_locked=3,
     )
 
     pending_transfers_tree_A = get_pending_transfers_tree(
@@ -146,7 +142,10 @@ def test_settle_channel_state(
     # used in `settle_state_tests` are incorrect
     assert custom_token.functions.balanceOf(A).call() == pre_balance_A + 33
     assert custom_token.functions.balanceOf(B).call() == pre_balance_B + 15
-    assert custom_token.functions.balanceOf(token_network.address).call() == pre_balance_contract - 48
+    assert custom_token.functions.balanceOf(
+        token_network.address,
+    ).call() == pre_balance_contract - 48
+
 
 def test_settle_single_direct_transfer_for_closing_party(
         web3,

--- a/raiden_contracts/tests/test_channel_settle_unlock_state.py
+++ b/raiden_contracts/tests/test_channel_settle_unlock_state.py
@@ -1,23 +1,27 @@
 import pytest
-from copy import deepcopy
-from random import randint
 from eth_tester.exceptions import TransactionFailed
-from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN
+from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN, ParticipantInfoIndex
 from raiden_contracts.tests.fixtures.channel import call_settle
-from raiden_contracts.tests.fixtures.channel_test_values import channel_settle_test_values
+from raiden_contracts.tests.fixtures.channel_test_values import (
+    channel_settle_test_values,
+    channel_settle_invalid_test_values,
+)
+from raiden_contracts.tests.fixtures.config import EMPTY_LOCKSROOT
+from raiden_contracts.utils.utils import get_pending_transfers_tree
 from raiden_contracts.tests.utils import (
     get_settlement_amounts,
     get_onchain_settlement_amounts,
     get_expected_after_settlement_unlock_amounts,
-    get_pending_transfers_tree,
-    get_unlocked_amount,
     are_balance_proofs_valid,
+    were_balance_proofs_valid,
     is_balance_proof_old,
+    get_unlocked_amount,
+    get_total_available_deposit,
 )
 
 
-@pytest.mark.parametrize('channel_test_values', channel_settle_test_values)
-def test_channel_settle_unlock_edge_cases(
+@pytest.fixture()
+def test_settlement_outcome(
         web3,
         get_accounts,
         secret_registry_contract,
@@ -27,132 +31,24 @@ def test_channel_settle_unlock_edge_cases(
         withdraw_channel,
         close_and_update_channel,
         settle_state_tests,
-        channel_test_values,
         reveal_secrets,
-        after_settle_unlock_balance_tests,
 ):
-    number_of_channels = 3
-    accounts = get_accounts(2 * number_of_channels)
-    (vals_A0, vals_B0) = channel_test_values
-    all_test_cases = [(vals_A0, vals_B0)]
-
-    # We mimic old balance proofs here, with a high locked claimable amount and lower transferred
-    # amount. We expect to have the same settlement values as the original values
-    def equivalent_transfers(balance_proof):
-        new_balance_proof = deepcopy(balance_proof)
-        new_balance_proof.claimable_locked = randint(
-            balance_proof.claimable_locked,
-            balance_proof.transferred + balance_proof.claimable_locked,
-        )
-        new_balance_proof.locked = (
-            new_balance_proof.claimable_locked +
-            new_balance_proof.unclaimable_locked
-        )
-        new_balance_proof.transferred = (
-            balance_proof.transferred +
-            balance_proof.claimable_locked -
-            new_balance_proof.claimable_locked
-        )
-        return new_balance_proof
-
-    # No reason to mimic old balance proofs if the tested values do not represent
-    # valid balance proofs that are the last ones known.
-    if are_balance_proofs_valid(vals_A0, vals_B0) and not is_balance_proof_old(vals_A0, vals_B0):
-        vals_A_reversed = deepcopy(vals_A0)
-        vals_A_reversed.claimable_locked = vals_A0.transferred
-        vals_A_reversed.transferred = vals_A0.claimable_locked
-        vals_A_reversed.locked = (
-            vals_A_reversed.claimable_locked +
-            vals_A_reversed.unclaimable_locked
-        )
-
-        vals_B_reversed = deepcopy(vals_B0)
-        vals_B_reversed.claimable_locked = vals_B0.transferred
-        vals_B_reversed.transferred = vals_B0.claimable_locked
-        vals_B_reversed.locked = (
-            vals_B_reversed.claimable_locked +
-            vals_B_reversed.unclaimable_locked
-        )
-
-        all_test_cases.extend([
-            (vals_A0, vals_B_reversed),
-            (vals_A_reversed, vals_B0),
-            (vals_A_reversed, vals_B_reversed),
-        ] + [
-            # mimicking an old balance proof for B
-            sorted(
-                [
-                    vals_A0,
-                    equivalent_transfers(vals_B0),
-                ],
-                key=lambda x: x.transferred + x.locked,
-                reverse=False,
-            ) for no in range(0, number_of_channels - 1)
-        ] + [
-            # mimicking an old balance proof for A
-            sorted(
-                [
-                    equivalent_transfers(vals_A0),
-                    vals_B0,
-                ],
-                key=lambda x: x.transferred + x.locked,
-                reverse=False,
-            ) for no in range(0, number_of_channels - 1)
-        ] + [
-            # mimicking old balance proofs for both A and B
-            sorted(
-                [
-                    equivalent_transfers(vals_A0),
-                    equivalent_transfers(vals_B0),
-                ],
-                key=lambda x: x.transferred + x.locked,
-                reverse=False,
-            ) for no in range(0, number_of_channels - 1)
-        ])
-
-    # Calculate how much A and B should receive while not knowing who will receive the
-    # locked amounts
-    settlement = get_settlement_amounts(vals_A0, vals_B0)
-    # Calculate how much A and B receive according to onchain computation
-    settlement2 = get_onchain_settlement_amounts(vals_A0, vals_B0)
-
-    # Calculate how much A and B should receive when knowing who will receive the locked amounts
-    # This is a very important check. These amounts must be equal to the final tokens received
-    # after the channel lifecycle is over (after settlement & all pending transfers unlocks)
-    # for all valid balance proofs. This must be true for the last known balance proofs,
-    # but also for a last known balance proof + an old balance proof provided on purpose or not.
-    # Where a valid balance proof is a balance proof that respects the Raiden client
-    # value contraints, as defined here:
-    # https://github.com/raiden-network/raiden-contracts/issues/188#issuecomment-404752095
-    (
-        expected_final_balance_A0,
-        expected_final_balance_B0,
-    ) = get_expected_after_settlement_unlock_amounts(vals_A0, vals_B0)
-
-    for no in range(0, len(all_test_cases)):
-        A = accounts[no]
-        B = accounts[no + 1]
-        (vals_A, vals_B) = all_test_cases[no]
-
-        # Some checks to test that mimicking old balance proofs with high locked claimable amounts
-        # and low transferred amounts is done correctly
-        assert vals_A.locked + vals_A.transferred == vals_A0.locked + vals_A0.transferred
-        assert (
-            vals_A.claimable_locked +
-            vals_A.unclaimable_locked +
-            vals_A.transferred
-        ) == vals_A0.locked + vals_A0.transferred
-        assert vals_B.locked + vals_B.transferred == vals_B0.locked + vals_B0.transferred
-        assert (
-            vals_B.claimable_locked +
-            vals_B.unclaimable_locked +
-            vals_B.transferred
-        ) == vals_B0.locked + vals_B0.transferred
+    def f(
+            participants,
+            channel_values,
+            expected_settlement0,
+            expected_settlement_onchain0,
+            expected_final_balance_A0,
+            expected_final_balance_B0,
+    ):
+        (A, B) = participants
+        (vals_A, vals_B, balance_proof_type) = channel_values
+        assert were_balance_proofs_valid(vals_A, vals_B)
 
         # Start channel lifecycle
-        create_channel_and_deposit(A, B, vals_A.deposit, vals_B.deposit)
-        withdraw_channel(A, vals_A.withdrawn, B)
-        withdraw_channel(B, vals_B.withdrawn, A)
+        channel_identifier = create_channel_and_deposit(A, B, vals_A.deposit, vals_B.deposit)
+        withdraw_channel(channel_identifier, A, vals_A.withdrawn, B)
+        withdraw_channel(channel_identifier, B, vals_B.withdrawn, A)
 
         # For the purpose of this test, it is not important when the secrets are revealed,
         # as long as the secrets connected to pending transfers that should be finalized,
@@ -179,6 +75,7 @@ def test_channel_settle_unlock_edge_cases(
         reveal_secrets(B, pending_transfers_tree_B.unlockable)
 
         close_and_update_channel(
+            channel_identifier,
             A,
             vals_A,
             B,
@@ -191,11 +88,12 @@ def test_channel_settle_unlock_edge_cases(
         pre_balance_B = custom_token.functions.balanceOf(B).call()
         pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
-        call_settle(token_network, A, vals_A, B, vals_B)
+        call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
 
         # We do the balance & state tests here for each channel and also compare with
         # the expected settlement amounts
         settle_state_tests(
+            channel_identifier,
             A,
             vals_A,
             B,
@@ -210,28 +108,25 @@ def test_channel_settle_unlock_edge_cases(
 
         # Calculate how much A and B should receive
         settlement_equivalent = get_settlement_amounts(vals_A, vals_B)
-        assert (
-            settlement.participant1_balance +
-            settlement.participant2_locked == settlement_equivalent.participant1_balance +
-            settlement_equivalent.participant2_locked
-        )
-        assert (
-            settlement.participant2_balance +
-            settlement.participant1_locked == settlement_equivalent.participant2_balance +
-            settlement_equivalent.participant1_locked
-        )
 
         # Calculate how much A and B receive according to onchain computation
-        settlement2_equivalent = get_onchain_settlement_amounts(vals_A, vals_B)
+        settlement_onchain_equivalent = get_onchain_settlement_amounts(vals_A, vals_B)
+
         assert (
-            settlement2.participant1_balance +
-            settlement2.participant2_locked == settlement2_equivalent.participant1_balance +
-            settlement2_equivalent.participant2_locked
+            settlement_equivalent.participant1_balance ==
+            settlement_onchain_equivalent.participant1_balance
         )
         assert (
-            settlement2.participant2_balance +
-            settlement2.participant1_locked == settlement2_equivalent.participant2_balance +
-            settlement2_equivalent.participant1_locked
+            settlement_equivalent.participant2_balance ==
+            settlement_onchain_equivalent.participant2_balance
+        )
+        assert (
+            settlement_equivalent.participant1_locked ==
+            settlement_onchain_equivalent.participant1_locked
+        )
+        assert (
+            settlement_equivalent.participant2_locked ==
+            settlement_onchain_equivalent.participant2_locked
         )
 
         assert get_unlocked_amount(
@@ -240,102 +135,290 @@ def test_channel_settle_unlock_edge_cases(
         ) == vals_B.claimable_locked
 
         # A unlocks B's pending transfers
-        contract_locked_B = token_network.functions.getParticipantLockedAmount(
+        info_B = token_network.functions.getChannelParticipantInfo(
+            channel_identifier,
             B,
             A,
-            vals_B.locksroot,
         ).call()
-        if contract_locked_B == 0:
+        assert settlement_equivalent.participant2_locked == info_B[
+            ParticipantInfoIndex.LOCKED_AMOUNT
+        ]
+
+        if info_B[ParticipantInfoIndex.LOCKED_AMOUNT] == 0:
             with pytest.raises(TransactionFailed):
                 token_network.functions.unlock(
+                    channel_identifier,
                     A,
                     B,
                     pending_transfers_tree_B.packed_transfers,
                 ).transact()
         else:
             token_network.functions.unlock(
+                channel_identifier,
                 A,
                 B,
                 pending_transfers_tree_B.packed_transfers,
             ).transact()
 
-            # The locked amount should have been removed from contract storage
-            assert token_network.functions.getParticipantLockedAmount(
-                B,
-                A,
-                vals_B.locksroot,
-            ).call() == 0
+        # The locked amount should have been removed from contract storage
+        info_B = token_network.functions.getChannelParticipantInfo(
+            channel_identifier,
+            B,
+            A,
+        ).call()
+        assert info_B[ParticipantInfoIndex.LOCKED_AMOUNT] == 0
+        assert info_B[ParticipantInfoIndex.LOCKSROOT] == EMPTY_LOCKSROOT
 
         # B unlocks A's pending transfers
-        contract_locked_A = token_network.functions.getParticipantLockedAmount(
+        info_A = token_network.functions.getChannelParticipantInfo(
+            channel_identifier,
             A,
             B,
-            vals_A.locksroot,
         ).call()
-        if contract_locked_A == 0:
+        assert settlement_equivalent.participant1_locked == info_A[
+            ParticipantInfoIndex.LOCKED_AMOUNT
+        ]
+
+        if info_A[ParticipantInfoIndex.LOCKED_AMOUNT] == 0:
             with pytest.raises(TransactionFailed):
                 token_network.functions.unlock(
+                    channel_identifier,
                     B,
                     A,
                     pending_transfers_tree_A.packed_transfers,
                 ).transact()
         else:
             token_network.functions.unlock(
+                channel_identifier,
                 B,
                 A,
                 pending_transfers_tree_A.packed_transfers,
             ).transact()
 
-            # The locked amount should have been removed from contract storage
-            assert token_network.functions.getParticipantLockedAmount(
-                A,
-                B,
-                vals_A.locksroot,
-            ).call() == 0
+        # The locked amount should have been removed from contract storage
+        info_A = token_network.functions.getChannelParticipantInfo(
+            channel_identifier,
+            A,
+            B,
+        ).call()
+        assert info_A[ParticipantInfoIndex.LOCKED_AMOUNT] == 0
+        assert info_A[ParticipantInfoIndex.LOCKSROOT] == EMPTY_LOCKSROOT
 
-        # Do the post settlement and unlock tests if balance proofs are valid
-        if are_balance_proofs_valid(vals_A, vals_B):
-            after_settle_unlock_balance_tests(
-                A,
-                vals_A,
-                B,
-                vals_B,
-                pre_balance_A,
-                pre_balance_B,
-                pre_balance_contract,
-            )
+        # Do the post settlement and unlock tests for valid balance proofs
+        balance_A = custom_token.functions.balanceOf(A).call()
+        balance_B = custom_token.functions.balanceOf(B).call()
 
-        # Calculate how much A and B should receive after the channel is settled and
-        # unlock is called by both.
-        (
-            expected_final_balance_A,
-            expected_final_balance_B,
-        ) = get_expected_after_settlement_unlock_amounts(vals_A, vals_B)
+        # We MUST ensure balance correctness for valid last balance proofs
+        if balance_proof_type is 'valid':
+            # Calculate how much A and B should receive after the channel is settled and
+            # unlock is called by both.
+            (
+                expected_final_balance_A,
+                expected_final_balance_B,
+            ) = get_expected_after_settlement_unlock_amounts(vals_A, vals_B)
+            expected_balance_A = pre_balance_A + expected_final_balance_A
+            expected_balance_B = pre_balance_B + expected_final_balance_B
 
-        # If the balance proofs are invalid (participants are using an unofficial malicious
-        # Raiden client), there are cases where participants can lose tokens.
-        # We ensure balance correctness only if both participants use the official Raiden client.
-        if are_balance_proofs_valid(vals_A, vals_B):
-            assert custom_token.functions.balanceOf(A).call() == (
-                pre_balance_A +
-                expected_final_balance_A
-            )
-            assert custom_token.functions.balanceOf(B).call() == (
-                pre_balance_B +
-                expected_final_balance_B
-            )
-            if are_balance_proofs_valid(vals_A0, vals_B0):
-                assert expected_final_balance_A0 == expected_final_balance_A
-                assert expected_final_balance_B0 == expected_final_balance_B
+            assert balance_A == expected_balance_A
+            assert balance_B <= expected_balance_B
+
+        # For balance proofs where one of them is old, we need to compare with the expected
+        # final balances for the valid last balance proofs
+        expected_balance_A = pre_balance_A + expected_final_balance_A0
+        expected_balance_B = pre_balance_B + expected_final_balance_B0
+
+        # Tests for when B has submitted an old balance proof for A
+        # A must not receive less tokens than expected with a valid last balance proof
+        # B must not receive more tokens than expected with a valid last balance proof
+        if balance_proof_type is 'old_last':
+            assert balance_A >= expected_balance_A
+            assert balance_B <= expected_balance_B
+
+        # Tests for when A has submitted an old balance proof for B
+        # A must not receive more tokens than expected with a valid last balance proof
+        # B must not receive less tokens than expected with a valid last balance proof
+        if balance_proof_type is 'last_old':
+            assert balance_A <= expected_balance_A
+            assert balance_B >= expected_balance_B
 
         # Regardless of the tokens received by the two participants, we must make sure tokens
         # are not stolen from the other channels. And we must make sure tokens are not locked in
         # the contract after the entire channel cycle is finalized.
+        final_contract_balance = custom_token.functions.balanceOf(token_network.address).call()
+        assert final_contract_balance == pre_balance_contract - get_total_available_deposit(
+            vals_A,
+            vals_B,
+        )
         assert custom_token.functions.balanceOf(token_network.address).call() == (
             pre_balance_contract -
-            (expected_final_balance_A + expected_final_balance_B)
+            (expected_final_balance_A0 + expected_final_balance_B0)
         )
-        assert (
-            expected_final_balance_A +
-            expected_final_balance_B
-        ) == (expected_final_balance_A0 + expected_final_balance_B0)
+
+    return f
+
+
+@pytest.mark.parametrize('channel_test_values', channel_settle_test_values)
+def test_channel_settle_valid_old_balance_proof_values(
+        web3,
+        get_accounts,
+        assign_tokens,
+        channel_test_values,
+        create_channel_and_deposit,
+        test_settlement_outcome,
+):
+    (A, B, C, D) = get_accounts(4)
+    (vals_A0, vals_B0) = channel_test_values['valid_last']
+    assert are_balance_proofs_valid(vals_A0, vals_B0)
+    assert not is_balance_proof_old(vals_A0, vals_B0)
+
+    # Mint additional tokens for participants
+    assign_tokens(A, 400)
+    assign_tokens(B, 200)
+    # We make sure the contract has more tokens than A, B will deposit
+    create_channel_and_deposit(C, D, 40, 60)
+
+    # Calculate how much A and B should receive while not knowing who will receive the
+    # locked amounts
+    expected_settlement0 = get_settlement_amounts(vals_A0, vals_B0)
+    # Calculate how much A and B receive according to onchain computation
+    expected_settlement_onchain0 = get_onchain_settlement_amounts(vals_A0, vals_B0)
+
+    # Calculate the final expected balances after the channel lifecycle, (after settlement and
+    # unlocks), when we know how the locked amounts will be distributed.
+    # This is a very important check. This must be true for the last known balance proofs,
+    # but also for a last known balance proof + an old balance proof provided on purpose or not.
+    # Where a valid balance proof is a balance proof that respects the Raiden client
+    # value contraints, as defined here:
+    # https://github.com/raiden-network/raiden-contracts/issues/188#issuecomment-404752095
+    (
+        expected_final_balance_A0,
+        expected_final_balance_B0,
+    ) = get_expected_after_settlement_unlock_amounts(vals_A0, vals_B0)
+
+    test_settlement_outcome(
+        (A, B),
+        (vals_A0, vals_B0, 'valid'),
+        expected_settlement0,
+        expected_settlement_onchain0,
+        expected_final_balance_A0,
+        expected_final_balance_B0,
+    )
+
+    if 'old_last' in channel_test_values:
+        for vals_A in channel_test_values['old_last']:
+            vals_B = vals_B0
+            test_settlement_outcome(
+                (A, B),
+                (vals_A, vals_B, 'old_last'),
+                expected_settlement0,
+                expected_settlement_onchain0,
+                expected_final_balance_A0,
+                expected_final_balance_B0,
+            )
+
+    if 'last_old' in channel_test_values:
+        for vals_B in channel_test_values['last_old']:
+            vals_A = vals_A0
+            test_settlement_outcome(
+                (A, B),
+                (vals_A, vals_B, 'last_old'),
+                expected_settlement0,
+                expected_settlement_onchain0,
+                expected_final_balance_A0,
+                expected_final_balance_B0,
+            )
+
+    if 'old_last' in channel_test_values and 'last_old' in channel_test_values:
+        for vals_A in channel_test_values['old_last']:
+            for vals_B in channel_test_values['last_old']:
+                test_settlement_outcome(
+                    (A, B),
+                    (vals_A, vals_B, 'invalid'),
+                    expected_settlement0,
+                    expected_settlement_onchain0,
+                    expected_final_balance_A0,
+                    expected_final_balance_B0,
+                )
+
+
+@pytest.mark.parametrize('channel_test_values', channel_settle_invalid_test_values)
+def test_channel_settle_invalid_balance_proof_values(
+        web3,
+        get_accounts,
+        custom_token,
+        token_network,
+        create_channel_and_deposit,
+        withdraw_channel,
+        close_and_update_channel,
+        settle_state_tests,
+        reveal_secrets,
+        channel_test_values,
+):
+    (A, B, C, D) = get_accounts(4)
+    (vals_A, vals_B) = channel_test_values
+
+    # We just need to test that settleChannel does not fail
+    # We cannot ensure correctly computed final balances if the balance proofs
+    # are invalid.
+    # We can just test that participants do not get more tokens than the channel deposit
+
+    # We make sure the contract has more tokens than A, B will deposit
+    create_channel_and_deposit(C, D, 40, 60)
+
+    # Start channel lifecycle for A, B
+    channel_identifier = create_channel_and_deposit(A, B, vals_A.deposit, vals_B.deposit)
+    withdraw_channel(channel_identifier, A, vals_A.withdrawn, B)
+    withdraw_channel(channel_identifier, B, vals_B.withdrawn, A)
+
+    # For the purpose of this test, it is not important when the secrets are revealed,
+    # as long as the secrets connected to pending transfers that should be finalized,
+    # are revealed before their expiration.
+
+    # Mock pending transfers data for A -> B
+    pending_transfers_tree_A = get_pending_transfers_tree(
+        web3,
+        unlockable_amount=vals_A.claimable_locked,
+        expired_amount=vals_A.unclaimable_locked,
+    )
+    vals_A.locksroot = pending_transfers_tree_A.merkle_root
+    # Reveal A's secrets.
+    reveal_secrets(A, pending_transfers_tree_A.unlockable)
+
+    # Mock pending transfers data for B -> A
+    pending_transfers_tree_B = get_pending_transfers_tree(
+        web3,
+        unlockable_amount=vals_B.claimable_locked,
+        expired_amount=vals_B.unclaimable_locked,
+    )
+    vals_B.locksroot = pending_transfers_tree_B.merkle_root
+    # Reveal B's secrets
+    reveal_secrets(B, pending_transfers_tree_B.unlockable)
+
+    close_and_update_channel(
+        channel_identifier,
+        A,
+        vals_A,
+        B,
+        vals_B,
+    )
+
+    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN)
+
+    pre_balance_A = custom_token.functions.balanceOf(A).call()
+    pre_balance_B = custom_token.functions.balanceOf(B).call()
+    pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
+
+    call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
+
+    # We do the balance & state tests here for each channel and also compare with
+    # the expected settlement amounts
+    settle_state_tests(
+        channel_identifier,
+        A,
+        vals_A,
+        B,
+        vals_B,
+        pre_balance_A,
+        pre_balance_B,
+        pre_balance_contract,
+    )

--- a/raiden_contracts/tests/test_channel_settle_unlock_state.py
+++ b/raiden_contracts/tests/test_channel_settle_unlock_state.py
@@ -328,9 +328,77 @@ def test_channel_settle_valid_old_balance_proof_values(
                 expected_final_balance_B0,
             )
 
+
+@pytest.mark.parametrize('channel_test_values', channel_settle_test_values)
+def test_channel_settle_old_old_balance_proof_values(
+        web3,
+        get_accounts,
+        assign_tokens,
+        channel_test_values,
+        create_channel_and_deposit,
+        test_settlement_outcome,
+):
+    (A, B, C, D) = get_accounts(4)
+    (vals_A0, vals_B0) = channel_test_values['valid_last']
+    assert are_balance_proofs_valid(vals_A0, vals_B0)
+    assert not is_balance_proof_old(vals_A0, vals_B0)
+
+    # Mint additional tokens for participants
+    assign_tokens(A, 400)
+    assign_tokens(B, 200)
+    # We make sure the contract has more tokens than A, B will deposit
+    create_channel_and_deposit(C, D, 40, 60)
+
+    expected_settlement0 = get_settlement_amounts(vals_A0, vals_B0)
+    expected_settlement_onchain0 = get_onchain_settlement_amounts(vals_A0, vals_B0)
+    (
+        expected_final_balance_A0,
+        expected_final_balance_B0,
+    ) = get_expected_after_settlement_unlock_amounts(vals_A0, vals_B0)
+
     if 'old_last' in channel_test_values and 'last_old' in channel_test_values:
-        for vals_A in channel_test_values['old_last']:
-            for vals_B in channel_test_values['last_old']:
+        for vals_A in channel_test_values['old_last'][:5]:
+            for vals_B in channel_test_values['last_old'][:5]:
+                test_settlement_outcome(
+                    (A, B),
+                    (vals_A, vals_B, 'invalid'),
+                    expected_settlement0,
+                    expected_settlement_onchain0,
+                    expected_final_balance_A0,
+                    expected_final_balance_B0,
+                )
+
+
+@pytest.mark.parametrize('channel_test_values', channel_settle_test_values)
+def test_channel_settle_old_old_balance_proof_values2(
+        web3,
+        get_accounts,
+        assign_tokens,
+        channel_test_values,
+        create_channel_and_deposit,
+        test_settlement_outcome,
+):
+    (A, B, C, D) = get_accounts(4)
+    (vals_A0, vals_B0) = channel_test_values['valid_last']
+    assert are_balance_proofs_valid(vals_A0, vals_B0)
+    assert not is_balance_proof_old(vals_A0, vals_B0)
+
+    # Mint additional tokens for participants
+    assign_tokens(A, 400)
+    assign_tokens(B, 200)
+    # We make sure the contract has more tokens than A, B will deposit
+    create_channel_and_deposit(C, D, 40, 60)
+
+    expected_settlement0 = get_settlement_amounts(vals_A0, vals_B0)
+    expected_settlement_onchain0 = get_onchain_settlement_amounts(vals_A0, vals_B0)
+    (
+        expected_final_balance_A0,
+        expected_final_balance_B0,
+    ) = get_expected_after_settlement_unlock_amounts(vals_A0, vals_B0)
+
+    if 'old_last' in channel_test_values and 'last_old' in channel_test_values:
+        for vals_A in channel_test_values['old_last'][5:]:
+            for vals_B in channel_test_values['last_old'][5:]:
                 test_settlement_outcome(
                     (A, B),
                     (vals_A, vals_B, 'invalid'),

--- a/raiden_contracts/tests/test_channel_settle_unlock_state.py
+++ b/raiden_contracts/tests/test_channel_settle_unlock_state.py
@@ -1,0 +1,332 @@
+import pytest
+from copy import deepcopy
+from random import randint
+from eth_tester.exceptions import TransactionFailed
+from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN
+from raiden_contracts.tests.fixtures.channel import call_settle
+from raiden_contracts.tests.fixtures.channel_test_values import channel_settle_test_values
+from raiden_contracts.tests.utils import (
+    get_settlement_amounts,
+    get_onchain_settlement_amounts,
+    get_expected_after_settlement_unlock_amounts,
+    get_pending_transfers_tree,
+    get_unlocked_amount,
+    are_balance_proofs_valid,
+    is_balance_proof_old,
+)
+
+
+@pytest.mark.parametrize('channel_test_values', channel_settle_test_values)
+def test_channel_settle_unlock_edge_cases(
+        web3,
+        get_accounts,
+        secret_registry_contract,
+        custom_token,
+        token_network,
+        create_channel_and_deposit,
+        withdraw_channel,
+        close_and_update_channel,
+        settle_state_tests,
+        channel_test_values,
+        reveal_secrets,
+):
+    number_of_channels = 3
+    accounts = get_accounts(2 * number_of_channels)
+    (vals_A0, vals_B0) = channel_test_values
+    all_test_cases = [(vals_A0, vals_B0)]
+
+    # We mimic old balance proofs here, with a high locked amount and lower transferred amount
+    # We expect to have the same settlement values as the original values
+
+    def equivalent_transfers(balance_proof):
+        new_balance_proof = deepcopy(balance_proof)
+        new_balance_proof.locked = randint(
+            balance_proof.locked,
+            balance_proof.transferred + balance_proof.locked,
+        )
+        new_balance_proof.claimable_locked = new_balance_proof.locked
+        new_balance_proof.unclaimable_locked = 0
+        new_balance_proof.transferred = (
+            balance_proof.transferred +
+            balance_proof.locked -
+            new_balance_proof.locked
+        )
+        return new_balance_proof
+
+    # No reason to mimic old balance proofs if the tested values do not represent
+    # valid balance proofs that are the last ones known.
+    if are_balance_proofs_valid(vals_A0, vals_B0) and not is_balance_proof_old(vals_A0, vals_B0):
+        print('mimic old balance proofs', vals_A0, vals_B0)
+        vals_A_reversed = deepcopy(vals_A0)
+        vals_A_reversed.locked = vals_A0.transferred
+        vals_A_reversed.transferred = vals_A0.locked
+        vals_A_reversed.claimable_locked = vals_A_reversed.locked
+        vals_A_reversed.unclaimable_locked = 0
+
+        vals_B_reversed = deepcopy(vals_B0)
+        vals_B_reversed.locked = vals_B0.transferred
+        vals_B_reversed.transferred = vals_B0.locked
+        vals_B_reversed.claimable_locked = vals_B_reversed.locked
+        vals_B_reversed.unclaimable_locked = 0
+
+        all_test_cases.extend([
+            (vals_A0, vals_B_reversed),
+            (vals_A_reversed, vals_B0),
+            (vals_A_reversed, vals_B_reversed),
+        ] + [
+            # mimicking an old balance proof for B
+            sorted(
+                [
+                    vals_A0,
+                    equivalent_transfers(vals_B0),
+                ],
+                key=lambda x: x.transferred + x.locked,
+                reverse=False,
+            ) for no in range(0, number_of_channels - 1)
+        ] + [
+            # mimicking an old balance proof for A
+            sorted(
+                [
+                    equivalent_transfers(vals_A0),
+                    vals_B0,
+                ],
+                key=lambda x: x.transferred + x.locked,
+                reverse=False,
+            ) for no in range(0, number_of_channels - 1)
+        ] + [
+            # mimicking old balance proofs for both A and B
+            sorted(
+                [
+                    equivalent_transfers(vals_A0),
+                    equivalent_transfers(vals_B0),
+                ],
+                key=lambda x: x.transferred + x.locked,
+                reverse=False,
+            ) for no in range(0, number_of_channels - 1)
+        ])
+
+    # Calculate how much A and B should receive while not knowing who will receive the
+    # locked amounts
+    settlement = get_settlement_amounts(vals_A0, vals_B0)
+    # Calculate how much A and B receive according to onchain computation
+    settlement2 = get_onchain_settlement_amounts(vals_A0, vals_B0)
+
+    # Calculate how much A and B should receive when knowing who will receive the locked amounts
+    # This is a very important check. These amounts must be equal to the final tokens received
+    # after the channel lifecycle is over (after settlement & all pending transfers unlocks)
+    # for all valid balance proofs that are the last ones known at the same point in time.
+    # Where a valid balance proof is a balance proof that respects the Raiden client
+    # value contraints, as defined here:
+    # https://github.com/raiden-network/raiden-contracts/issues/188#issuecomment-404752095
+    (
+        expected_final_balance_A0,
+        expected_final_balance_B0,
+    ) = get_expected_after_settlement_unlock_amounts(vals_A0, vals_B0)
+
+    for no in range(0, len(all_test_cases)):
+        A = accounts[no]
+        B = accounts[no + 1]
+        (vals_A, vals_B) = all_test_cases[no]
+
+        # Some checks to test that mimicking old balance proofs is done correctly
+        assert vals_A.locked + vals_A.transferred == vals_A0.locked + vals_A0.transferred
+        assert (
+            vals_A.claimable_locked +
+            vals_A.unclaimable_locked +
+            vals_A.transferred
+        ) == vals_A0.locked + vals_A0.transferred
+        assert vals_B.locked + vals_B.transferred == vals_B0.locked + vals_B0.transferred
+        assert (
+            vals_B.claimable_locked +
+            vals_B.unclaimable_locked +
+            vals_B.transferred
+        ) == vals_B0.locked + vals_B0.transferred
+
+        # Start channel lifecycle
+        create_channel_and_deposit(A, B, vals_A.deposit, vals_B.deposit)
+        withdraw_channel(A, vals_A.withdrawn, B)
+        withdraw_channel(B, vals_B.withdrawn, A)
+
+        # For the purpose of this test, it is not important when the secrets are revealed,
+        # as long as the secrets connected to pending transfers that should be finalized,
+        # are revealed before their expiration.
+
+        # Mock pending transfers data for A -> B
+        pending_transfers_tree_A = get_pending_transfers_tree(
+            web3,
+            unlockable_amount=vals_A.claimable_locked,
+            expired_amount=vals_A.unclaimable_locked,
+        )
+        vals_A.locksroot = pending_transfers_tree_A.merkle_root
+        # Reveal A's secrets.
+        reveal_secrets(A, pending_transfers_tree_A.unlockable)
+
+        # Mock pending transfers data for B -> A
+        pending_transfers_tree_B = get_pending_transfers_tree(
+            web3,
+            unlockable_amount=vals_B.claimable_locked,
+            expired_amount=vals_B.unclaimable_locked,
+        )
+        vals_B.locksroot = pending_transfers_tree_B.merkle_root
+        # Reveal B's secrets
+        reveal_secrets(B, pending_transfers_tree_B.unlockable)
+
+        close_and_update_channel(
+            A,
+            vals_A,
+            B,
+            vals_B,
+        )
+
+        web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN)
+
+        pre_balance_A = custom_token.functions.balanceOf(A).call()
+        pre_balance_B = custom_token.functions.balanceOf(B).call()
+        pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
+
+        call_settle(token_network, A, vals_A, B, vals_B)
+
+        # We do the balance & state tests here for each channel and also compare with
+        # the expected settlement amounts
+        settle_state_tests(
+            A,
+            vals_A,
+            B,
+            vals_B,
+            pre_balance_A,
+            pre_balance_B,
+            pre_balance_contract,
+        )
+
+        # We compute again the settlement amounts here to compare with the other channel
+        # settlement test values, which should be equal
+
+        # Calculate how much A and B should receive
+        settlement_equivalent = get_settlement_amounts(vals_A, vals_B)
+        assert (
+            settlement.participant1_balance +
+            settlement.participant2_locked == settlement_equivalent.participant1_balance +
+            settlement_equivalent.participant2_locked
+        )
+        assert (
+            settlement.participant2_balance +
+            settlement.participant1_locked == settlement_equivalent.participant2_balance +
+            settlement_equivalent.participant1_locked
+        )
+
+        # Calculate how much A and B receive according to onchain computation
+        settlement2_equivalent = get_onchain_settlement_amounts(vals_A, vals_B)
+        assert (
+            settlement2.participant1_balance +
+            settlement2.participant2_locked == settlement2_equivalent.participant1_balance +
+            settlement2_equivalent.participant2_locked
+        )
+        assert (
+            settlement2.participant2_balance +
+            settlement2.participant1_locked == settlement2_equivalent.participant2_balance +
+            settlement2_equivalent.participant1_locked
+        )
+
+        assert get_unlocked_amount(
+            secret_registry_contract,
+            pending_transfers_tree_B.packed_transfers,
+        ) == vals_B.claimable_locked
+
+        # A unlocks B's pending transfers
+        contract_locked_B = token_network.functions.getParticipantLockedAmount(
+            B,
+            A,
+            vals_B.locksroot,
+        ).call()
+        if contract_locked_B == 0:
+            with pytest.raises(TransactionFailed):
+                token_network.functions.unlock(
+                    A,
+                    B,
+                    pending_transfers_tree_B.packed_transfers,
+                ).transact()
+        else:
+            token_network.functions.unlock(
+                A,
+                B,
+                pending_transfers_tree_B.packed_transfers,
+            ).transact()
+
+            # The locked amount should have been removed from contract storage
+            assert token_network.functions.getParticipantLockedAmount(
+                B,
+                A,
+                vals_B.locksroot,
+            ).call() == 0
+
+        # B unlocks A's pending transfers
+        contract_locked_A = token_network.functions.getParticipantLockedAmount(
+            A,
+            B,
+            vals_A.locksroot,
+        ).call()
+        if contract_locked_A == 0:
+            with pytest.raises(TransactionFailed):
+                token_network.functions.unlock(
+                    B,
+                    A,
+                    pending_transfers_tree_A.packed_transfers,
+                ).transact()
+        else:
+            token_network.functions.unlock(
+                B,
+                A,
+                pending_transfers_tree_A.packed_transfers,
+            ).transact()
+
+            # The locked amount should have been removed from contract storage
+            assert token_network.functions.getParticipantLockedAmount(
+                A,
+                B,
+                vals_A.locksroot,
+            ).call() == 0
+
+        # Calculate how much A and B should receive after the channel is settled and
+        # unlock is called by both.
+        (
+            expected_final_balance_A,
+            expected_final_balance_B,
+        ) = get_expected_after_settlement_unlock_amounts(vals_A, vals_B)
+
+        # If the balance proofs are invalid (participants are using an unofficial malicious
+        # Raiden client), there are cases where participants can lose tokens.
+        # We ensure balance correctness only if both participants use the official Raiden client.
+        if are_balance_proofs_valid(vals_A, vals_B):
+            # If both balance proofs are valid and are the last ones known, then the final
+            # settlement & post-unlock amounts should be the expected ones.
+            if not is_balance_proof_old(vals_A, vals_B):
+                assert custom_token.functions.balanceOf(A).call() == (
+                    pre_balance_A +
+                    expected_final_balance_A
+                )
+                assert custom_token.functions.balanceOf(B).call() == (
+                    pre_balance_B +
+                    expected_final_balance_B
+                )
+                if are_balance_proofs_valid(vals_A0, vals_B0):
+                    assert expected_final_balance_A0 == expected_final_balance_A
+                    assert expected_final_balance_B0 == expected_final_balance_B
+
+            # TODO
+            # Even when old balance proofs are used, we must ensure that we still get the
+            # expected amount as if we are using the last balance proofs or
+            # the attacker (participant who sends the older balance proof) gets <= tokens
+            # than expected. This case has been documented here
+            # https://github.com/raiden-network/raiden-contracts/issues/188#issuecomment-404759425
+
+        # Regardless of the tokens received by the two participants, we must make sure tokens
+        # are not stolen from the other channels. And we must make sure tokens are not locked in
+        # the contract after the entire channel cycle is finalized.
+        assert custom_token.functions.balanceOf(token_network.address).call() == (
+            pre_balance_contract -
+            (expected_final_balance_A + expected_final_balance_B)
+        )
+        assert (
+            expected_final_balance_A +
+            expected_final_balance_B
+        ) == (expected_final_balance_A0 + expected_final_balance_B0)

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -500,7 +500,9 @@ def test_channel_unlock_expired_lock_refunds(
     web3.testing.mine(max_lock_expiration)
 
     # Secrets are revealed before settlement window, but after expiration
-    reveal_secrets(A, pending_transfers_tree.unlockable)
+    for (expiration, amount, secrethash, secret) in pending_transfers_tree.unlockable:
+        secret_registry_contract.functions.registerSecret(secret).transact({'from': A})
+        assert secret_registry_contract.functions.getSecretRevealBlockHeight(secrethash).call() == web3.eth.blockNumber
 
     close_and_update_channel(
         channel_identifier,

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -500,9 +500,11 @@ def test_channel_unlock_expired_lock_refunds(
     web3.testing.mine(max_lock_expiration)
 
     # Secrets are revealed before settlement window, but after expiration
-    for (expiration, amount, secrethash, secret) in pending_transfers_tree.unlockable:
+    for (_, _, secrethash, secret) in pending_transfers_tree.unlockable:
         secret_registry_contract.functions.registerSecret(secret).transact({'from': A})
-        assert secret_registry_contract.functions.getSecretRevealBlockHeight(secrethash).call() == web3.eth.blockNumber
+        assert secret_registry_contract.functions.getSecretRevealBlockHeight(
+            secrethash,
+        ).call() == web3.eth.blockNumber
 
     close_and_update_channel(
         channel_identifier,

--- a/raiden_contracts/tests/utils/utils.py
+++ b/raiden_contracts/tests/utils/utils.py
@@ -45,98 +45,6 @@ class ChannelValues():
         )
 
 
-def random_secret():
-    secret = os.urandom(32)
-    return (Web3.soliditySha3(['bytes32'], [secret]), secret)
-
-
-def get_pending_transfers(
-        web3,
-        unlockable_amounts,
-        expired_amounts,
-        min_expiration_delta=0,
-        max_expiration_delta=0,
-):
-    current_block = web3.eth.blockNumber
-    min_expiration_delta = min_expiration_delta or (len(unlockable_amounts) + 1)
-    max_expiration_delta = max_expiration_delta or (min_expiration_delta + TEST_SETTLE_TIMEOUT_MIN)
-
-    unlockable_locks = [
-        [
-            current_block + random.randint(min_expiration_delta, max_expiration_delta),
-            amount,
-            *random_secret(),
-        ]
-        for amount in unlockable_amounts
-    ]
-    expired_locks = [
-        [current_block, amount, *random_secret()]
-        for amount in expired_amounts
-    ]
-    return (unlockable_locks, expired_locks)
-
-
-def get_pending_transfers_tree(
-        web3,
-        unlockable_amounts=None,
-        expired_amounts=None,
-        min_expiration_delta=None,
-        max_expiration_delta=None,
-        unlockable_amount=None,
-        expired_amount=None,
-):
-    types = ['uint256', 'uint256', 'bytes32']
-    if unlockable_amounts is None:
-        unlockable_amounts = []
-    if expired_amounts is None:
-        expired_amounts = []
-    if unlockable_amount is not None:
-        unlockable_amounts = get_random_values_for_sum(unlockable_amount)
-    if expired_amount is not None:
-        expired_amounts = get_random_values_for_sum(expired_amount)
-
-    (unlockable_locks, expired_locks) = get_pending_transfers(
-        web3,
-        unlockable_amounts,
-        expired_amounts,
-        min_expiration_delta,
-        max_expiration_delta,
-    )
-    pending_transfers = unlockable_locks + expired_locks
-
-    hashed_pending_transfers = [
-        Web3.soliditySha3(types, transfer_data[:-1])
-        for transfer_data in pending_transfers
-    ]
-    if len(pending_transfers) > 0:
-        hashed_pending_transfers, pending_transfers = zip(*sorted(zip(
-            hashed_pending_transfers,
-            pending_transfers,
-        )))
-        packed_transfers = get_packed_transfers(pending_transfers, types)
-    else:
-        packed_transfers = b''
-
-    merkle_tree = compute_merkle_tree(hashed_pending_transfers)
-    merkle_root = get_merkle_root(merkle_tree)
-    locked_amount = get_locked_amount(pending_transfers)
-
-    return PendingTransfersTree(
-        transfers=pending_transfers,
-        unlockable=unlockable_locks,
-        expired=expired_locks,
-        packed_transfers=packed_transfers,
-        merkle_tree=merkle_tree,
-        merkle_root=merkle_root,
-        locked_amount=locked_amount,
-    )
-
-
-def get_packed_transfers(pending_transfers, types):
-    packed_transfers = [encode_abi(types, x[:-1]) for x in pending_transfers]
-    return reduce((lambda x, y: x + y), packed_transfers)
-
-
 def get_participant_available_balance(participant1, participant2):
     """ Returns the available balance for participant1
 
@@ -161,18 +69,35 @@ def are_balance_proofs_valid(participant1, participant2):
     participant1_available_balance = get_participant_available_balance(participant1, participant2)
     participant2_available_balance = get_participant_available_balance(participant2, participant1)
 
+    total_available_deposit = get_total_available_deposit(participant1, participant2)
+
     return (
         participant1.transferred + participant1.locked <= MAX_UINT256 and
         participant2.transferred + participant2.locked <= MAX_UINT256 and
-        participant1_available_balance >= 0 and participant2_available_balance >= 0
+        participant1_available_balance >= 0 and
+        participant2_available_balance >= 0 and
+        participant1_available_balance <= total_available_deposit and
+        participant2_available_balance <= total_available_deposit and
+        participant1.locked <= participant1_available_balance and
+        participant2.locked <= participant2_available_balance
+    )
+
+
+def were_balance_proofs_valid(participant1, participant2):
+    """ Checks if balance proofs were ever valid. """
+    deposit = participant1.deposit + participant2.deposit
+
+    # Regardless of issuance time, the locked amount must be smaller than the
+    # total channel deposit.
+    return (
+        participant1.locked <= deposit and
+        participant2.locked <= deposit
     )
 
 
 def is_balance_proof_old(participant1, participant2):
     """ Checks if balance proofs are valid, with at least one old. """
-    both_valid = are_balance_proofs_valid(participant1, participant2)
-    if not both_valid:
-        return False
+    assert were_balance_proofs_valid(participant1, participant2)
 
     total_available_deposit = get_total_available_deposit(participant1, participant2)
 
@@ -181,7 +106,8 @@ def is_balance_proof_old(participant1, participant2):
         participant2_balance,
     ) = get_expected_after_settlement_unlock_amounts(participant1, participant2)
 
-    if participant1_balance + participant2_balance != total_available_deposit:
+    # Valid last balance proofs should ensure the following equality:
+    if participant1_balance + participant2_balance == total_available_deposit:
         return False
 
     return True
@@ -387,13 +313,3 @@ def get_participants_hash(A, B):
     A = to_canonical_address(A)
     B = to_canonical_address(B)
     return keccak(A + B) if A < B else keccak(B + A)
-
-
-def get_random_values_for_sum(values_sum):
-    amount = 0
-    values = []
-    while amount < values_sum:
-        value = random.randint(1, values_sum - amount)
-        values.append(value)
-        amount += value
-    return values

--- a/raiden_contracts/tests/utils/utils.py
+++ b/raiden_contracts/tests/utils/utils.py
@@ -78,14 +78,18 @@ def get_pending_transfers(
 
 def get_pending_transfers_tree(
         web3,
-        unlockable_amounts=[],
-        expired_amounts=[],
+        unlockable_amounts=None,
+        expired_amounts=None,
         min_expiration_delta=None,
         max_expiration_delta=None,
         unlockable_amount=None,
         expired_amount=None,
 ):
     types = ['uint256', 'uint256', 'bytes32']
+    if unlockable_amounts is None:
+        unlockable_amounts = []
+    if expired_amounts is None:
+        expired_amounts = []
     if unlockable_amount is not None:
         unlockable_amounts = get_random_values_for_sum(unlockable_amount)
     if expired_amount is not None:

--- a/raiden_contracts/tests/utils/utils.py
+++ b/raiden_contracts/tests/utils/utils.py
@@ -153,7 +153,11 @@ def get_participant_available_balance(participant1, participant2):
 
 
 def are_balance_proofs_valid(participant1, participant2):
-    """ Checks if balance proofs are valid or could have been valid at a certain point in time """
+    """ Checks if balance proofs are valid or could have been valid at a certain point in time
+
+    Balance proof constraints are detailed in
+    https://github.com/raiden-network/raiden-contracts/issues/188#issuecomment-404752095
+    """
     participant1_available_balance = get_participant_available_balance(participant1, participant2)
     participant2_available_balance = get_participant_available_balance(participant2, participant1)
 

--- a/raiden_contracts/tests/utils/utils.py
+++ b/raiden_contracts/tests/utils/utils.py
@@ -156,7 +156,7 @@ def are_balance_proofs_valid(participant1, participant2):
     """ Checks if balance proofs are valid or could have been valid at a certain point in time """
     participant1_available_balance = get_participant_available_balance(participant1, participant2)
     participant2_available_balance = get_participant_available_balance(participant2, participant1)
-    print('av balances', participant1_available_balance, participant2_available_balance)
+
     return (
         participant1.transferred + participant1.locked <= MAX_UINT256 and
         participant2.transferred + participant2.locked <= MAX_UINT256 and


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden-contracts/issues/132

Linked issue: https://github.com/raiden-network/raiden-contracts/issues/188. This PR implements tests for old balance proofs. I manually created examples for the old balance proofs that can exist for a pair of last valid balance proofs.

- added values for balance proofs edge cases, mimicking old balance proofs
- removed the tests that only tried to mimic old balance proofs with the same `transferred + claimable_locked` sum (added manual values for this); these tests are redundant and they were not implemented correctly; it is hard to implement this correctly, because there are constraints on the maximum locked amount that can exist in a valid balance proof
- added balance tests to make sure that with an old balance proof, the attacker cannot receive more tokens that he is supposed to (at the end of the channel lifecycle)