### PR TITLE
Adds wrapper for getSettleTransferAmounts.

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -609,7 +609,7 @@ contract TokenNetwork is Utils {
         uint256 participant2_locked_amount
     )
         view
-        private
+        internal
         returns (uint256, uint256, uint256, uint256)
     {
         // Direct token transfers done through the token `transfer` function


### PR DESCRIPTION
We must decide if we wanna change the visibility of `getSettleTransferAmounts` to make it testable. 
Alternative would be to cp+pst it to `TokenNetworkInternalsTest` and keep it synced - danger to get green tests due testing an outdated function. 