### PR TITLE
Add nonce as argument to NonClosingBalanceProofUpdated event

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -130,7 +130,8 @@ contract TokenNetwork is Utils {
 
     event NonClosingBalanceProofUpdated(
         uint256 indexed channel_identifier,
-        address indexed closing_participant
+        address indexed closing_participant,
+        uint256 nonce
     );
 
     event ChannelSettled(
@@ -460,7 +461,7 @@ contract TokenNetwork is Utils {
         // Update the balance proof data for the closing_participant
         updateBalanceProofData(channel, closing_participant, nonce, balance_hash);
 
-        emit NonClosingBalanceProofUpdated(channel_identifier, closing_participant);
+        emit NonClosingBalanceProofUpdated(channel_identifier, closing_participant, nonce);
 
         // Channel must be closed
         require(channel.state == 2);

--- a/raiden_contracts/tests/test_channel_update_transfer.py
+++ b/raiden_contracts/tests/test_channel_update_transfer.py
@@ -958,6 +958,7 @@ def test_update_channel_event(
     channel_identifier = create_channel(A, B)[0]
     channel_deposit(A, deposit_A, B)
     channel_deposit(B, deposit_B, A)
+
     balance_proof_B = create_balance_proof(channel_identifier, B, 5, 0, 3)
     balance_proof_A = create_balance_proof(channel_identifier, A, 2, 0, 1)
     balance_proof_update_signature_B = create_balance_proof_update_signature(
@@ -977,6 +978,27 @@ def test_update_channel_event(
     ev_handler.add(
         txn_hash,
         EVENT_CHANNEL_BALANCE_PROOF_UPDATED,
-        check_transfer_updated(channel_identifier, A),
+        check_transfer_updated(channel_identifier, A, 1),
+    )
+    ev_handler.check()
+
+    # Test event for second balance proof update
+    balance_proof_A2 = create_balance_proof(channel_identifier, A, 4, 0, 2)
+    balance_proof_update_signature_B2 = create_balance_proof_update_signature(
+        B,
+        channel_identifier,
+        *balance_proof_A2,
+    )
+    txn_hash = token_network.functions.updateNonClosingBalanceProof(
+        A,
+        B,
+        *balance_proof_A2,
+        balance_proof_update_signature_B2,
+    ).transact({'from': B})
+
+    ev_handler.add(
+        txn_hash,
+        EVENT_CHANNEL_BALANCE_PROOF_UPDATED,
+        check_transfer_updated(channel_identifier, A, 2),
     )
     ev_handler.check()

--- a/raiden_contracts/utils/events.py
+++ b/raiden_contracts/utils/events.py
@@ -68,10 +68,11 @@ def check_channel_unlocked(participant, partner, locksroot, unlocked_amount, ret
     return get
 
 
-def check_transfer_updated(channel_identifier, closing_participant):
+def check_transfer_updated(channel_identifier, closing_participant, nonce):
     def get(event):
         assert event['args']['channel_identifier'] == channel_identifier
         assert event['args']['closing_participant'] == closing_participant
+        assert event['args']['nonce'] == nonce
     return get
 
 


### PR DESCRIPTION
Fixes https://github.com/raiden-network/raiden-contracts/issues/196

Needed for keeping track of balance data updates more easily from the Raiden client & Monitoring Service
- add `nonce` as argument to `NonClosingBalanceProofUpdated` event
- fix & extend test for the event