### PR TITLE
 Refactor unlock data storage in TokenNetwork, link to channel identifier

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -742,7 +742,7 @@ contract TokenNetwork is Utils {
         // Locksroot must be the same as the computed locksroot
         require(unlock_data.locksroot == computed_locksroot);
 
-        // There are no pending transfers if the locked_amount will be 0. Transaction must fail
+        // There are no pending transfers if the locked_amount is 0. Transaction must fail
         require(locked_amount > 0);
 
         // Make sure we don't transfer more tokens than previously reserved in the smart contract.
@@ -1083,8 +1083,8 @@ contract TokenNetwork is Utils {
     /// @param channel_identifier Identifier for the channel on which this operation takes place.
     /// @param participant Address of the channel participant whose data will be returned.
     /// @param partner Address of the channel partner
-    /// @return Participant's channel deposit, whether the participant has called
-    /// `closeChannel` or not, balance_hash and nonce.
+    /// @return Participant's deposit, withdrawn_amount, whether the participant has called
+    /// `closeChannel` or not, balance_hash, nonce, locksroot, locked_amount.
     function getChannelParticipantInfo(
             uint256 channel_identifier,
             address participant,

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -38,12 +38,10 @@ contract TokenNetwork is Utils {
     // We keep the unlock data in a separate mapping to allow channel data structures to be
     // removed when settling uncooperatively. If there are locked pending transfers, we need to
     // store data needed to unlock them at a later time.
-    // The key is `keccak256(participants_hash + participant_address + locksroot)`
-    // The value is the total amount of tokens locked in the pending transfers corresponding to
-    // the `locksroot`, that were sent by `participant_address` to his channel partner.
-    // Note that the assumption is that no two locksroots can be the same due to having different
-    // values for the secrethash of each lock, combined with different `expiration` values.
-    mapping(bytes32 => uint256) locksroot_identifier_to_locked_amount;
+    // The key is `keccak256(uint256 channel_identifier, address participant, address partner)`
+    // Where `participant` is the participant that sent the pending transfers
+    // We need `partner` for knowing where to send the claimable tokens
+    mapping(bytes32 => UnlockData) unlock_identifier_to_unlock_data;
 
     struct Participant {
         // Total amount of token transferred to this smart contract through the
@@ -93,6 +91,13 @@ contract TokenNetwork is Utils {
         uint256 withdrawn;
         uint256 transferred;
         uint256 locked;
+    }
+
+    struct UnlockData {
+        // Merkle root of the pending transfers tree from the Raiden client
+        bytes32 locksroot;
+        // Total amount of tokens locked in the pending transfers corresponding to the `locksroot`
+        uint256 locked_amount;
     }
 
     event ChannelOpened(
@@ -563,15 +568,16 @@ contract TokenNetwork is Utils {
         // Remove the pair's channel counter
         delete participants_hash_to_channel_identifier[pair_hash];
 
-
         // Store balance data needed for `unlock`
         updateUnlockData(
+            channel_identifier,
             participant1,
             participant2,
             participant1_locked_amount,
             participant1_locksroot
         );
         updateUnlockData(
+            channel_identifier,
             participant2,
             participant1,
             participant2_locked_amount,
@@ -692,8 +698,8 @@ contract TokenNetwork is Utils {
     /// `participant`. Locked tokens corresponding to locks where the secret was not revelead
     /// on-chain will return to the `partner`. Anyone can call unlock.
     /// @param channel_identifier Identifier for the channel on which this operation takes place.
-    /// @param participant Address who will receive the unlocked tokens.
-    /// @param partner Address who sent the pending transfers.
+    /// @param participant Address who will receive the claimable unlocked tokens.
+    /// @param partner Address who sent the pending transfers and will receive the unclaimable unlocked tokens.
     /// @param merkle_tree_leaves The entire merkle tree of pending transfers that `partner`
     /// sent to `participant`.
     function unlock(
@@ -706,9 +712,16 @@ contract TokenNetwork is Utils {
     {
         // Channel represented by channel_identifier must be settled and channel data deleted
         require(channel_identifier != getChannelIdentifier(participant, partner));
+
+        // After the channel is settled the storage is cleared, therefore the
+        // value will be NonExistent and not Settled. The value Settled is used
+        // for the external APIs
+        require(channels[channel_identifier].state == ChannelState.NonExistent);
+
         require(merkle_tree_leaves.length > 0);
 
         bytes32 unlock_key;
+        bytes32 locksroot;
         bytes32 computed_locksroot;
         uint256 unlocked_amount;
         uint256 locked_amount;
@@ -722,10 +735,14 @@ contract TokenNetwork is Utils {
         // the computed locksroot.
         // Get the amount of tokens that have been left in the contract, to account for the
         // pending transfers `partner` -> `participant`.
-        unlock_key = getLocksrootIdentifier(partner, participant, computed_locksroot);
-        locked_amount = locksroot_identifier_to_locked_amount[unlock_key];
+        unlock_key = getUnlockIdentifier(channel_identifier, partner, participant);
+        UnlockData storage unlock_data = unlock_identifier_to_unlock_data[unlock_key];
+        locked_amount = unlock_data.locked_amount;
 
-        // If the locksroot does not exist, then the locked_amount will be 0. Transaction must fail
+        // Locksroot must be the same as the computed locksroot
+        require(unlock_data.locksroot == computed_locksroot);
+
+        // There are no pending transfers if the locked_amount will be 0. Transaction must fail
         require(locked_amount > 0);
 
         // Make sure we don't transfer more tokens than previously reserved in the smart contract.
@@ -735,7 +752,7 @@ contract TokenNetwork is Utils {
         returned_tokens = locked_amount - unlocked_amount;
 
         // Remove partner's unlock data
-        delete locksroot_identifier_to_locked_amount[unlock_key];
+        delete unlock_identifier_to_unlock_data[unlock_key];
 
         // Transfer the unlocked tokens to the participant. unlocked_amount can be 0
         if (unlocked_amount > 0) {
@@ -756,14 +773,8 @@ contract TokenNetwork is Utils {
             returned_tokens
         );
 
-        // After the channel is settled the storage is cleared, therefore the
-        // value will be NonExistent and not Settled. The value Settled is used
-        // for the external APIs
-        require(channels[channel_identifier].state == ChannelState.NonExistent);
-
-        require(computed_locksroot != 0);
-        require(locked_amount > 0);
-        require(locked_amount >= returned_tokens);
+        // At this point, this should always be true
+        assert(locked_amount >= returned_tokens);
         assert(locked_amount >= unlocked_amount);
     }
 
@@ -895,21 +906,17 @@ contract TokenNetwork is Utils {
         }
     }
 
-    function getLocksrootIdentifier(
+    function getUnlockIdentifier(
+        uint256 channel_identifier,
         address participant,
-        address partner,
-        bytes32 locksroot
+        address partner
     )
         pure
         public
-        returns (bytes32 key)
+        returns (bytes32)
     {
-        require(locksroot != 0x0);
-
-        bytes32 participants_hash = getParticipantsHash(participant, partner);
-
-        // Get the locksroot corresponding to the pending transfers participant -> partner
-        key = keccak256(abi.encodePacked(participants_hash, participant, locksroot));
+        require(participant != partner);
+        return keccak256(abi.encodePacked(channel_identifier, participant, partner));
     }
 
     function updateBalanceProofData(
@@ -931,6 +938,7 @@ contract TokenNetwork is Utils {
     }
 
     function updateUnlockData(
+        uint256 channel_identifier,
         address participant,
         address partner,
         uint256 locked_amount,
@@ -943,8 +951,10 @@ contract TokenNetwork is Utils {
             return;
         }
 
-        bytes32 key = getLocksrootIdentifier(participant, partner, locksroot);
-        locksroot_identifier_to_locked_amount[key] = locked_amount;
+        bytes32 key = getUnlockIdentifier(channel_identifier, participant, partner);
+        UnlockData storage unlock_data = unlock_identifier_to_unlock_data[key];
+        unlock_data.locksroot = locksroot;
+        unlock_data.locked_amount = locked_amount;
     }
 
     function getChannelAvailableDeposit(
@@ -1072,43 +1082,35 @@ contract TokenNetwork is Utils {
     /// @dev Returns the channel specific data.
     /// @param channel_identifier Identifier for the channel on which this operation takes place.
     /// @param participant Address of the channel participant whose data will be returned.
+    /// @param partner Address of the channel partner
     /// @return Participant's channel deposit, whether the participant has called
     /// `closeChannel` or not, balance_hash and nonce.
-    function getChannelParticipantInfo(uint256 channel_identifier, address participant)
+    function getChannelParticipantInfo(
+            uint256 channel_identifier,
+            address participant,
+            address partner
+    )
         view
         external
-        returns (uint256, uint256, bool, bytes32, uint256)
+        returns (uint256, uint256, bool, bytes32, uint256, bytes32, uint256)
     {
+        bytes32 unlock_key;
+
         Participant storage participant_state = channels[channel_identifier].participants[
             participant
         ];
+        unlock_key = getUnlockIdentifier(channel_identifier, participant, partner);
+        UnlockData storage unlock_data = unlock_identifier_to_unlock_data[unlock_key];
 
         return (
             participant_state.deposit,
             participant_state.withdrawn_amount,
             participant_state.is_the_closer,
             participant_state.balance_hash,
-            participant_state.nonce
+            participant_state.nonce,
+            unlock_data.locksroot,
+            unlock_data.locked_amount
         );
-    }
-
-    /// @dev Returns the locked amount of tokens for a given locksroot.
-    /// @param participant1 Address of a channel participant.
-    /// @param participant2 Address of the other channel participant.
-    /// @return The amount of tokens that `participant1` has locked in the contract to account for
-    /// his pending transfers to `participant2`.
-    function getParticipantLockedAmount(
-        address participant1,
-        address participant2,
-        bytes32 locksroot
-    )
-        view
-        public
-        returns (uint256)
-    {
-        bytes32 unlock_key = getLocksrootIdentifier(participant1, participant2, locksroot);
-
-        return locksroot_identifier_to_locked_amount[unlock_key];
     }
 
     /*

--- a/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
+++ b/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
@@ -40,6 +40,7 @@ contract TokenNetworkInternalsTest is TokenNetwork {
     }
 
     function updateUnlockDataPublic(
+        uint256 channel_identifier,
         address participant,
         address partner,
         uint256 locked_amount,
@@ -48,6 +49,7 @@ contract TokenNetworkInternalsTest is TokenNetwork {
         public
     {
        return updateUnlockData(
+            channel_identifier,
             participant,
             partner,
             locked_amount,

--- a/raiden_contracts/tests/test_channel_close.py
+++ b/raiden_contracts/tests/test_channel_close.py
@@ -281,11 +281,14 @@ def test_close_channel_state(
     assert state == CHANNEL_STATE_OPENED
 
     (
-        _, _,
+        _,
+        _,
         A_is_the_closer,
         A_balance_hash,
         A_nonce,
-    ) = token_network.functions.getChannelParticipantInfo(channel_identifier, A).call()
+        _,
+        _,
+    ) = token_network.functions.getChannelParticipantInfo(channel_identifier, A, B).call()
     assert A_is_the_closer is False
     assert A_balance_hash == fake_bytes(32)
     assert A_nonce == 0
@@ -307,7 +310,9 @@ def test_close_channel_state(
         A_is_the_closer,
         A_balance_hash,
         A_nonce,
-    ) = token_network.functions.getChannelParticipantInfo(channel_identifier, A).call()
+        _,
+        _,
+    ) = token_network.functions.getChannelParticipantInfo(channel_identifier, A, B).call()
     assert A_is_the_closer is True
     assert A_balance_hash == fake_bytes(32)
     assert A_nonce == 0
@@ -317,7 +322,9 @@ def test_close_channel_state(
         B_is_the_closer,
         B_balance_hash,
         B_nonce,
-    ) = token_network.functions.getChannelParticipantInfo(channel_identifier, B).call()
+        _,
+        _,
+    ) = token_network.functions.getChannelParticipantInfo(channel_identifier, B, A).call()
     assert B_is_the_closer is False
     assert B_balance_hash == balance_proof[0]
     assert B_nonce == nonce

--- a/raiden_contracts/tests/test_channel_deposit.py
+++ b/raiden_contracts/tests/test_channel_deposit.py
@@ -219,18 +219,34 @@ def test_deposit_channel_state(token_network, create_channel, channel_deposit, g
 
     channel_identifier = create_channel(A, B)[0]
 
-    A_deposit = token_network.functions.getChannelParticipantInfo(channel_identifier, A).call()[0]
+    A_deposit = token_network.functions.getChannelParticipantInfo(
+        channel_identifier,
+        A,
+        B,
+    ).call()[0]
     assert A_deposit == 0
 
-    B_deposit = token_network.functions.getChannelParticipantInfo(channel_identifier, B).call()[0]
+    B_deposit = token_network.functions.getChannelParticipantInfo(
+        channel_identifier,
+        B,
+        A,
+    ).call()[0]
     assert B_deposit == 0
 
     channel_deposit(channel_identifier, A, deposit_A, B)
-    A_deposit = token_network.functions.getChannelParticipantInfo(channel_identifier, A).call()[0]
+    A_deposit = token_network.functions.getChannelParticipantInfo(
+        channel_identifier,
+        A,
+        B,
+    ).call()[0]
     assert A_deposit == deposit_A
 
     channel_deposit(channel_identifier, B, deposit_B, A)
-    B_deposit = token_network.functions.getChannelParticipantInfo(channel_identifier, B).call()[0]
+    B_deposit = token_network.functions.getChannelParticipantInfo(
+        channel_identifier,
+        B,
+        A,
+    ).call()[0]
     assert B_deposit == deposit_B
 
 

--- a/raiden_contracts/tests/test_channel_open.py
+++ b/raiden_contracts/tests/test_channel_open.py
@@ -11,6 +11,7 @@ from raiden_contracts.utils.events import check_channel_opened
 from .fixtures.config import EMPTY_ADDRESS, FAKE_ADDRESS, fake_bytes
 from web3.exceptions import ValidationError
 from .utils import get_participants_hash
+from raiden_contracts.utils.merkle import EMPTY_MERKLE_ROOT
 
 
 def test_open_channel_call(token_network, get_accounts):
@@ -162,12 +163,16 @@ def test_open_channel_state(token_network, get_accounts):
         A_is_the_closer,
         A_balance_hash,
         A_nonce,
-    ) = token_network.functions.getChannelParticipantInfo(channel_identifier, A).call()
+        A_locksroot,
+        A_locked_amount,
+    ) = token_network.functions.getChannelParticipantInfo(channel_identifier, A, B).call()
     assert A_deposit == 0
     assert A_withdrawn == 0
     assert A_is_the_closer is False
     assert A_balance_hash == fake_bytes(32)
     assert A_nonce == 0
+    assert A_locksroot == EMPTY_MERKLE_ROOT
+    assert A_locked_amount == 0
 
     (
         B_deposit,
@@ -175,12 +180,16 @@ def test_open_channel_state(token_network, get_accounts):
         B_is_the_closer,
         B_balance_hash,
         B_nonce,
-    ) = token_network.functions.getChannelParticipantInfo(channel_identifier, B).call()
+        B_locksroot,
+        B_locked_amount,
+    ) = token_network.functions.getChannelParticipantInfo(channel_identifier, B, A).call()
     assert B_deposit == 0
     assert B_withdrawn == 0
     assert B_is_the_closer is False
     assert B_balance_hash == fake_bytes(32)
     assert B_nonce == 0
+    assert B_locksroot == EMPTY_MERKLE_ROOT
+    assert B_locked_amount == 0
 
 
 def test_reopen_channel(
@@ -252,12 +261,16 @@ def test_reopen_channel(
         A_is_the_closer,
         A_balance_hash,
         A_nonce,
-    ) = token_network.functions.getChannelParticipantInfo(channel_identifier2, A).call()
+        A_locksroot,
+        A_locked_amount,
+    ) = token_network.functions.getChannelParticipantInfo(channel_identifier2, A, B).call()
     assert A_deposit == 0
     assert A_withdrawn == 0
     assert A_is_the_closer is False
     assert A_balance_hash == fake_bytes(32)
     assert A_nonce == 0
+    assert A_locksroot == EMPTY_MERKLE_ROOT
+    assert A_locked_amount == 0
 
     (
         B_deposit,
@@ -265,12 +278,16 @@ def test_reopen_channel(
         B_is_the_closer,
         B_balance_hash,
         B_nonce,
-    ) = token_network.functions.getChannelParticipantInfo(channel_identifier2, B).call()
+        B_locksroot,
+        B_locked_amount,
+    ) = token_network.functions.getChannelParticipantInfo(channel_identifier2, B, A).call()
     assert B_deposit == 0
     assert B_withdrawn == 0
     assert B_is_the_closer is False
     assert B_balance_hash == fake_bytes(32)
     assert B_nonce == 0
+    assert B_locksroot == EMPTY_MERKLE_ROOT
+    assert B_locked_amount == 0
 
 
 def test_open_channel_event(get_accounts, token_network, event_handler):

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -381,9 +381,11 @@ def test_channel_settle_and_unlock(
         A,
         pending_transfers_tree_1.packed_transfers,
     ).transact({'from': A})
+
     # Mock pending transfers data for a reopened channel
     pending_transfers_tree_2 = get_pending_transfers_tree(web3, [1, 3, 5], [2, 4], settle_timeout)
     reveal_secrets(A, pending_transfers_tree_2.unlockable)
+
     # Settle the channel again
     channel_identifier2 = create_settled_channel(
         A,
@@ -394,6 +396,7 @@ def test_channel_settle_and_unlock(
         EMPTY_MERKLE_ROOT,
         settle_timeout,
     )
+
     # 2nd unlocks should go through
     token_network.functions.unlock(
         channel_identifier2,
@@ -418,9 +421,11 @@ def test_channel_settle_and_unlock(
         EMPTY_MERKLE_ROOT,
         settle_timeout,
     )
+
     # Mock pending transfers data for a reopened channel
     pending_transfers_tree_2 = get_pending_transfers_tree(web3, [1, 3, 5], [2, 4], settle_timeout)
     reveal_secrets(A, pending_transfers_tree_2.unlockable)
+
     # Settle the channel again
     channel_identifier4 = create_settled_channel(
         A,
@@ -431,15 +436,16 @@ def test_channel_settle_and_unlock(
         EMPTY_MERKLE_ROOT,
         settle_timeout,
     )
+
     # Both old and new unlocks should go through
     token_network.functions.unlock(
-        channel_identifier3,
+        channel_identifier4,
         B,
         A,
         pending_transfers_tree_2.packed_transfers,
     ).transact({'from': A})
     token_network.functions.unlock(
-        channel_identifier4,
+        channel_identifier3,
         B,
         A,
         pending_transfers_tree_1.packed_transfers,

--- a/raiden_contracts/tests/test_channel_withdraw.py
+++ b/raiden_contracts/tests/test_channel_withdraw.py
@@ -397,9 +397,10 @@ def test_withdraw_channel_state(
     balance_C = custom_token.functions.balanceOf(C).call()
     balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
-    (_, withdrawn_amount, _, _, _) = token_network.functions.getChannelParticipantInfo(
+    (_, withdrawn_amount, _, _, _, _, _) = token_network.functions.getChannelParticipantInfo(
         channel_identifier,
         A,
+        B,
     ).call()
     assert withdrawn_amount == 0
 


### PR DESCRIPTION
Please review and merge after https://github.com/raiden-network/raiden-contracts/pull/198

As discussed in https://github.com/raiden-network/raiden-contracts/issues/202 and https://github.com/raiden-network/raiden-contracts/issues/193

Link the unlock data to a channel_identifier because we can currently have a new channel opened between two participants while still having tokens to unlock from previous channels between the same participants.

This makes it easier for the Raiden client to keep track of channel data that still is stored on-chain.

## Interface changes:

```
// returns participant's: deposit, withdrawn_amount, is_the_closer, balance_hash, nonce, locksroot, locked_amount
// `participant` - sends the pending transfers
// `partner` - receives claimable locked amount from `participant`'s transfers
function getChannelParticipantInfo(uint256 channel_identifier, address participant, address partner)
```