### PR TITLE
Added enum type represent the channel state

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -72,7 +72,7 @@ contract TokenNetwork is Utils {
         Opened,      // 1
         Closed,      // 2
         Settled      // 3; Note: The channel can be at the settled state and
-                     //          have pending unlocks or not
+                     //          may or may not have pending unlocks
     }
 
     struct Channel {
@@ -756,9 +756,9 @@ contract TokenNetwork is Utils {
             returned_tokens
         );
 
-        // After the channel is settled the storage is cleared, therefor the
-        // value will be Gone and not Settled. The value Settled is used for
-        // the external APIs
+        // After the channel is settled the storage is cleared, therefore the
+        // value will be NonExistent and not Settled. The value Settled is used
+        // for the external APIs
         require(channels[channel_identifier].state == ChannelState.NonExistent);
 
         require(computed_locksroot != 0);
@@ -1052,12 +1052,12 @@ contract TokenNetwork is Utils {
     function getChannelInfo(uint256 channel_identifier)
         view
         external
-        returns (uint256, uint8)
+        returns (uint256, ChannelState)
     {
         Channel storage channel = channels[channel_identifier];
-        ChannelState memory state = channel.state;  // This must **not** update the storage
+        ChannelState state = channel.state;  // This must **not** update the storage
 
-        if (state == ChannelState.Gone && channel_identifier > 0 && channel_identifier <= channel_counter) {
+        if (state == ChannelState.NonExistent && channel_identifier > 0 && channel_identifier <= channel_counter) {
             // The channel has been settled, channel data is removed
             // We might still have data stored for a future unlock operation
             state = ChannelState.Settled;

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -68,10 +68,10 @@ contract TokenNetwork is Utils {
     }
 
     enum ChannelState {
-        Gone,    // 0
-        Opened,  // 1
-        Closed,  // 2
-        Settled  // 3; note: the channel can be in a settled, but pending unlock state
+        NonExistent, // 0
+        Opened,      // 1
+        Closed,      // 2
+        Settled      // 3; note: the channel can be in a settled, but pending unlock state
     }
 
     struct Channel {
@@ -218,11 +218,10 @@ contract TokenNetwork is Utils {
         Channel storage channel = channels[channel_identifier];
 
         require(channel.settle_block_number == 0);
-        require(channel.state == ChannelState.Gone);
+        require(channel.state == ChannelState.NonExistent);
 
         // Store channel information
         channel.settle_block_number = settle_timeout;
-        // Mark channel as opened
         channel.state = ChannelState.Opened;
 
         emit ChannelOpened(channel_identifier, participant1, participant2, settle_timeout);
@@ -759,7 +758,7 @@ contract TokenNetwork is Utils {
         // After the channel is settled the storage is cleared, therefor the
         // value will be Gone and not Settled. The value Settled is used for
         // the external APIs
-        require(channels[channel_identifier].state == ChannelState.Gone);
+        require(channels[channel_identifier].state == ChannelState.NonExistent);
 
         require(computed_locksroot != 0);
         require(locked_amount > 0);

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -71,7 +71,8 @@ contract TokenNetwork is Utils {
         NonExistent, // 0
         Opened,      // 1
         Closed,      // 2
-        Settled      // 3; note: the channel can be in a settled, but pending unlock state
+        Settled      // 3; Note: The channel can be at the settled state and
+                     //          have pending unlocks or not
     }
 
     struct Channel {

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -67,6 +67,13 @@ contract TokenNetwork is Utils {
         uint256 nonce;
     }
 
+    enum ChannelState {
+        Gone,    // 0
+        Opened,  // 1
+        Closed,  // 2
+        Settled  // 3; note: the channel can be in a settled, but pending unlock state
+    }
+
     struct Channel {
         // After opening the channel this value represents the settlement window. This is the
         // number of blocks that need to be mined between closing the channel uncooperatively
@@ -75,12 +82,7 @@ contract TokenNetwork is Utils {
         // block number after which settleChannel can be called.
         uint256 settle_block_number;
 
-        // Channel state
-        // 0 = non-existent
-        // 1 = open
-        // 2 = closed
-        // 3 = settled; note: the channel can be in a settled, but pending unlock state
-        uint8 state;
+        ChannelState state;
 
         mapping(address => Participant) participants;
     }
@@ -137,12 +139,8 @@ contract TokenNetwork is Utils {
         uint256 participant2_amount
     );
 
-    /*
-     * Modifiers
-     */
-
     modifier isOpen(uint256 channel_identifier) {
-        require(channels[channel_identifier].state == 1);
+        require(channels[channel_identifier].state == ChannelState.Opened);
         _;
     }
 
@@ -220,12 +218,12 @@ contract TokenNetwork is Utils {
         Channel storage channel = channels[channel_identifier];
 
         require(channel.settle_block_number == 0);
-        require(channel.state == 0);
+        require(channel.state == ChannelState.Gone);
 
         // Store channel information
         channel.settle_block_number = settle_timeout;
         // Mark channel as opened
-        channel.state = 1;
+        channel.state = ChannelState.Opened;
 
         emit ChannelOpened(channel_identifier, participant1, participant2, settle_timeout);
 
@@ -318,9 +316,7 @@ contract TokenNetwork is Utils {
 
         // Do the tokens transfer
         require(token.transfer(participant, current_withdraw));
-
-        // Channel must be open
-        require(channel.state == 1);
+        require(channel.state == ChannelState.Opened);
 
         verifyWithdrawSignatures(
             channel_identifier,
@@ -376,8 +372,7 @@ contract TokenNetwork is Utils {
 
         Channel storage channel = channels[channel_identifier];
 
-        // Mark the channel as closed and mark the closing participant
-        channel.state = 2;
+        channel.state = ChannelState.Closed;
         channel.participants[msg.sender].is_the_closer = true;
 
         // This is the block number at which the channel can be settled.
@@ -465,8 +460,7 @@ contract TokenNetwork is Utils {
 
         emit NonClosingBalanceProofUpdated(channel_identifier, closing_participant, nonce);
 
-        // Channel must be closed
-        require(channel.state == 2);
+        require(channel.state == ChannelState.Closed);
 
         // Channel must be in the settlement window
         require(channel.settle_block_number >= block.number);
@@ -518,8 +512,7 @@ contract TokenNetwork is Utils {
         pair_hash = getParticipantsHash(participant1, participant2);
         Channel storage channel = channels[channel_identifier];
 
-        // Channel must be closed
-        require(channel.state == 2);
+        require(channel.state == ChannelState.Closed);
 
         // Settlement window must be over
         require(channel.settle_block_number < block.number);
@@ -763,6 +756,11 @@ contract TokenNetwork is Utils {
             returned_tokens
         );
 
+        // After the channel is settled the storage is cleared, therefor the
+        // value will be Gone and not Settled. The value Settled is used for
+        // the external APIs
+        require(channels[channel_identifier].state == ChannelState.Gone);
+
         require(computed_locksroot != 0);
         require(locked_amount > 0);
         require(locked_amount >= returned_tokens);
@@ -802,8 +800,7 @@ contract TokenNetwork is Utils {
         pair_hash = getParticipantsHash(participant1_address, participant2_address);
         Channel storage channel = channels[channel_identifier];
 
-        // The channel must be open
-        require(channel.state == 1);
+        require(channel.state == ChannelState.Opened);
 
         participant1 = recoverAddressFromCooperativeSettleSignature(
             channel_identifier,
@@ -1058,12 +1055,12 @@ contract TokenNetwork is Utils {
         returns (uint256, uint8)
     {
         Channel storage channel = channels[channel_identifier];
-        uint8 state = channel.state;
+        ChannelState memory state = channel.state;  // This must **not** update the storage
 
-        if (state == 0 && channel_identifier > 0 && channel_identifier <= channel_counter) {
+        if (state == ChannelState.Gone && channel_identifier > 0 && channel_identifier <= channel_counter) {
             // The channel has been settled, channel data is removed
             // We might still have data stored for a future unlock operation
-            state = 3;
+            state = ChannelState.Settled;
         }
 
         return (


### PR DESCRIPTION
Note: I did not check how much extra gas is being used for the conversion from the enum to uint8


- The first element of the enum starts with the value 0, therefor that
is used for the inexisting state.
- Because of storage optimization the state is stored in a uint8,
therefor the enum value must be converted to from uint8.