### PR TITLE
removed redundant require

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -154,8 +154,6 @@ contract TokenNetwork is Utils {
     )
         public
     {
-        require(_token_address != 0x0);
-        require(_secret_registry != 0x0);
         require(_chain_id > 0);
         require(_settlement_timeout_min > 0);
         require(_settlement_timeout_max > 0);


### PR DESCRIPTION
contractExists returns false for the address 0x0 therefore the check is redundant.

The only reason to not do this change is if we think the address 0x0 could have code in the future