### PR TITLE
storeUnlockData instead of updateUnlockData to clarify scope

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -571,14 +571,14 @@ contract TokenNetwork is Utils {
         delete participants_hash_to_channel_identifier[pair_hash];
 
         // Store balance data needed for `unlock`
-        updateUnlockData(
+        storeUnlockData(
             channel_identifier,
             participant1,
             participant2,
             participant1_locked_amount,
             participant1_locksroot
         );
-        updateUnlockData(
+        storeUnlockData(
             channel_identifier,
             participant2,
             participant1,
@@ -935,7 +935,7 @@ contract TokenNetwork is Utils {
         participant_state.balance_hash = balance_hash;
     }
 
-    function updateUnlockData(
+    function storeUnlockData(
         uint256 channel_identifier,
         address participant,
         address partner,

--- a/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
+++ b/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
@@ -48,7 +48,7 @@ contract TokenNetworkInternalsTest is TokenNetwork {
     )
         public
     {
-       return updateUnlockData(
+       return storeUnlockData(
             channel_identifier,
             participant,
             partner,


### PR DESCRIPTION
Clarify naming and function scope:
Data needed for an `unlock` cannot be updated. If existent, is written to storage only one time, when calling `settleChannel`.