### PR TITLE
Endpoint registry cosmetic

### DIFF
--- a/raiden_contracts/contracts/EndpointRegistry.sol
+++ b/raiden_contracts/contracts/EndpointRegistry.sol
@@ -2,8 +2,8 @@ pragma solidity ^0.4.23;
 
 /// @title Endpoint Registry
 /// @notice This contract is a registry which maps an Ethereum address to its
-/// endpoint i.e. sockets. The Ethereum address registers its address in this
-/// registry.
+/// endpoint i.e. sockets. The Raiden node registers its ethereum address in
+/// this registry.
 contract EndpointRegistry {
     string constant public contract_version = "0.3._";
 
@@ -19,8 +19,7 @@ contract EndpointRegistry {
         _;
     }
 
-    /// @notice Registers the Ethereum address to the Endpoint socket.
-    /// @dev Registers the Ethereum address to the Endpoint socket.
+    /// @notice Registers the Ethereum address to the  Endpoint socket.
     /// @param socket String in the format "127.0.0.1:38647".
     function registerEndpoint(string socket)
         public
@@ -44,24 +43,29 @@ contract EndpointRegistry {
     }
 
     /// @notice Finds the socket if given a registered Ethereum address.
-    /// @dev Finds the socket if given a registered Ethereum address.
     /// @param eth_address A 20 byte Ethereum address.
     /// @return socket which the current Ethereum address is using.
-    function findEndpointByAddress(address eth_address) public view returns (string socket)
+    function findEndpointByAddress(address eth_address)
+        public
+        view
+        returns (string socket)
     {
         return address_to_socket[eth_address];
     }
 
     /// @notice Finds an Ethereum address if given a registered socket address.
-    /// @dev Finds an Ethereum address if given a registered socket address.
     /// @param socket A string in the format "127.0.0.1:38647".
     /// @return eth_address An Ethereum address.
-    function findAddressByEndpoint(string socket) public view returns (address eth_address)
+    function findAddressByEndpoint(string socket)
+        public
+        view
+        returns
+        (address eth_address)
     {
         return socket_to_address[socket];
     }
 
-    /// @dev Checks if two strings are equal or not.
+    /// @notice Checks if two strings are equal or not.
     /// @param a First string.
     /// @param b Second string.
     /// @return result True if `a` and `b` are equal, false otherwise.

--- a/raiden_contracts/contracts/EndpointRegistry.sol
+++ b/raiden_contracts/contracts/EndpointRegistry.sol
@@ -2,67 +2,66 @@ pragma solidity ^0.4.23;
 
 /// @title Endpoint Registry
 /// @notice This contract is a registry which maps an Ethereum address to its
-/// endpoint i.e. sockets. The Raiden node registers its ethereum address in
-/// this registry.
+/// endpoint. The Raiden node registers its ethereum address in this registry.
 contract EndpointRegistry {
     string constant public contract_version = "0.3._";
 
-    event AddressRegistered(address indexed eth_address, string socket);
+    event AddressRegistered(address indexed eth_address, string endpoint);
 
-    // Mapping of Ethereum addresses => SocketEndpoints
-    mapping (address => string) address_to_socket;
-    // Mapping of SocketEndpoints => Ethereum addresses
-    mapping (string => address) socket_to_address;
+    // Mapping of Ethereum addresses => Endpoints
+    mapping (address => string) address_to_endpoint;
+    // Mapping of Endpoints => Ethereum addresses
+    mapping (string => address) endpoint_to_address;
 
     modifier noEmptyString(string str) {
         require(equals(str, "") != true);
         _;
     }
 
-    /// @notice Registers the Ethereum address to the  Endpoint socket.
-    /// @param socket String in the format "127.0.0.1:38647".
-    function registerEndpoint(string socket)
+    /// @notice Registers the Ethereum address to the given endpoint.
+    /// @param endpoint String in the format "127.0.0.1:38647".
+    function registerEndpoint(string endpoint)
         public
-        noEmptyString(socket)
+        noEmptyString(endpoint)
     {
-        string storage old_socket = address_to_socket[msg.sender];
+        string storage old_endpoint = address_to_endpoint[msg.sender];
 
-        // Compare if the new socket matches the old one, if it does just
+        // Compare if the new endpoint matches the old one, if it does just
         // return
-        if (equals(old_socket, socket)) {
+        if (equals(old_endpoint, endpoint)) {
             return;
         }
 
-        // Set the value for the `old_socket` mapping key to `0`
-        socket_to_address[old_socket] = address(0);
+        // Set the value for the `old_endpoint` mapping key to `0`
+        endpoint_to_address[old_endpoint] = address(0);
 
-        // Update the storage with the new socket value
-        address_to_socket[msg.sender] = socket;
-        socket_to_address[socket] = msg.sender;
-        emit AddressRegistered(msg.sender, socket);
+        // Update the storage with the new endpoint value
+        address_to_endpoint[msg.sender] = endpoint;
+        endpoint_to_address[endpoint] = msg.sender;
+        emit AddressRegistered(msg.sender, endpoint);
     }
 
-    /// @notice Finds the socket if given a registered Ethereum address.
+    /// @notice Finds the endpoint if given a registered Ethereum address.
     /// @param eth_address A 20 byte Ethereum address.
-    /// @return socket which the current Ethereum address is using.
+    /// @return endpoint which the current Ethereum address is using.
     function findEndpointByAddress(address eth_address)
         public
         view
-        returns (string socket)
+        returns (string endpoint)
     {
-        return address_to_socket[eth_address];
+        return address_to_endpoint[eth_address];
     }
 
-    /// @notice Finds an Ethereum address if given a registered socket address.
-    /// @param socket A string in the format "127.0.0.1:38647".
+    /// @notice Finds an Ethereum address if given a registered endpoint
+    /// @param endpoint A string in the format "127.0.0.1:38647".
     /// @return eth_address An Ethereum address.
-    function findAddressByEndpoint(string socket)
+    function findAddressByEndpoint(string endpoint)
         public
         view
         returns
         (address eth_address)
     {
-        return socket_to_address[socket];
+        return endpoint_to_address[endpoint];
     }
 
     /// @notice Checks if two strings are equal or not.

--- a/raiden_contracts/tests/test_endpointregistry.py
+++ b/raiden_contracts/tests/test_endpointregistry.py
@@ -4,21 +4,32 @@ from raiden_contracts.constants import EVENT_ADDRESS_REGISTERED
 
 def test_endpointregistry_calls(endpoint_registry_contract, get_accounts):
     (A, B) = get_accounts(2)
-    PORT = '127.0.0.1:38647'
-    endpoint_registry_contract.functions.registerEndpoint(PORT).transact({'from': A})
-    assert endpoint_registry_contract.functions.findAddressByEndpoint(PORT).call() == A
-    NEW_PORT = '192.168.0.1:4002'
-    endpoint_registry_contract.functions.registerEndpoint(NEW_PORT).transact({'from': A})
-    assert endpoint_registry_contract.functions.findAddressByEndpoint(NEW_PORT).call() == A
-    assert endpoint_registry_contract.functions.findEndpointByAddress(A).call() == NEW_PORT
+    ENDPOINT = '127.0.0.1:38647'
+    endpoint_registry_contract.functions.registerEndpoint(ENDPOINT).transact({'from': A})
+    assert endpoint_registry_contract.functions.findAddressByEndpoint(
+        ENDPOINT,
+    ).call() == A
+    NEW_ENDPOINT = '192.168.0.1:4002'
+    endpoint_registry_contract.functions.registerEndpoint(NEW_ENDPOINT).transact({'from': A})
+    assert endpoint_registry_contract.functions.findAddressByEndpoint(
+        NEW_ENDPOINT,
+    ).call() == A
+    assert endpoint_registry_contract.functions.findEndpointByAddress(
+        A,
+    ).call() == NEW_ENDPOINT
 
 
 def test_events(endpoint_registry_contract, get_accounts, event_handler):
     (A, B) = get_accounts(2)
     ev_handler = event_handler(endpoint_registry_contract)
 
-    PORT = '127.0.0.1:38647'
-    txn_hash = endpoint_registry_contract.functions.registerEndpoint(PORT).transact({'from': A})
+    ENDPOINT = '127.0.0.1:38647'
+    txn_hash = endpoint_registry_contract.functions.registerEndpoint(
+        ENDPOINT,
+    ).transact({'from': A})
 
-    ev_handler.add(txn_hash, EVENT_ADDRESS_REGISTERED, check_address_registered(A, PORT))
+    ev_handler.add(txn_hash, EVENT_ADDRESS_REGISTERED, check_address_registered(
+        A,
+        ENDPOINT,
+    ))
     ev_handler.check()

--- a/raiden_contracts/utils/events.py
+++ b/raiden_contracts/utils/events.py
@@ -19,10 +19,10 @@ def check_token_network_created(token_address, token_network_address):
     return get
 
 
-def check_address_registered(eth_address, socket):
+def check_address_registered(eth_address, endpoint):
     def get(event):
         assert event['args']['eth_address'] == eth_address
-        assert event['args']['socket'] == socket
+        assert event['args']['endpoint'] == endpoint
     return get
 
 


### PR DESCRIPTION
After https://github.com/raiden-network/raiden-contracts/pull/217 there are some mostly cosmetic changes I would like to do to the EndpointRegistry:

- Reword some comments a bit
- Remove the [at]dev natspec as it's not needed and it was just a copy of [at]notice
- Be consistent in the naming. We were using both socket and endpoint to refer to the same thing. A TCP socket is one type of endpoint, but since it's an endpoint registry I think using that term everywhere is better.