### PR TITLE
Reorder withdraw checks

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -336,10 +336,20 @@ contract TokenNetwork is Utils {
         bytes participant_signature,
         bytes partner_signature
     )
+        isOpen(channel_identifier)
         external
     {
         require(channel_identifier == getChannelIdentifier(participant, partner));
         require(total_withdraw > 0);
+
+        verifyWithdrawSignatures(
+            channel_identifier,
+            participant,
+            partner,
+            total_withdraw,
+            participant_signature,
+            partner_signature
+        );
 
         uint256 total_deposit;
         uint256 current_withdraw;
@@ -359,16 +369,6 @@ contract TokenNetwork is Utils {
 
         // Do the tokens transfer
         require(token.transfer(participant, current_withdraw));
-        require(channel.state == ChannelState.Opened);
-
-        verifyWithdrawSignatures(
-            channel_identifier,
-            participant,
-            partner,
-            total_withdraw,
-            participant_signature,
-            partner_signature
-        );
 
         require(current_withdraw > 0);
 


### PR DESCRIPTION
Reorder withdraw checks

**Update**: Case detailed previously is impossible (we have correct state checks in `setTotalWithdraw` & transactions are atomic even when internal transactions happen).
However, I still consider it good practice to have the checks before the external function call / storage change.