### PR TITLE
Use address(0x0) instead of 0x0 for input checks of type address

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -187,8 +187,8 @@ contract TokenNetwork is Utils {
     )
         public
     {
-        require(_token_address != 0x0);
-        require(_secret_registry != 0x0);
+        require(_token_address != address(0x0));
+        require(_secret_registry != address(0x0));
         require(_chain_id > 0);
         require(_settlement_timeout_min > 0);
         require(_settlement_timeout_max > _settlement_timeout_min);
@@ -871,8 +871,8 @@ contract TokenNetwork is Utils {
         public
         returns (uint256)
     {
-        require(participant != 0x0);
-        require(partner != 0x0);
+        require(participant != address(0x0));
+        require(partner != address(0x0));
         require(participant != partner);
 
         bytes32 pair_hash = getParticipantsHash(participant, partner);
@@ -975,8 +975,8 @@ contract TokenNetwork is Utils {
         public
         returns (bytes32)
     {
-        require(participant != 0x0);
-        require(partner != 0x0);
+        require(participant != address(0x0));
+        require(partner != address(0x0));
         require(participant != partner);
 
         if (participant < partner) {

--- a/raiden_contracts/contracts/TokenNetworkRegistry.sol
+++ b/raiden_contracts/contracts/TokenNetworkRegistry.sol
@@ -51,14 +51,18 @@ contract TokenNetworkRegistry is Utils {
     {
         require(token_to_token_networks[_token_address] == address(0x0));
 
+        TokenNetwork token_network;
+
         // Token contract checks are in the corresponding TokenNetwork contract
-        token_network_address = new TokenNetwork(
+        token_network = new TokenNetwork(
             _token_address,
             secret_registry_address,
             chain_id,
             settlement_timeout_min,
             settlement_timeout_max
         );
+
+        token_network_address = address(token_network);
 
         token_to_token_networks[_token_address] = token_network_address;
         emit TokenNetworkCreated(_token_address, token_network_address);

--- a/raiden_contracts/contracts/TokenNetworkRegistry.sol
+++ b/raiden_contracts/contracts/TokenNetworkRegistry.sol
@@ -33,7 +33,7 @@ contract TokenNetworkRegistry is Utils {
         require(_settlement_timeout_min > 0);
         require(_settlement_timeout_max > 0);
         require(_settlement_timeout_max > _settlement_timeout_min);
-        require(_secret_registry_address != 0x0);
+        require(_secret_registry_address != address(0x0));
         require(contractExists(_secret_registry_address));
         secret_registry_address = _secret_registry_address;
         chain_id = _chain_id;
@@ -49,7 +49,7 @@ contract TokenNetworkRegistry is Utils {
         external
         returns (address token_network_address)
     {
-        require(token_to_token_networks[_token_address] == 0x0);
+        require(token_to_token_networks[_token_address] == address(0x0));
 
         // Token contract checks are in the corresponding TokenNetwork contract
         token_network_address = new TokenNetwork(

--- a/raiden_contracts/contracts/lib/ECVerify.sol
+++ b/raiden_contracts/contracts/lib/ECVerify.sol
@@ -34,7 +34,7 @@ library ECVerify {
         signature_address = ecrecover(hash, v, r, s);
 
         // ecrecover returns zero on error
-        require(signature_address != 0x0);
+        require(signature_address != address(0x0));
 
         return signature_address;
     }


### PR DESCRIPTION
(update: this is actually a breaking change in solc `0.5.0`, we will need these changes)

`address(0x0)` is a more specific type.
Using `0x0` is not a bug or a current issue with `solc 0.4.24`. However, if we want to implement stronger types (e.g. https://github.com/raiden-network/raiden-contracts/issues/210), using `address()` is a good idea.

Note that the current contract address cannot be retrieved with `this` in the EVM anymore, we need to use `address(this)`. The proposed change is therefore in line with Solidity changes.