### PR TITLE
Use abi.encodeWithSignature for external calls

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -206,7 +206,7 @@ contract TokenNetwork is Utils {
         require(token.totalSupply() > 0);
 
         // Try to get token decimals, otherwise assume 18
-        bool exists = address(token).call(bytes4(keccak256("decimals()")));
+        bool exists = address(token).call(abi.encodeWithSignature("decimals()"));
         uint8 decimals = 18;
         if (exists) {
             decimals = token.decimals();


### PR DESCRIPTION
In line with `0.5.0` solc breaking changes regarding the new ABI encoder.