### PR TITLE
Removed address_by_endpoint from the endpoint registry

### DIFF
--- a/raiden_contracts/contracts/EndpointRegistry.sol
+++ b/raiden_contracts/contracts/EndpointRegistry.sol
@@ -7,11 +7,7 @@ contract EndpointRegistry {
     string constant public contract_version = "0.3._";
 
     event AddressRegistered(address indexed eth_address, string endpoint);
-
-    // Mapping of Ethereum addresses => Endpoints
     mapping (address => string) private address_to_endpoint;
-    // Mapping of Endpoints => Ethereum addresses
-    mapping (string => address) private endpoint_to_address;
 
     modifier noEmptyString(string str) {
         require(equals(str, "") != true);
@@ -32,12 +28,8 @@ contract EndpointRegistry {
             return;
         }
 
-        // Set the value for the `old_endpoint` mapping key to `0`
-        endpoint_to_address[old_endpoint] = address(0);
-
         // Update the storage with the new endpoint value
         address_to_endpoint[msg.sender] = endpoint;
-        endpoint_to_address[endpoint] = msg.sender;
         emit AddressRegistered(msg.sender, endpoint);
     }
 
@@ -50,18 +42,6 @@ contract EndpointRegistry {
         returns (string endpoint)
     {
         return address_to_endpoint[eth_address];
-    }
-
-    /// @notice Finds an Ethereum address if given a registered endpoint
-    /// @param endpoint A string in the format "127.0.0.1:38647".
-    /// @return eth_address An Ethereum address.
-    function findAddressByEndpoint(string endpoint)
-        public
-        view
-        returns
-        (address eth_address)
-    {
-        return endpoint_to_address[endpoint];
     }
 
     /// @notice Checks if two strings are equal or not.

--- a/raiden_contracts/tests/test_endpointregistry.py
+++ b/raiden_contracts/tests/test_endpointregistry.py
@@ -6,14 +6,8 @@ def test_endpointregistry_calls(endpoint_registry_contract, get_accounts):
     (A, B) = get_accounts(2)
     ENDPOINT = '127.0.0.1:38647'
     endpoint_registry_contract.functions.registerEndpoint(ENDPOINT).transact({'from': A})
-    assert endpoint_registry_contract.functions.findAddressByEndpoint(
-        ENDPOINT,
-    ).call() == A
     NEW_ENDPOINT = '192.168.0.1:4002'
     endpoint_registry_contract.functions.registerEndpoint(NEW_ENDPOINT).transact({'from': A})
-    assert endpoint_registry_contract.functions.findAddressByEndpoint(
-        NEW_ENDPOINT,
-    ).call() == A
     assert endpoint_registry_contract.functions.findEndpointByAddress(
         A,
     ).call() == NEW_ENDPOINT


### PR DESCRIPTION
The smart contract function address_by_endpoint allowed a malicious node
to set its address for an endpoint which it did not control. The
functionality was not used and buggy, this removes it.