### PR TITLE
Reorder checks again

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -658,6 +658,12 @@ contract TokenNetwork is Utils {
             participant2_locksroot
         );
 
+        emit ChannelSettled(
+            channel_identifier,
+            participant1_transferred_amount,
+            participant2_transferred_amount
+        );
+
         // Do the actual token transfers
         if (participant1_transferred_amount > 0) {
             require(token.transfer(participant1, participant1_transferred_amount));
@@ -666,12 +672,6 @@ contract TokenNetwork is Utils {
         if (participant2_transferred_amount > 0) {
             require(token.transfer(participant2, participant2_transferred_amount));
         }
-
-        emit ChannelSettled(
-            channel_identifier,
-            participant1_transferred_amount,
-            participant2_transferred_amount
-        );
     }
 
     /// @notice Unlocks all pending off-chain transfers from `partner` to

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -450,6 +450,8 @@ contract TokenNetwork is Utils {
                 additional_hash,
                 signature
             );
+            // Signature must be from the channel partner
+            require(partner == recovered_partner_address);
 
             updateBalanceProofData(
                 channel,
@@ -457,9 +459,6 @@ contract TokenNetwork is Utils {
                 nonce,
                 balance_hash
             );
-
-            // Signature must be from the channel partner
-            require(partner == recovered_partner_address);
         }
 
         emit ChannelClosed(channel_identifier, msg.sender);

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -744,6 +744,15 @@ contract TokenNetwork is Utils {
         // Remove partner's unlock data
         delete unlock_identifier_to_unlock_data[unlock_key];
 
+        emit ChannelUnlocked(
+            channel_identifier,
+            participant,
+            partner,
+            computed_locksroot,
+            unlocked_amount,
+            returned_tokens
+        );
+
         // Transfer the unlocked tokens to the participant. unlocked_amount can
         // be 0
         if (unlocked_amount > 0) {
@@ -754,15 +763,6 @@ contract TokenNetwork is Utils {
         if (returned_tokens > 0) {
             require(token.transfer(partner, returned_tokens));
         }
-
-        emit ChannelUnlocked(
-            channel_identifier,
-            participant,
-            partner,
-            computed_locksroot,
-            unlocked_amount,
-            returned_tokens
-        );
 
         // At this point, this should always be true
         assert(locked_amount >= returned_tokens);

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -293,12 +293,21 @@ contract TokenNetwork is Utils {
 
         // Calculate the actual amount of tokens that will be transferred
         added_deposit = total_deposit - participant_state.deposit;
+        // The actual amount of tokens that will be transferred must be > 0
+        require(added_deposit > 0);
+        // Underflow check; we use <= because added_deposit == total_deposit for the first deposit
+        require(added_deposit <= total_deposit);
+        // This should never fail at this point. Added check for security, because we directly set
+        // the participant_state.deposit = total_deposit, while we transfer `added_deposit` tokens.
+        assert(participant_state.deposit + added_deposit == total_deposit);
 
         // Update the participant's channel deposit
-        participant_state.deposit += added_deposit;
+        participant_state.deposit = total_deposit;
 
         // Calculate the entire channel deposit, to avoid overflow
         channel_deposit = participant_state.deposit + partner_state.deposit;
+        // Overflow check
+        require(channel_deposit >= participant_state.deposit);
 
         emit ChannelNewDeposit(
             channel_identifier,
@@ -308,10 +317,6 @@ contract TokenNetwork is Utils {
 
         // Do the transfer
         require(token.transferFrom(msg.sender, address(this), added_deposit));
-
-        require(participant_state.deposit >= added_deposit);
-        require(channel_deposit >= participant_state.deposit);
-        require(channel_deposit >= partner_state.deposit);
     }
 
     /// @notice Allows `participant` to withdraw tokens from the channel that he


### PR DESCRIPTION
Fixes the issue from this thread: https://github.com/raiden-network/raiden-contracts/issues/47#issuecomment-413893255 stemmed from the fact that the code is less readable when the checks do not follow the implementation logic, but are artificially grouped together.

> the beginning of a function starts with the requirements, first validating/requiring the value inputs, then the code is followed by the pure computation, which is followed by the validation of the computation and side-effects, and the code finishes with the asserts/invariants that must be true after the execution of the code.

- check function inputs
- check other preconditions to the state changes that will be done
- perform actions and immediately check if these actions succeeded
- check all other invariants at the end