### PR TITLE
Removes redundant partner argument from setTotalWithdraw.

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -374,6 +374,7 @@ contract TokenNetwork is Utils {
 
         // Entire withdrawn amount must not be bigger than the current channel deposit
         require((total_withdraw + partner_state.withdrawn_amount) <= total_deposit);
+        require(total_withdraw <= (total_withdraw + partner_state.withdrawn_amount));
 
         // Using the total_withdraw (monotonically increasing) in the signed
         // message ensures that we do not allow replay attack to happen, by
@@ -392,15 +393,15 @@ contract TokenNetwork is Utils {
         // while we transfer `current_withdraw` tokens.
         assert(participant_state.withdrawn_amount + current_withdraw == total_withdraw);
 
-        // Do the state change and tokens transfer
-        participant_state.withdrawn_amount = total_withdraw;
-        require(token.transfer(participant, current_withdraw));
-
         emit ChannelWithdraw(
             channel_identifier,
             participant,
-            participant_state.withdrawn_amount
+            total_withdraw
         );
+
+        // Do the state change and tokens transfer
+        participant_state.withdrawn_amount = total_withdraw;
+        require(token.transfer(participant, current_withdraw));
 
         // This should never happen, as we have an overflow check in setTotalDeposit
         assert(total_deposit >= participant_state.deposit);

--- a/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
+++ b/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
@@ -218,27 +218,6 @@ contract TokenNetworkInternalsTest is TokenNetwork {
         );
     }
 
-    function verifyWithdrawSignaturesPublic(
-        uint256 channel_identifier,
-        address participant,
-        address partner,
-        uint256 total_withdraw,
-        bytes participant_signature,
-        bytes partner_signature
-    )
-        view
-        public
-    {
-        return verifyWithdrawSignatures(
-            channel_identifier,
-            participant,
-            partner,
-            total_withdraw,
-            participant_signature,
-            partner_signature
-        );
-    }
-
     function getMerkleRootAndUnlockedAmountPublic(bytes merkle_tree_leaves)
         view
         public

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -116,7 +116,6 @@ def withdraw_channel(token_network, create_withdraw_signatures):
             channel_identifier,
             participant,
             withdraw_amount,
-            partner,
             signature_participant,
             signature_partner
         ).transact({'from': delegate})

--- a/raiden_contracts/tests/test_channel_withdraw.py
+++ b/raiden_contracts/tests/test_channel_withdraw.py
@@ -34,7 +34,6 @@ def test_withdraw_call(
             channel_identifier,
             0x0,
             withdraw_A,
-            B,
             signature_A_for_A,
             signature_B_for_A,
         ).transact({'from': A})
@@ -43,25 +42,6 @@ def test_withdraw_call(
             channel_identifier,
             '',
             withdraw_A,
-            B,
-            signature_A_for_A,
-            signature_B_for_A,
-        ).transact({'from': A})
-    with pytest.raises(ValidationError):
-        token_network.functions.setTotalWithdraw(
-            channel_identifier,
-            A,
-            withdraw_A,
-            0x0,
-            signature_A_for_A,
-            signature_B_for_A,
-        ).transact({'from': A})
-    with pytest.raises(ValidationError):
-        token_network.functions.setTotalWithdraw(
-            channel_identifier,
-            A,
-            withdraw_A,
-            '',
             signature_A_for_A,
             signature_B_for_A,
         ).transact({'from': A})
@@ -70,7 +50,6 @@ def test_withdraw_call(
             channel_identifier,
             A,
             -1,
-            B,
             signature_A_for_A,
             signature_B_for_A,
         ).transact({'from': A})
@@ -79,7 +58,6 @@ def test_withdraw_call(
             channel_identifier,
             A,
             MAX_UINT256 + 1,
-            B,
             signature_A_for_A,
             signature_B_for_A,
         ).transact({'from': A})
@@ -89,16 +67,6 @@ def test_withdraw_call(
             channel_identifier,
             EMPTY_ADDRESS,
             withdraw_A,
-            B,
-            signature_A_for_A,
-            signature_B_for_A,
-        ).transact({'from': A})
-    with pytest.raises(TransactionFailed):
-        token_network.functions.setTotalWithdraw(
-            channel_identifier,
-            A,
-            withdraw_A,
-            EMPTY_ADDRESS,
             signature_A_for_A,
             signature_B_for_A,
         ).transact({'from': A})
@@ -107,7 +75,6 @@ def test_withdraw_call(
             channel_identifier,
             A,
             0,
-            B,
             signature_A_for_A,
             signature_B_for_A,
         ).transact({'from': A})
@@ -116,7 +83,6 @@ def test_withdraw_call(
             channel_identifier,
             A,
             withdraw_A,
-            B,
             fake_bytes(65),
             signature_B_for_A,
         ).transact({'from': A})
@@ -125,7 +91,6 @@ def test_withdraw_call(
             channel_identifier,
             A,
             withdraw_A,
-            B,
             signature_A_for_A,
             fake_bytes(65),
         ).transact({'from': A})
@@ -134,7 +99,6 @@ def test_withdraw_call(
         channel_identifier,
         A,
         withdraw_A,
-        B,
         signature_A_for_A,
         signature_B_for_A,
     ).transact({'from': A})
@@ -245,7 +209,6 @@ def test_withdraw_wrong_signers(
             channel_identifier,
             A,
             withdraw_A,
-            B,
             signature_C_for_A,
             signature_B_for_A,
         ).transact({'from': C})
@@ -254,7 +217,6 @@ def test_withdraw_wrong_signers(
             channel_identifier,
             A,
             withdraw_A,
-            B,
             signature_A_for_A,
             signature_C_for_A,
         ).transact({'from': C})
@@ -263,7 +225,6 @@ def test_withdraw_wrong_signers(
         channel_identifier,
         A,
         withdraw_A,
-        B,
         signature_A_for_A,
         signature_B_for_A,
     ).transact({'from': C})
@@ -314,7 +275,6 @@ def test_withdraw_wrong_signature_content(
             channel_identifier,
             A,
             withdraw_A,
-            B,
             signature_A_for_A_fake1,
             signature_B_for_A,
         ).transact({'from': A})
@@ -323,7 +283,6 @@ def test_withdraw_wrong_signature_content(
             channel_identifier,
             A,
             withdraw_A,
-            B,
             signature_A_for_A,
             signature_B_for_A_fake1,
         ).transact({'from': A})
@@ -332,7 +291,6 @@ def test_withdraw_wrong_signature_content(
             channel_identifier,
             A,
             withdraw_A,
-            B,
             signature_A_for_A_fake2,
             signature_B_for_A,
         ).transact({'from': A})
@@ -341,7 +299,6 @@ def test_withdraw_wrong_signature_content(
             channel_identifier,
             A,
             withdraw_A,
-            B,
             signature_A_for_A,
             signature_B_for_A_fake2,
         ).transact({'from': A})
@@ -350,7 +307,6 @@ def test_withdraw_wrong_signature_content(
             channel_identifier,
             A,
             withdraw_A,
-            B,
             signature_A_for_A_fake3,
             signature_B_for_A,
         ).transact({'from': A})
@@ -359,7 +315,6 @@ def test_withdraw_wrong_signature_content(
             channel_identifier,
             A,
             withdraw_A,
-            B,
             signature_A_for_A,
             signature_B_for_A_fake3,
         ).transact({'from': A})
@@ -368,7 +323,6 @@ def test_withdraw_wrong_signature_content(
         channel_identifier,
         A,
         withdraw_A,
-        B,
         signature_A_for_A,
         signature_B_for_A,
     ).transact({'from': A})
@@ -486,7 +440,6 @@ def test_withdraw_replay_reopened_channel(
         channel_identifier1,
         A,
         withdraw_A,
-        B,
         signature_A_for_A,
         signature_B_for_A,
     ).transact({'from': A})
@@ -522,7 +475,6 @@ def test_withdraw_replay_reopened_channel(
             channel_identifier2,
             A,
             withdraw_A,
-            B,
             signature_A_for_A,
             signature_B_for_A,
         ).transact({'from': A})
@@ -538,7 +490,6 @@ def test_withdraw_replay_reopened_channel(
         channel_identifier2,
         A,
         withdraw_A,
-        B,
         signature_A_for_A2,
         signature_B_for_A2,
     ).transact({'from': A})

--- a/raiden_contracts/tests/unit/test_unit_internals.py
+++ b/raiden_contracts/tests/unit/test_unit_internals.py
@@ -51,60 +51,6 @@ def test_max(token_network_test):
         assert token_network_test.functions.maxPublic(a, b).call() == max(a, b)
 
 
-def test_verify_withdraw_signatures(
-        token_network_test,
-        create_withdraw_signatures,
-        get_accounts,
-):
-
-    (A, B) = get_accounts(2)
-    fake_signature = fake_bytes(64)
-    channel_identifier = 4
-    (signature_A, signature_B) = create_withdraw_signatures(
-        [A, B],
-        channel_identifier,
-        A,
-        1,
-        token_network_test.address,
-    )
-    token_network_test.functions.verifyWithdrawSignaturesPublic(
-        channel_identifier,
-        A,
-        B,
-        1,
-        signature_A,
-        signature_B,
-    ).call()
-
-    with pytest.raises(TransactionFailed):
-        token_network_test.functions.verifyWithdrawSignaturesPublic(
-            channel_identifier,
-            A,
-            B,
-            3,
-            signature_B,
-            signature_A,
-        ).call()
-    with pytest.raises(TransactionFailed):
-        token_network_test.functions.verifyWithdrawSignaturesPublic(
-            channel_identifier,
-            A,
-            B,
-            3,
-            signature_A,
-            fake_signature,
-        ).call()
-    with pytest.raises(TransactionFailed):
-        token_network_test.functions.verifyWithdrawSignaturesPublic(
-            channel_identifier,
-            A,
-            B,
-            3,
-            fake_signature,
-            signature_B,
-        ).call()
-
-
 def test_recover_address_from_withdraw_message(
         token_network_test,
         create_withdraw_signatures,


### PR DESCRIPTION
Removes redundant partner argument from `setTotalWithdraw`, as described in  #238. Additionally, the function was refactored to be more clear and readable, as discussed in #47. Closes #238. 