### PR TITLE
Use a eth_sign and EIP191 compatible signature format

### DIFF
--- a/raiden_contracts/constants.py
+++ b/raiden_contracts/constants.py
@@ -39,6 +39,13 @@ DEPLOY_SETTLE_TIMEOUT_MIN = 500  # ~ 2 hours
 DEPLOY_SETTLE_TIMEOUT_MAX = 555428  # ~ 3 months
 
 
+class MessageTypeId(IntEnum):
+    BALANCE_PROOF = 1
+    BALANCE_PROOF_UPDATE = 2
+    WITHDRAW = 3
+    COOPERATIVE_SETTLE = 4
+
+
 class ChannelState(IntEnum):
     NONEXISTENT = 0
     OPENED = 1

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -93,6 +93,14 @@ contract TokenNetwork is Utils {
         Removed      // 4; Note: Channel data is removed, there are no pending unlocks
     }
 
+    enum MessageTypeId {
+        None,
+        BalanceProof,
+        BalanceProofUpdate,
+        Withdraw,
+        CooperativeSettle
+    }
+
     struct Channel {
         // After opening the channel this value represents the settlement
         // window. This is the number of blocks that need to be mined between
@@ -1381,8 +1389,6 @@ contract TokenNetwork is Utils {
         internal
         returns (address signature_address)
     {
-        uint256 message_type_id = 1;
-
         // Length of the actual message: 20 + 32 + 32 + 32 + 32 + 32 + 32
         string memory message_length = '212';
 
@@ -1391,7 +1397,7 @@ contract TokenNetwork is Utils {
             message_length,
             address(this),
             chain_id,
-            message_type_id,
+            uint256(MessageTypeId.BalanceProof),
             channel_identifier,
             balance_hash,
             nonce,
@@ -1413,8 +1419,6 @@ contract TokenNetwork is Utils {
         internal
         returns (address signature_address)
     {
-        uint256 message_type_id = 2;
-
         // Length of the actual message: 20 + 32 + 32 + 32 + 32 + 32 + 32 + 65
         string memory message_length = '277';
 
@@ -1423,7 +1427,7 @@ contract TokenNetwork is Utils {
             message_length,
             address(this),
             chain_id,
-            message_type_id,
+            uint256(MessageTypeId.BalanceProofUpdate),
             channel_identifier,
             balance_hash,
             nonce,
@@ -1446,8 +1450,6 @@ contract TokenNetwork is Utils {
         internal
         returns (address signature_address)
     {
-        uint256 message_type_id = 4;
-
         // Length of the actual message: 20 + 32 + 32 + 32 + 20 + 32 + 20 + 32
         string memory message_length = '220';
 
@@ -1456,7 +1458,7 @@ contract TokenNetwork is Utils {
             message_length,
             address(this),
             chain_id,
-            message_type_id,
+            uint256(MessageTypeId.CooperativeSettle),
             channel_identifier,
             participant1,
             participant1_balance,
@@ -1477,8 +1479,6 @@ contract TokenNetwork is Utils {
         internal
         returns (address signature_address)
     {
-        uint256 message_type_id = 3;
-
         // Length of the actual message: 20 + 32 + 32 + 32 + 20 + 32
         string memory message_length = '168';
 
@@ -1487,7 +1487,7 @@ contract TokenNetwork is Utils {
             message_length,
             address(this),
             chain_id,
-            message_type_id,
+            uint256(MessageTypeId.Withdraw),
             channel_identifier,
             participant,
             total_withdraw

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -1381,7 +1381,7 @@ contract TokenNetwork is Utils {
         internal
         returns (address signature_address)
     {
-        uint256 message_type_id = 0;
+        uint256 message_type_id = 1;
 
         // Length of the actual message: 20 + 32 + 32 + 32 + 32 + 32 + 32
         string memory message_length = '212';
@@ -1413,7 +1413,7 @@ contract TokenNetwork is Utils {
         internal
         returns (address signature_address)
     {
-        uint256 message_type_id = 1;
+        uint256 message_type_id = 2;
 
         // Length of the actual message: 20 + 32 + 32 + 32 + 32 + 32 + 32 + 65
         string memory message_length = '277';
@@ -1446,7 +1446,7 @@ contract TokenNetwork is Utils {
         internal
         returns (address signature_address)
     {
-        uint256 message_type_id = 3;
+        uint256 message_type_id = 4;
 
         // Length of the actual message: 20 + 32 + 32 + 32 + 20 + 32 + 20 + 32
         string memory message_length = '220';
@@ -1477,7 +1477,7 @@ contract TokenNetwork is Utils {
         internal
         returns (address signature_address)
     {
-        uint256 message_type_id = 2;
+        uint256 message_type_id = 3;
 
         // Length of the actual message: 20 + 32 + 32 + 32 + 20 + 32
         string memory message_length = '168';

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -38,6 +38,8 @@ contract TokenNetwork is Utils {
     // opened channels in this contract
     uint256 public channel_counter;
 
+    string public constant signature_prefix = '\x19Ethereum Signed Message:\n';
+
     // channel_identifier => Channel
     // channel identifier is the channel_counter value at the time of opening
     // the channel
@@ -1379,13 +1381,21 @@ contract TokenNetwork is Utils {
         internal
         returns (address signature_address)
     {
+        uint256 message_type_id = 0;
+
+        // Length of the actual message: 20 + 32 + 32 + 32 + 32 + 32 + 32
+        string memory message_length = '212';
+
         bytes32 message_hash = keccak256(abi.encodePacked(
+            signature_prefix,
+            message_length,
+            address(this),
+            chain_id,
+            message_type_id,
+            channel_identifier,
             balance_hash,
             nonce,
-            additional_hash,
-            channel_identifier,
-            address(this),
-            chain_id
+            additional_hash
         ));
 
         signature_address = ECVerify.ecverify(message_hash, signature);
@@ -1403,13 +1413,21 @@ contract TokenNetwork is Utils {
         internal
         returns (address signature_address)
     {
+        uint256 message_type_id = 1;
+
+        // Length of the actual message: 20 + 32 + 32 + 32 + 32 + 32 + 32 + 65
+        string memory message_length = '277';
+
         bytes32 message_hash = keccak256(abi.encodePacked(
+            signature_prefix,
+            message_length,
+            address(this),
+            chain_id,
+            message_type_id,
+            channel_identifier,
             balance_hash,
             nonce,
             additional_hash,
-            channel_identifier,
-            address(this),
-            chain_id,
             closing_signature
         ));
 
@@ -1428,14 +1446,22 @@ contract TokenNetwork is Utils {
         internal
         returns (address signature_address)
     {
+        uint256 message_type_id = 3;
+
+        // Length of the actual message: 20 + 32 + 32 + 32 + 20 + 32 + 20 + 32
+        string memory message_length = '220';
+
         bytes32 message_hash = keccak256(abi.encodePacked(
+            signature_prefix,
+            message_length,
+            address(this),
+            chain_id,
+            message_type_id,
+            channel_identifier,
             participant1,
             participant1_balance,
             participant2,
-            participant2_balance,
-            channel_identifier,
-            address(this),
-            chain_id
+            participant2_balance
         ));
 
         signature_address = ECVerify.ecverify(message_hash, signature);
@@ -1451,12 +1477,20 @@ contract TokenNetwork is Utils {
         internal
         returns (address signature_address)
     {
+        uint256 message_type_id = 2;
+
+        // Length of the actual message: 20 + 32 + 32 + 32 + 20 + 32
+        string memory message_length = '168';
+
         bytes32 message_hash = keccak256(abi.encodePacked(
-            participant,
-            total_withdraw,
-            channel_identifier,
+            signature_prefix,
+            message_length,
             address(this),
-            chain_id
+            chain_id,
+            message_type_id,
+            channel_identifier,
+            participant,
+            total_withdraw
         ));
 
         signature_address = ECVerify.ecverify(message_hash, signature);

--- a/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
+++ b/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.4.23;
-
 import "raiden/TokenNetwork.sol";
 
-contract TokenNetworkInternalsTest is TokenNetwork {
+
+contract TokenNetworkInternalStorageTest is TokenNetwork {
     constructor (
         address _token_address,
         address _secret_registry,
@@ -135,6 +135,27 @@ contract TokenNetworkInternalsTest is TokenNetwork {
            participant2_state
         );
     }
+}
+
+contract TokenNetworkSignatureTest is TokenNetwork {
+    constructor (
+        address _token_address,
+        address _secret_registry,
+        uint256 _chain_id,
+        uint256 _settlement_timeout_min,
+        uint256 _settlement_timeout_max
+    )
+        TokenNetwork(
+            _token_address,
+            _secret_registry,
+            _chain_id,
+            _settlement_timeout_min,
+            _settlement_timeout_max
+        )
+        public
+    {
+
+    }
 
     function recoverAddressFromBalanceProofPublic(
         uint256 channel_identifier,
@@ -216,6 +237,27 @@ contract TokenNetworkInternalsTest is TokenNetwork {
             amount_to_withdraw,
             signature
         );
+    }
+}
+
+contract TokenNetworkUtilsTest is TokenNetwork {
+    constructor (
+        address _token_address,
+        address _secret_registry,
+        uint256 _chain_id,
+        uint256 _settlement_timeout_min,
+        uint256 _settlement_timeout_max
+    )
+        TokenNetwork(
+            _token_address,
+            _secret_registry,
+            _chain_id,
+            _settlement_timeout_min,
+            _settlement_timeout_max
+        )
+        public
+    {
+
     }
 
     function getMerkleRootAndUnlockedAmountPublic(bytes merkle_tree_leaves)

--- a/raiden_contracts/tests/fixtures/test_contracts.py
+++ b/raiden_contracts/tests/fixtures/test_contracts.py
@@ -7,22 +7,60 @@ from raiden_contracts.constants import (
 
 
 @pytest.fixture()
-def get_token_network_test(deploy_tester_contract):
-    def get(arguments, transaction=None):
-        return deploy_tester_contract(
-            'TokenNetworkInternalsTest',
-            {},
-            arguments,
-        )
-    return get
+def token_network_test_storage(
+        deploy_tester_contract,
+        web3,
+        custom_token,
+        secret_registry_contract,
+):
+    return deploy_tester_contract(
+        'TokenNetworkInternalStorageTest',
+        {},
+        [
+            custom_token.address,
+            secret_registry_contract.address,
+            int(web3.version.network),
+            TEST_SETTLE_TIMEOUT_MIN,
+            TEST_SETTLE_TIMEOUT_MAX,
+        ],
+    )
 
 
 @pytest.fixture()
-def token_network_test(web3, get_token_network_test, custom_token, secret_registry_contract):
-    return get_token_network_test([
-        custom_token.address,
-        secret_registry_contract.address,
-        int(web3.version.network),
-        TEST_SETTLE_TIMEOUT_MIN,
-        TEST_SETTLE_TIMEOUT_MAX,
-    ])
+def token_network_test_signatures(
+        deploy_tester_contract,
+        web3,
+        custom_token,
+        secret_registry_contract,
+):
+    return deploy_tester_contract(
+        'TokenNetworkSignatureTest',
+        {},
+        [
+            custom_token.address,
+            secret_registry_contract.address,
+            int(web3.version.network),
+            TEST_SETTLE_TIMEOUT_MIN,
+            TEST_SETTLE_TIMEOUT_MAX,
+        ],
+    )
+
+
+@pytest.fixture()
+def token_network_test_utils(
+        deploy_tester_contract,
+        web3,
+        custom_token,
+        secret_registry_contract,
+):
+    return deploy_tester_contract(
+        'TokenNetworkUtilsTest',
+        {},
+        [
+            custom_token.address,
+            secret_registry_contract.address,
+            int(web3.version.network),
+            TEST_SETTLE_TIMEOUT_MIN,
+            TEST_SETTLE_TIMEOUT_MAX,
+        ],
+    )

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -27,8 +27,8 @@ from raiden_contracts.tests.fixtures.config import (
 )
 
 
-def test_max_safe_uint256(token_network, token_network_test):
-    max_safe_uint256 = token_network_test.functions.get_max_safe_uint256().call()
+def test_max_safe_uint256(token_network, token_network_test_utils):
+    max_safe_uint256 = token_network_test_utils.functions.get_max_safe_uint256().call()
 
     assert token_network.functions.MAX_SAFE_UINT256().call() == max_safe_uint256
     assert max_safe_uint256 == MAX_UINT256

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -16,11 +16,11 @@ from raiden_contracts.tests.utils import ChannelValues
 from raiden_contracts.tests.fixtures.channel import call_settle
 
 
-def test_merkle_root_0_items(token_network_test):
+def test_merkle_root_0_items(token_network_test_utils):
     (
         locksroot,
         unlocked_amount,
-    ) = token_network_test.functions.getMerkleRootAndUnlockedAmountPublic(b'').call()
+    ) = token_network_test_utils.functions.getMerkleRootAndUnlockedAmountPublic(b'').call()
     assert locksroot == EMPTY_MERKLE_ROOT
     assert unlocked_amount == 0
 
@@ -28,7 +28,7 @@ def test_merkle_root_0_items(token_network_test):
 def test_merkle_root_1_item_unlockable(
         web3,
         get_accounts,
-        token_network_test,
+        token_network_test_utils,
         secret_registry_contract,
 ):
     A = get_accounts(1)[0]
@@ -41,7 +41,7 @@ def test_merkle_root_1_item_unlockable(
         pending_transfers_tree.unlockable[0][2],
     ).call() == web3.eth.blockNumber
 
-    (locksroot, unlocked_amount) = token_network_test.functions.getMerkleRootAndUnlockedAmountPublic(  # noqa
+    (locksroot, unlocked_amount) = token_network_test_utils.functions.getMerkleRootAndUnlockedAmountPublic(  # noqa
         pending_transfers_tree.packed_transfers,
     ).call()
 
@@ -53,7 +53,7 @@ def test_merkle_root_1_item_unlockable(
 def test_merkle_root(
         web3,
         get_accounts,
-        token_network_test,
+        token_network_test_utils,
         secret_registry_contract,
         reveal_secrets,
 ):
@@ -62,7 +62,7 @@ def test_merkle_root(
 
     reveal_secrets(A, pending_transfers_tree.unlockable)
 
-    (locksroot, unlocked_amount) = token_network_test.functions.getMerkleRootAndUnlockedAmountPublic(  # noqa
+    (locksroot, unlocked_amount) = token_network_test_utils.functions.getMerkleRootAndUnlockedAmountPublic(  # noqa
         pending_transfers_tree.packed_transfers,
     ).call()
     merkle_root = pending_transfers_tree.merkle_root

--- a/raiden_contracts/tests/test_channel_update_transfer.py
+++ b/raiden_contracts/tests/test_channel_update_transfer.py
@@ -504,7 +504,7 @@ def test_update_not_allowed_for_the_closing_address(
 
 def test_update_invalid_balance_proof_arguments(
         token_network,
-        token_network_test,
+        token_network_test_utils,
         create_channel,
         channel_deposit,
         get_accounts,
@@ -558,7 +558,7 @@ def test_update_invalid_balance_proof_arguments(
         0,
         2,
         fake_bytes(32, '02'),
-        other_token_network=token_network_test,
+        other_token_network=token_network_test_utils,
     ))
 
     signature_invalid_token_network = create_balance_proof_update_signature(
@@ -568,7 +568,7 @@ def test_update_invalid_balance_proof_arguments(
         balance_proof_valid.nonce,
         balance_proof_valid.additional_hash,
         balance_proof_valid.signature,
-        other_token_network=token_network_test,
+        other_token_network=token_network_test_utils,
     )
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
@@ -729,7 +729,7 @@ def test_update_invalid_balance_proof_arguments(
 
 def test_update_signature_on_invalid_arguments(
         token_network,
-        token_network_test,
+        token_network_test_utils,
         create_channel,
         channel_deposit,
         get_accounts,
@@ -773,7 +773,7 @@ def test_update_signature_on_invalid_arguments(
         B,
         channel_identifier,
         *balance_proof_valid,
-        other_token_network=token_network_test,  # invalid token_network_address
+        other_token_network=token_network_test_utils,  # invalid token_network_address
     )
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(

--- a/raiden_contracts/tests/unit/test_unit_internals.py
+++ b/raiden_contracts/tests/unit/test_unit_internals.py
@@ -2,13 +2,10 @@ from itertools import chain, product
 
 import pytest
 from eth_tester.constants import UINT256_MIN, UINT256_MAX
-from eth_tester.exceptions import TransactionFailed
-
-from raiden_contracts.tests.fixtures import fake_bytes
 from web3.exceptions import ValidationError
 
 
-def test_min_uses_usigned(token_network_test):
+def test_min_uses_usigned(token_network_test_utils):
     """ Min cannot be called with negative values. """
     INVALID_VALUES = [-UINT256_MAX, -1]
     VALID_VALUES = [UINT256_MIN, UINT256_MAX, UINT256_MAX]
@@ -20,10 +17,10 @@ def test_min_uses_usigned(token_network_test):
 
     for a, b in all_invalid:
         with pytest.raises(ValidationError):
-            token_network_test.functions.minPublic(a, b).call()
+            token_network_test_utils.functions.minPublic(a, b).call()
 
 
-def test_max_uses_usigned(token_network_test):
+def test_max_uses_usigned(token_network_test_utils):
 
     INVALID_VALUES = [-UINT256_MAX, -1]
     VALID_VALUES = [UINT256_MIN, UINT256_MAX, UINT256_MAX]
@@ -34,247 +31,18 @@ def test_max_uses_usigned(token_network_test):
     )
     for a, b in all_invalid:
         with pytest.raises(ValidationError):
-            token_network_test.functions.maxPublic(a, b).call()
+            token_network_test_utils.functions.maxPublic(a, b).call()
 
 
-def test_min(token_network_test):
-
-    VALUES = [UINT256_MIN, 1, UINT256_MAX, UINT256_MAX]
-    for a, b in product(VALUES, VALUES):
-        assert token_network_test.functions.minPublic(a, b).call() == min(a, b)
-
-
-def test_max(token_network_test):
+def test_min(token_network_test_utils):
 
     VALUES = [UINT256_MIN, 1, UINT256_MAX, UINT256_MAX]
     for a, b in product(VALUES, VALUES):
-        assert token_network_test.functions.maxPublic(a, b).call() == max(a, b)
+        assert token_network_test_utils.functions.minPublic(a, b).call() == min(a, b)
 
 
-def test_recover_address_from_withdraw_message(
-        token_network_test,
-        create_withdraw_signatures,
-        create_channel_and_deposit,
-        get_accounts,
-):
-    (A, B) = get_accounts(2)
-    fake_signature = fake_bytes(64)
-    deposit_A = 5
-    deposit_B = 7
-    withdraw_A = 3
-    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
-    (signature_A, signature_B) = create_withdraw_signatures(
-        [A, B],
-        channel_identifier,
-        A,
-        withdraw_A,
-        token_network_test.address,
-    )
+def test_max(token_network_test_utils):
 
-    recovered_address_A = token_network_test.functions.recoverAddressFromWithdrawMessagePublic(
-        channel_identifier,
-        A,
-        withdraw_A,
-        signature_A,
-    ).call()
-    assert recovered_address_A == A
-
-    recovered_address_B = token_network_test.functions.recoverAddressFromWithdrawMessagePublic(
-        channel_identifier,
-        A,
-        withdraw_A,
-        signature_B,
-    ).call()
-    assert recovered_address_B == B
-
-    with pytest.raises(TransactionFailed):
-        token_network_test.functions.recoverAddressFromWithdrawMessagePublic(
-            channel_identifier,
-            A,
-            withdraw_A,
-            fake_signature,
-        ).call()
-
-    wrong_participant = token_network_test.functions.recoverAddressFromWithdrawMessagePublic(
-        channel_identifier,
-        B,
-        withdraw_A,
-        signature_A,
-    ).call()
-    assert recovered_address_A != wrong_participant
-
-    wrong_withdraw_value = token_network_test.functions.recoverAddressFromWithdrawMessagePublic(
-        channel_identifier,
-        A,
-        1,
-        signature_A,
-    ).call()
-
-    assert recovered_address_A != wrong_withdraw_value
-
-    wrong_signature = token_network_test.functions.recoverAddressFromWithdrawMessagePublic(
-        channel_identifier,
-        A,
-        withdraw_A,
-        signature_B,
-    ).call()
-
-    assert recovered_address_A != wrong_signature
-
-
-def test_recover_address_from_balance_proof(
-        token_network_test,
-        create_balance_proof,
-        get_accounts,
-):
-    (A, B) = get_accounts(2)
-
-    channel_identifier = 4
-    balance_proof = create_balance_proof(
-        channel_identifier,
-        A,
-        other_token_network=token_network_test,
-    )
-
-    balance_proof_wrong_token_network = create_balance_proof(
-        channel_identifier,
-        A,
-    )
-
-    balance_proof_other_signer = create_balance_proof(
-        channel_identifier,
-        A,
-        signer=B,
-        other_token_network=token_network_test,
-    )
-
-    assert A == token_network_test.functions.recoverAddressFromBalanceProofPublic(
-        channel_identifier, *balance_proof).call()
-
-    assert B == token_network_test.functions.recoverAddressFromBalanceProofPublic(
-        channel_identifier,
-        *balance_proof_other_signer,
-    ).call()
-
-    assert A != token_network_test.functions.recoverAddressFromBalanceProofPublic(
-        channel_identifier, *balance_proof_wrong_token_network).call()
-
-
-def test_recover_address_from_balance_proof_update(
-        token_network_test,
-        create_balance_proof,
-        create_balance_proof_update_signature,
-        get_accounts,
-):
-
-    (A, B) = get_accounts(2)
-
-    channel_identifier = 4
-    balance_proof = create_balance_proof(
-        channel_identifier,
-        A,
-        other_token_network=token_network_test,
-    )
-    balance_proof_update_signature = create_balance_proof_update_signature(
-        B,
-        channel_identifier,
-        *balance_proof,
-        other_token_network=token_network_test,
-    )
-
-    balance_proof_update_signature_wrong_token_network = create_balance_proof_update_signature(
-        B,
-        channel_identifier,
-        *balance_proof,
-    )
-
-    balance_proof_signed_B = create_balance_proof(
-        channel_identifier,
-        B,
-        other_token_network=token_network_test,
-    )
-    balance_proof_update_signature_wrong_signer = create_balance_proof_update_signature(
-        B,
-        channel_identifier,
-        *balance_proof_signed_B,
-    )
-
-    assert B == token_network_test.functions.recoverAddressFromBalanceProofUpdateMessagePublic(
-        channel_identifier, *balance_proof, balance_proof_update_signature).call()
-
-    assert B != token_network_test.functions.recoverAddressFromBalanceProofUpdateMessagePublic(
-        channel_identifier,
-        *balance_proof,
-        balance_proof_update_signature_wrong_token_network,
-    ).call()
-
-    assert B != token_network_test.functions.recoverAddressFromBalanceProofUpdateMessagePublic(
-        channel_identifier,
-        *balance_proof,
-        balance_proof_update_signature_wrong_signer,
-    ).call()
-
-
-def test_recover_address_from_cooperative_settle_signature(
-        token_network_test,
-        create_cooperative_settle_signatures,
-        get_accounts,
-):
-    (A, B) = get_accounts(2)
-    channel_identifier = 4
-    fake_signature = fake_bytes(64)
-
-    (signature_A, signature_B) = create_cooperative_settle_signatures(
-        [A, B],
-        channel_identifier,
-        A,
-        0,
-        B,
-        0,
-        other_token_network=token_network_test,
-    )
-    assert A == token_network_test.functions.recoverAddressFromCooperativeSettleSignaturePublic(
-        channel_identifier,
-        A,
-        0,
-        B,
-        0,
-        signature_A,
-    ).call()
-
-    assert B == token_network_test.functions.recoverAddressFromCooperativeSettleSignaturePublic(
-        channel_identifier,
-        A,
-        0,
-        B,
-        0,
-        signature_B,
-    ).call()
-
-    assert B != token_network_test.functions.recoverAddressFromCooperativeSettleSignaturePublic(
-        channel_identifier,
-        A,
-        0,
-        B,
-        0,
-        signature_A,
-    ).call()
-
-    assert A != token_network_test.functions.recoverAddressFromCooperativeSettleSignaturePublic(
-        channel_identifier,
-        A,
-        0,
-        B,
-        0,
-        signature_B,
-    ).call()
-
-    with pytest.raises(TransactionFailed):
-        token_network_test.functions.recoverAddressFromCooperativeSettleSignaturePublic(
-            channel_identifier,
-            A,
-            0,
-            B,
-            0,
-            fake_signature,
-        ).call()
+    VALUES = [UINT256_MIN, 1, UINT256_MAX, UINT256_MAX]
+    for a, b in product(VALUES, VALUES):
+        assert token_network_test_utils.functions.maxPublic(a, b).call() == max(a, b)

--- a/raiden_contracts/tests/unit/test_unit_signatures.py
+++ b/raiden_contracts/tests/unit/test_unit_signatures.py
@@ -3,61 +3,6 @@ from eth_tester.exceptions import TransactionFailed
 from raiden_contracts.tests.fixtures import fake_bytes
 
 
-def test_verify_withdraw_signatures(
-        token_network_test_signatures,
-        create_withdraw_signatures,
-        get_accounts,
-):
-
-    (A, B) = get_accounts(2)
-    fake_signature = fake_bytes(64)
-    channel_identifier = 4
-
-    (signature_A, signature_B) = create_withdraw_signatures(
-        [A, B],
-        channel_identifier,
-        A,
-        1,
-        token_network_test_signatures.address,
-    )
-    token_network_test_signatures.functions.verifyWithdrawSignaturesPublic(
-        channel_identifier,
-        A,
-        B,
-        1,
-        signature_A,
-        signature_B,
-    ).call()
-
-    with pytest.raises(TransactionFailed):
-        token_network_test_signatures.functions.verifyWithdrawSignaturesPublic(
-            channel_identifier,
-            A,
-            B,
-            3,
-            signature_B,
-            signature_A,
-        ).call()
-    with pytest.raises(TransactionFailed):
-        token_network_test_signatures.functions.verifyWithdrawSignaturesPublic(
-            channel_identifier,
-            A,
-            B,
-            3,
-            signature_A,
-            fake_signature,
-        ).call()
-    with pytest.raises(TransactionFailed):
-        token_network_test_signatures.functions.verifyWithdrawSignaturesPublic(
-            channel_identifier,
-            A,
-            B,
-            3,
-            fake_signature,
-            signature_B,
-        ).call()
-
-
 def test_recover_address_from_withdraw_message(
         token_network_test_signatures,
         create_withdraw_signatures,

--- a/raiden_contracts/tests/unit/test_unit_signatures.py
+++ b/raiden_contracts/tests/unit/test_unit_signatures.py
@@ -1,0 +1,290 @@
+import pytest
+from eth_tester.exceptions import TransactionFailed
+from raiden_contracts.tests.fixtures import fake_bytes
+
+
+def test_verify_withdraw_signatures(
+        token_network_test_signatures,
+        create_withdraw_signatures,
+        get_accounts,
+):
+
+    (A, B) = get_accounts(2)
+    fake_signature = fake_bytes(64)
+    channel_identifier = 4
+
+    (signature_A, signature_B) = create_withdraw_signatures(
+        [A, B],
+        channel_identifier,
+        A,
+        1,
+        token_network_test_signatures.address,
+    )
+    token_network_test_signatures.functions.verifyWithdrawSignaturesPublic(
+        channel_identifier,
+        A,
+        B,
+        1,
+        signature_A,
+        signature_B,
+    ).call()
+
+    with pytest.raises(TransactionFailed):
+        token_network_test_signatures.functions.verifyWithdrawSignaturesPublic(
+            channel_identifier,
+            A,
+            B,
+            3,
+            signature_B,
+            signature_A,
+        ).call()
+    with pytest.raises(TransactionFailed):
+        token_network_test_signatures.functions.verifyWithdrawSignaturesPublic(
+            channel_identifier,
+            A,
+            B,
+            3,
+            signature_A,
+            fake_signature,
+        ).call()
+    with pytest.raises(TransactionFailed):
+        token_network_test_signatures.functions.verifyWithdrawSignaturesPublic(
+            channel_identifier,
+            A,
+            B,
+            3,
+            fake_signature,
+            signature_B,
+        ).call()
+
+
+def test_recover_address_from_withdraw_message(
+        token_network_test_signatures,
+        create_withdraw_signatures,
+        create_channel_and_deposit,
+        get_accounts,
+):
+    (A, B) = get_accounts(2)
+    token_network = token_network_test_signatures
+    fake_signature = fake_bytes(64)
+    deposit_A = 5
+    deposit_B = 7
+    withdraw_A = 3
+    channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
+    (signature_A, signature_B) = create_withdraw_signatures(
+        [A, B],
+        channel_identifier,
+        A,
+        withdraw_A,
+        token_network.address,
+    )
+
+    recovered_address_A = token_network.functions.recoverAddressFromWithdrawMessagePublic(
+        channel_identifier,
+        A,
+        withdraw_A,
+        signature_A,
+    ).call()
+    assert recovered_address_A == A
+
+    recovered_address_B = token_network.functions.recoverAddressFromWithdrawMessagePublic(
+        channel_identifier,
+        A,
+        withdraw_A,
+        signature_B,
+    ).call()
+    assert recovered_address_B == B
+
+    with pytest.raises(TransactionFailed):
+        token_network.functions.recoverAddressFromWithdrawMessagePublic(
+            channel_identifier,
+            A,
+            withdraw_A,
+            fake_signature,
+        ).call()
+
+    wrong_participant = token_network.functions.recoverAddressFromWithdrawMessagePublic(
+        channel_identifier,
+        B,
+        withdraw_A,
+        signature_A,
+    ).call()
+    assert recovered_address_A != wrong_participant
+
+    wrong_withdraw_value = token_network.functions.recoverAddressFromWithdrawMessagePublic(
+        channel_identifier,
+        A,
+        1,
+        signature_A,
+    ).call()
+
+    assert recovered_address_A != wrong_withdraw_value
+
+    wrong_signature = token_network.functions.recoverAddressFromWithdrawMessagePublic(
+        channel_identifier,
+        A,
+        withdraw_A,
+        signature_B,
+    ).call()
+
+    assert recovered_address_A != wrong_signature
+
+
+def test_recover_address_from_balance_proof(
+        token_network_test_signatures,
+        create_balance_proof,
+        get_accounts,
+):
+    (A, B) = get_accounts(2)
+
+    channel_identifier = 4
+    balance_proof = create_balance_proof(
+        channel_identifier,
+        A,
+        other_token_network=token_network_test_signatures,
+    )
+
+    balance_proof_wrong_token_network = create_balance_proof(
+        channel_identifier,
+        A,
+    )
+
+    balance_proof_other_signer = create_balance_proof(
+        channel_identifier,
+        A,
+        signer=B,
+        other_token_network=token_network_test_signatures,
+    )
+
+    assert A == token_network_test_signatures.functions.recoverAddressFromBalanceProofPublic(
+        channel_identifier, *balance_proof).call()
+
+    assert B == token_network_test_signatures.functions.recoverAddressFromBalanceProofPublic(
+        channel_identifier,
+        *balance_proof_other_signer,
+    ).call()
+
+    assert A != token_network_test_signatures.functions.recoverAddressFromBalanceProofPublic(
+        channel_identifier, *balance_proof_wrong_token_network).call()
+
+
+def test_recover_address_from_balance_proof_update(
+        token_network_test_signatures,
+        create_balance_proof,
+        create_balance_proof_update_signature,
+        get_accounts,
+):
+
+    (A, B) = get_accounts(2)
+    other_token_network = token_network_test_signatures
+
+    channel_identifier = 4
+    balance_proof = create_balance_proof(
+        channel_identifier,
+        A,
+        other_token_network=other_token_network,
+    )
+    balance_proof_update_signature = create_balance_proof_update_signature(
+        B,
+        channel_identifier,
+        *balance_proof,
+        other_token_network=other_token_network,
+    )
+
+    balance_proof_update_signature_wrong_token_network = create_balance_proof_update_signature(
+        B,
+        channel_identifier,
+        *balance_proof,
+    )
+
+    balance_proof_signed_B = create_balance_proof(
+        channel_identifier,
+        B,
+        other_token_network=other_token_network,
+    )
+    balance_proof_update_signature_wrong_signer = create_balance_proof_update_signature(
+        B,
+        channel_identifier,
+        *balance_proof_signed_B,
+    )
+
+    assert B == other_token_network.functions.recoverAddressFromBalanceProofUpdateMessagePublic(
+        channel_identifier, *balance_proof, balance_proof_update_signature).call()
+
+    assert B != other_token_network.functions.recoverAddressFromBalanceProofUpdateMessagePublic(
+        channel_identifier,
+        *balance_proof,
+        balance_proof_update_signature_wrong_token_network,
+    ).call()
+
+    assert B != other_token_network.functions.recoverAddressFromBalanceProofUpdateMessagePublic(
+        channel_identifier,
+        *balance_proof,
+        balance_proof_update_signature_wrong_signer,
+    ).call()
+
+
+def test_recover_address_from_cooperative_settle_signature(
+        token_network_test_signatures,
+        create_cooperative_settle_signatures,
+        get_accounts,
+):
+    (A, B) = get_accounts(2)
+    other_token_network = token_network_test_signatures
+    channel_identifier = 4
+    fake_signature = fake_bytes(64)
+
+    (signature_A, signature_B) = create_cooperative_settle_signatures(
+        [A, B],
+        channel_identifier,
+        A,
+        0,
+        B,
+        0,
+        other_token_network=other_token_network,
+    )
+    assert A == other_token_network.functions.recoverAddressFromCooperativeSettleSignaturePublic(
+        channel_identifier,
+        A,
+        0,
+        B,
+        0,
+        signature_A,
+    ).call()
+
+    assert B == other_token_network.functions.recoverAddressFromCooperativeSettleSignaturePublic(
+        channel_identifier,
+        A,
+        0,
+        B,
+        0,
+        signature_B,
+    ).call()
+
+    assert B != other_token_network.functions.recoverAddressFromCooperativeSettleSignaturePublic(
+        channel_identifier,
+        A,
+        0,
+        B,
+        0,
+        signature_A,
+    ).call()
+
+    assert A != other_token_network.functions.recoverAddressFromCooperativeSettleSignaturePublic(
+        channel_identifier,
+        A,
+        0,
+        B,
+        0,
+        signature_B,
+    ).call()
+
+    with pytest.raises(TransactionFailed):
+        other_token_network.functions.recoverAddressFromCooperativeSettleSignaturePublic(
+            channel_identifier,
+            A,
+            0,
+            B,
+            0,
+            fake_signature,
+        ).call()

--- a/raiden_contracts/utils/sign.py
+++ b/raiden_contracts/utils/sign.py
@@ -1,6 +1,7 @@
 from web3 import Web3
 from eth_abi import encode_single
 from .sign_utils import sign
+from raiden_contracts.constants import MessageTypeId
 
 
 def hash_balance_data(transferred_amount, locked_amount, locksroot):
@@ -27,11 +28,10 @@ def hash_balance_proof(
         nonce,
         additional_hash,
 ):
-    message_type_id = 0
     return eth_sign_hash_message(
         Web3.toBytes(hexstr=token_network_address) +
         encode_single('uint256', chain_identifier) +
-        encode_single('uint256', message_type_id) +
+        encode_single('uint256', MessageTypeId.BALANCE_PROOF) +
         encode_single('uint256', channel_identifier) +
         balance_hash +
         encode_single('uint256', nonce) +
@@ -48,11 +48,10 @@ def hash_balance_proof_update_message(
         additional_hash,
         closing_signature,
 ):
-    message_type_id = 1
     return eth_sign_hash_message(
         Web3.toBytes(hexstr=token_network_address) +
         encode_single('uint256', chain_identifier) +
-        encode_single('uint256', message_type_id) +
+        encode_single('uint256', MessageTypeId.BALANCE_PROOF_UPDATE) +
         encode_single('uint256', channel_identifier) +
         balance_hash +
         encode_single('uint256', nonce) +
@@ -70,11 +69,10 @@ def hash_cooperative_settle_message(
         participant2_address,
         participant2_balance,
 ):
-    message_type_id = 3
     return eth_sign_hash_message(
         Web3.toBytes(hexstr=token_network_address) +
         encode_single('uint256', chain_identifier) +
-        encode_single('uint256', message_type_id) +
+        encode_single('uint256', MessageTypeId.COOPERATIVE_SETTLE) +
         encode_single('uint256', channel_identifier) +
         Web3.toBytes(hexstr=participant1_address) +
         encode_single('uint256', participant1_balance) +
@@ -90,11 +88,10 @@ def hash_withdraw_message(
         participant,
         amount_to_withdraw,
 ):
-    message_type_id = 2
     return eth_sign_hash_message(
         Web3.toBytes(hexstr=token_network_address) +
         encode_single('uint256', chain_identifier) +
-        encode_single('uint256', message_type_id) +
+        encode_single('uint256', MessageTypeId.WITHDRAW) +
         encode_single('uint256', channel_identifier) +
         Web3.toBytes(hexstr=participant) +
         encode_single('uint256', amount_to_withdraw),

--- a/raiden_contracts/utils/sign.py
+++ b/raiden_contracts/utils/sign.py
@@ -15,7 +15,7 @@ def eth_sign_hash_message(encoded_message):
     return Web3.sha3(
         Web3.toBytes(text=signature_prefix) +
         Web3.toBytes(text=str(len(encoded_message))) +
-        encoded_message
+        encoded_message,
     )
 
 
@@ -35,7 +35,7 @@ def hash_balance_proof(
         encode_single('uint256', channel_identifier) +
         balance_hash +
         encode_single('uint256', nonce) +
-        additional_hash
+        additional_hash,
     )
 
 
@@ -57,7 +57,7 @@ def hash_balance_proof_update_message(
         balance_hash +
         encode_single('uint256', nonce) +
         additional_hash +
-        closing_signature
+        closing_signature,
     )
 
 
@@ -79,7 +79,7 @@ def hash_cooperative_settle_message(
         Web3.toBytes(hexstr=participant1_address) +
         encode_single('uint256', participant1_balance) +
         Web3.toBytes(hexstr=participant2_address) +
-        encode_single('uint256', participant2_balance)
+        encode_single('uint256', participant2_balance),
     )
 
 
@@ -97,7 +97,7 @@ def hash_withdraw_message(
         encode_single('uint256', message_type_id) +
         encode_single('uint256', channel_identifier) +
         Web3.toBytes(hexstr=participant) +
-        encode_single('uint256', amount_to_withdraw)
+        encode_single('uint256', amount_to_withdraw),
     )
 
 

--- a/raiden_contracts/utils/sign.py
+++ b/raiden_contracts/utils/sign.py
@@ -1,4 +1,5 @@
 from web3 import Web3
+from eth_abi import encode_single
 from .sign_utils import sign
 
 
@@ -6,6 +7,15 @@ def hash_balance_data(transferred_amount, locked_amount, locksroot):
     return Web3.soliditySha3(
         ['uint256', 'uint256', 'bytes32'],
         [transferred_amount, locked_amount, locksroot],
+    )
+
+
+def eth_sign_hash_message(encoded_message):
+    signature_prefix = '\x19Ethereum Signed Message:\n'
+    return Web3.sha3(
+        Web3.toBytes(text=signature_prefix) +
+        Web3.toBytes(text=str(len(encoded_message))) +
+        encoded_message
     )
 
 
@@ -17,21 +27,16 @@ def hash_balance_proof(
         nonce,
         additional_hash,
 ):
-    return Web3.soliditySha3([
-        'bytes32',
-        'uint256',
-        'bytes32',
-        'uint256',
-        'address',
-        'uint256',
-    ], [
-        balance_hash,
-        nonce,
-        additional_hash,
-        channel_identifier,
-        token_network_address,
-        chain_identifier,
-    ])
+    message_type_id = 0
+    return eth_sign_hash_message(
+        Web3.toBytes(hexstr=token_network_address) +
+        encode_single('uint256', chain_identifier) +
+        encode_single('uint256', message_type_id) +
+        encode_single('uint256', channel_identifier) +
+        balance_hash +
+        encode_single('uint256', nonce) +
+        additional_hash
+    )
 
 
 def hash_balance_proof_update_message(
@@ -43,23 +48,17 @@ def hash_balance_proof_update_message(
         additional_hash,
         closing_signature,
 ):
-    return Web3.soliditySha3([
-        'bytes32',
-        'uint256',
-        'bytes32',
-        'uint256',
-        'address',
-        'uint256',
-        'bytes',
-    ], [
-        balance_hash,
-        nonce,
-        additional_hash,
-        channel_identifier,
-        token_network_address,
-        chain_identifier,
-        closing_signature,
-    ])
+    message_type_id = 1
+    return eth_sign_hash_message(
+        Web3.toBytes(hexstr=token_network_address) +
+        encode_single('uint256', chain_identifier) +
+        encode_single('uint256', message_type_id) +
+        encode_single('uint256', channel_identifier) +
+        balance_hash +
+        encode_single('uint256', nonce) +
+        additional_hash +
+        closing_signature
+    )
 
 
 def hash_cooperative_settle_message(
@@ -71,23 +70,17 @@ def hash_cooperative_settle_message(
         participant2_address,
         participant2_balance,
 ):
-    return Web3.soliditySha3([
-        'address',
-        'uint256',
-        'address',
-        'uint256',
-        'uint256',
-        'address',
-        'uint256',
-    ], [
-        participant1_address,
-        participant1_balance,
-        participant2_address,
-        participant2_balance,
-        channel_identifier,
-        token_network_address,
-        chain_identifier,
-    ])
+    message_type_id = 3
+    return eth_sign_hash_message(
+        Web3.toBytes(hexstr=token_network_address) +
+        encode_single('uint256', chain_identifier) +
+        encode_single('uint256', message_type_id) +
+        encode_single('uint256', channel_identifier) +
+        Web3.toBytes(hexstr=participant1_address) +
+        encode_single('uint256', participant1_balance) +
+        Web3.toBytes(hexstr=participant2_address) +
+        encode_single('uint256', participant2_balance)
+    )
 
 
 def hash_withdraw_message(
@@ -97,19 +90,15 @@ def hash_withdraw_message(
         participant,
         amount_to_withdraw,
 ):
-    return Web3.soliditySha3([
-        'address',
-        'uint256',
-        'uint256',
-        'address',
-        'uint256',
-    ], [
-        participant,
-        amount_to_withdraw,
-        channel_identifier,
-        token_network_address,
-        chain_identifier,
-    ])
+    message_type_id = 2
+    return eth_sign_hash_message(
+        Web3.toBytes(hexstr=token_network_address) +
+        encode_single('uint256', chain_identifier) +
+        encode_single('uint256', message_type_id) +
+        encode_single('uint256', channel_identifier) +
+        Web3.toBytes(hexstr=participant) +
+        encode_single('uint256', amount_to_withdraw)
+    )
 
 
 def hash_reward_proof(


### PR DESCRIPTION
Fixes https://github.com/raiden-network/raiden-contracts/issues/241

I also split the `TokenNetworkInternalsTest` into 3 contracts, because the bytecode size was too big for deployment after the signature changes.

# PR changes regarding the Raiden signed messages format:

Compatibility with EIP191 & `eth_sign`:

```
\x19Ethereum Signed Message:\n" + len(message) + message
message = <token_network_address> <chain_id> <message_type_id> <message specific data to sign>
```

## Implementation

```
string public constant signature_prefix = '\x19Ethereum Signed Message:\n';
```

Message content is tightly packed as described here: https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#abi-packed-mode
Python tests implementation: https://github.com/raiden-network/raiden-contracts/pull/252/commits/1569bb635b178c9683c9714b0c92dff4899b4afd#diff-6180c16583e73c52c0366184d36015f9 (I would have used `encode_abi_packed` from https://eth-abi.readthedocs.io/en/latest/encoding.html#non-standard-packed-mode-encoding, but there are some dependencies issues at the moment)

### Balance Proof Message:

```js
        uint256 message_type_id = 1;

        // Length of the actual message: 20 + 32 + 32 + 32 + 32 + 32 + 32
        string memory message_length = '212';

        bytes32 message_hash = keccak256(abi.encodePacked(
            signature_prefix,  // string
            message_length,  // string
            token_network_address,  // address
            chain_id,  // uint256
            message_type_id,  // uint256
            channel_identifier,  // uint256
            balance_hash,  // bytes32
            nonce,  // uint256
            additional_hash  // bytes32
        ));
```

### Balance Proof Update Message:

```
        uint256 message_type_id = 2;

        // Length of the actual message: 20 + 32 + 32 + 32 + 32 + 32 + 32 + 65
        string memory message_length = '277';

        bytes32 message_hash = keccak256(abi.encodePacked(
            signature_prefix,  // string
            message_length,  // string
            token_network_address,  // address
            chain_id,  // uint256
            message_type_id,  // uint256
            channel_identifier,  // uint256
            balance_hash,  // bytes32
            nonce,  // uint256
            additional_hash  // bytes32
            closing_signature  // bytes
        ));
```

### Withdraw Message:

```
        uint256 message_type_id = 3;

        // Length of the actual message: 20 + 32 + 32 + 32 + 20 + 32
        string memory message_length = '168';

        bytes32 message_hash = keccak256(abi.encodePacked(
            signature_prefix,  // string
            message_length,  // string
            token_network_address,  // address
            chain_id,  // uint256
            message_type_id,  // uint256
            channel_identifier,  // uint256
            participant,  // address
            total_withdraw  // uint256
        ));
```

### Cooperative Settle Message:

```
        uint256 message_type_id = 4;

        // Length of the actual message: 20 + 32 + 32 + 32 + 20 + 32 + 20 + 32
        string memory message_length = '220';

        bytes32 message_hash = keccak256(abi.encodePacked(
            signature_prefix,  // string
            message_length,  // string
            token_network_address,  // address
            chain_id,  // uint256
            message_type_id,  // uint256
            channel_identifier,  // uint256
            participant1,  // address
            participant1_balance,  // uint256
            participant2,  // address
            participant2_balance  // uint256
        ));
```
