### PR TITLE
Sync dependency with raiden-libs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
 rlp>=1.0.0
-coincurve>=7.1.0,<8.0
+coincurve>=8.0.0,<9.0
 web3>=4.4.1
 py-solc>=3.0.0


### PR DESCRIPTION
Raiden-libs updated its `coincurve` dependency. No breaking changes on this update.