### PR TITLE
Check for solc when doing a release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,7 @@ lint:
 	flake8 raiden_contracts/
 
 clean:
-	rm -rf build/ *egg-info/ raiden_contracts/data/contracts.json dist
+	rm -rf build/ *egg-info/ raiden_contracts/data/contracts.json.gz dist .eggs
+
+release: clean
+	RAIDEN_SOLC_REQUIRED=1 python setup.py sdist bdist_wheel upload

--- a/setup.py
+++ b/setup.py
@@ -62,12 +62,6 @@ class CompileContracts(Command):
         # precompiled `contracts.json` from preventing us from compiling a new one
         os.environ['_RAIDEN_CONTRACT_MANAGER_SKIP_PRECOMPILED'] = '1'
 
-        try:
-            from solc import compile_files  # noqa
-        except ModuleNotFoundError:
-            print('py-solc is not installed, skipping contracts compilation')
-            return
-
         from raiden_contracts.contract_manager import (
             ContractManager,
             CONTRACTS_PRECOMPILED_PATH,
@@ -78,6 +72,8 @@ class CompileContracts(Command):
             contract_manager = ContractManager(CONTRACTS_SOURCE_DIRS)
             contract_manager.store_compiled_contracts(CONTRACTS_PRECOMPILED_PATH)
         except RuntimeError:
+            if os.environ.get('RAIDEN_SOLC_REQUIRED') is not None:
+                raise
             import traceback
             print("Couldn't compile the contracts!")
             traceback.print_exc()


### PR DESCRIPTION
- adds `make release` target - solc is required for building a release
  if RAIDEN_SOLC_REQUIRED environment variable is set
- removed check for `py-solc` module (it's a `setup.py` dependency now)

Fixes #266 