### PR TITLE
Comment out cooperativeSettle & setTotalWithdraw temporarily

### DIFF
--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -811,7 +811,7 @@ contract TokenNetwork is Utils {
         assert(locked_amount >= unlocked_amount);
     }
 
-    /// @notice Cooperatively settles the balances between the two channel
+    /* /// @notice Cooperatively settles the balances between the two channel
     /// participants and transfers the agreed upon token amounts to the
     /// participants. After this the channel lifecycle has ended and no more
     /// operations can be done on it.
@@ -908,7 +908,7 @@ contract TokenNetwork is Utils {
         if (participant2_balance > 0) {
             require(token.transfer(participant2, participant2_balance));
         }
-    }
+    } */
 
     /// @notice Returns the unique identifier for the channel given by the
     /// contract.
@@ -1438,7 +1438,7 @@ contract TokenNetwork is Utils {
         signature_address = ECVerify.ecverify(message_hash, non_closing_signature);
     }
 
-    function recoverAddressFromCooperativeSettleSignature(
+    /* function recoverAddressFromCooperativeSettleSignature(
         uint256 channel_identifier,
         address participant1,
         uint256 participant1_balance,
@@ -1467,7 +1467,7 @@ contract TokenNetwork is Utils {
         ));
 
         signature_address = ECVerify.ecverify(message_hash, signature);
-    }
+    } */
 
     function recoverAddressFromWithdrawMessage(
         uint256 channel_identifier,

--- a/raiden_contracts/contracts/TokenNetwork.sol
+++ b/raiden_contracts/contracts/TokenNetwork.sol
@@ -145,11 +145,11 @@ contract TokenNetwork is Utils {
     // total_withdraw is how much the participant has withdrawn during the
     // lifetime of the channel. The actual amount which the participant withdrew
     // is `total_withdraw - total_withdraw_from_previous_event_or_zero`
-    event ChannelWithdraw(
+    /* event ChannelWithdraw(
         uint256 indexed channel_identifier,
         address indexed participant,
         uint256 total_withdraw
-    );
+    ); */
 
     event ChannelClosed(
         uint256 indexed channel_identifier,
@@ -330,7 +330,7 @@ contract TokenNetwork is Utils {
         require(token.transferFrom(msg.sender, address(this), added_deposit));
     }
 
-    /// @notice Allows `participant` to withdraw tokens from the channel that he
+    /* /// @notice Allows `participant` to withdraw tokens from the channel that he
     /// has with `partner`, without closing it. Can be called by anyone. Can
     /// only be called once per each signed withdraw message.
     /// @param channel_identifier Identifier for the channel on which this
@@ -422,7 +422,7 @@ contract TokenNetwork is Utils {
         assert(participant_state.nonce == 0);
         assert(partner_state.nonce == 0);
 
-    }
+    } */
 
     /// @notice Close the channel defined by the two participant addresses. Only
     /// a participant may close the channel, providing a balance proof signed by
@@ -1469,7 +1469,7 @@ contract TokenNetwork is Utils {
         signature_address = ECVerify.ecverify(message_hash, signature);
     } */
 
-    function recoverAddressFromWithdrawMessage(
+    /* function recoverAddressFromWithdrawMessage(
         uint256 channel_identifier,
         address participant,
         uint256 total_withdraw,
@@ -1494,7 +1494,7 @@ contract TokenNetwork is Utils {
         ));
 
         signature_address = ECVerify.ecverify(message_hash, signature);
-    }
+    } */
 
     /// @dev Calculates the merkle root for the pending transfers data and
     //calculates the amount / of tokens that can be unlocked because the secret

--- a/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
+++ b/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
@@ -199,7 +199,7 @@ contract TokenNetworkSignatureTest is TokenNetwork {
         );
     }
 
-    function recoverAddressFromCooperativeSettleSignaturePublic(
+    /* function recoverAddressFromCooperativeSettleSignaturePublic(
         uint256 channel_identifier,
         address participant1,
         uint256 participant1_balance,
@@ -219,7 +219,7 @@ contract TokenNetworkSignatureTest is TokenNetwork {
             participant2_balance,
             signature
         );
-    }
+    } */
 
     function recoverAddressFromWithdrawMessagePublic(
         uint256 channel_identifier,

--- a/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
+++ b/raiden_contracts/contracts/test/TokenNetworkInternalsTest.sol
@@ -221,7 +221,7 @@ contract TokenNetworkSignatureTest is TokenNetwork {
         );
     } */
 
-    function recoverAddressFromWithdrawMessagePublic(
+    /* function recoverAddressFromWithdrawMessagePublic(
         uint256 channel_identifier,
         address participant,
         uint256 amount_to_withdraw,
@@ -237,7 +237,7 @@ contract TokenNetworkSignatureTest is TokenNetwork {
             amount_to_withdraw,
             signature
         );
-    }
+    } */
 }
 
 contract TokenNetworkUtilsTest is TokenNetwork {

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -115,13 +115,15 @@ def withdraw_channel(token_network, create_withdraw_signatures):
             channel_identifier,
             participant, withdraw_amount
         )
-        txn_hash = token_network.functions.setTotalWithdraw(
-            channel_identifier,
-            participant,
-            withdraw_amount,
-            signature_participant,
-            signature_partner
-        ).transact({'from': delegate})
+        # TODO uncomment this after setTotalWithdraw is uncommented in the TokenNetwork contract
+        txn_hash = b''
+        # txn_hash = token_network.functions.setTotalWithdraw(
+        #     channel_identifier,
+        #     participant,
+        #     withdraw_amount,
+        #     signature_participant,
+        #     signature_partner
+        # ).transact({'from': delegate})
         return txn_hash
     return get
 

--- a/raiden_contracts/tests/test_channel_cooperative_settle.py
+++ b/raiden_contracts/tests/test_channel_cooperative_settle.py
@@ -6,6 +6,7 @@ from raiden_contracts.constants import ChannelEvent
 from web3.exceptions import ValidationError
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_cooperative_settle_channel_call(
         token_network,
         create_channel_and_deposit,
@@ -123,6 +124,7 @@ def test_cooperative_settle_channel_call(
     ).transact({'from': C})
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_cooperative_settle_channel_signatures(
         token_network,
         create_channel_and_deposit,
@@ -188,6 +190,7 @@ def test_cooperative_settle_channel_signatures(
     ).transact({'from': C})
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_cooperative_settle_channel_0(
         custom_token,
         token_network,
@@ -239,6 +242,7 @@ def test_cooperative_settle_channel_0(
     )
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_cooperative_settle_channel_00(
         custom_token,
         token_network,
@@ -290,6 +294,7 @@ def test_cooperative_settle_channel_00(
     )
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_cooperative_settle_channel_state(
         custom_token,
         token_network,
@@ -342,6 +347,7 @@ def test_cooperative_settle_channel_state(
     )
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_cooperative_settle_channel_state_withdraw(
         custom_token,
         token_network,
@@ -399,6 +405,7 @@ def test_cooperative_settle_channel_state_withdraw(
     )
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_cooperative_settle_channel_bigger_withdraw(
         custom_token,
         token_network,
@@ -442,6 +449,7 @@ def test_cooperative_settle_channel_bigger_withdraw(
         ).transact({'from': C})
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_cooperative_settle_channel_wrong_balances(
         custom_token,
         token_network,
@@ -520,6 +528,7 @@ def test_cooperative_settle_channel_wrong_balances(
     ).transact({'from': C})
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_cooperative_close_replay_reopened_channel(
         get_accounts,
         token_network,
@@ -593,6 +602,7 @@ def test_cooperative_close_replay_reopened_channel(
     ).transact({'from': B})
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_cooperative_settle_channel_event(
         get_accounts,
         token_network,

--- a/raiden_contracts/tests/test_channel_cooperative_settle.py
+++ b/raiden_contracts/tests/test_channel_cooperative_settle.py
@@ -6,7 +6,7 @@ from raiden_contracts.constants import ChannelEvent
 from web3.exceptions import ValidationError
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_cooperative_settle_channel_call(
         token_network,
         create_channel_and_deposit,
@@ -124,7 +124,7 @@ def test_cooperative_settle_channel_call(
     ).transact({'from': C})
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_cooperative_settle_channel_signatures(
         token_network,
         create_channel_and_deposit,
@@ -190,7 +190,7 @@ def test_cooperative_settle_channel_signatures(
     ).transact({'from': C})
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_cooperative_settle_channel_0(
         custom_token,
         token_network,
@@ -242,7 +242,7 @@ def test_cooperative_settle_channel_0(
     )
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_cooperative_settle_channel_00(
         custom_token,
         token_network,
@@ -294,7 +294,7 @@ def test_cooperative_settle_channel_00(
     )
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_cooperative_settle_channel_state(
         custom_token,
         token_network,
@@ -347,7 +347,7 @@ def test_cooperative_settle_channel_state(
     )
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_cooperative_settle_channel_state_withdraw(
         custom_token,
         token_network,
@@ -405,7 +405,7 @@ def test_cooperative_settle_channel_state_withdraw(
     )
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_cooperative_settle_channel_bigger_withdraw(
         custom_token,
         token_network,
@@ -449,7 +449,7 @@ def test_cooperative_settle_channel_bigger_withdraw(
         ).transact({'from': C})
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_cooperative_settle_channel_wrong_balances(
         custom_token,
         token_network,
@@ -528,7 +528,7 @@ def test_cooperative_settle_channel_wrong_balances(
     ).transact({'from': C})
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_cooperative_close_replay_reopened_channel(
         get_accounts,
         token_network,
@@ -602,7 +602,7 @@ def test_cooperative_close_replay_reopened_channel(
     ).transact({'from': B})
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_cooperative_settle_channel_event(
         get_accounts,
         token_network,

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -142,11 +142,20 @@ def test_settle_channel_state(
 
     # Some manual checks for the final balances, in case the settlement algorithms
     # used in `settle_state_tests` are incorrect
-    assert custom_token.functions.balanceOf(A).call() == pre_balance_A + 33
-    assert custom_token.functions.balanceOf(B).call() == pre_balance_B + 15
+
+    # FIXME after setTotalWithdraw is implemented again
+    post_balance_A = pre_balance_A + 33
+    post_balance_B = pre_balance_B + 15
+    post_balance_contract = pre_balance_contract - 48
+
+    # FIXME after setTotalWithdraw is implemented again
+    # we add the withdrawn amount here, because it was never withdrawn due to the
+    # removal of setTotalWithdraw
+    assert custom_token.functions.balanceOf(A).call() == post_balance_A + 10
+    assert custom_token.functions.balanceOf(B).call() == post_balance_B + 5
     assert custom_token.functions.balanceOf(
         token_network.address,
-    ).call() == pre_balance_contract - 48
+    ).call() == post_balance_contract - 15
 
 
 def test_settle_single_direct_transfer_for_closing_party(

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -345,6 +345,7 @@ def test_settlement_with_unauthorized_token_transfer(
 
     # Assign additional tokens to A
     assign_tokens(A, externally_transferred_amount)
+    assert custom_token.functions.balanceOf(A).call() >= externally_transferred_amount
 
     # Fetch onchain balances after settlement
     pre_balance_A = custom_token.functions.balanceOf(A).call()
@@ -356,6 +357,10 @@ def test_settlement_with_unauthorized_token_transfer(
         token_network.address,
         externally_transferred_amount,
     ).transact({'from': A})
+    assert custom_token.functions.balanceOf(token_network.address).call() == (
+        pre_balance_contract +
+        externally_transferred_amount
+    )
 
     web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN)
 

--- a/raiden_contracts/tests/test_channel_withdraw.py
+++ b/raiden_contracts/tests/test_channel_withdraw.py
@@ -17,6 +17,7 @@ from raiden_contracts.tests.fixtures.config import (
 )
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_withdraw_call(
         token_network,
         create_channel_and_deposit,
@@ -109,6 +110,7 @@ def test_withdraw_call(
     ).transact({'from': A})
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_withdraw_wrong_state(
         web3,
         token_network,
@@ -161,6 +163,7 @@ def test_withdraw_wrong_state(
         withdraw_channel(channel_identifier, A, withdraw_A, B)
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_withdraw_bigger(
         web3,
         token_network,
@@ -189,6 +192,7 @@ def test_withdraw_bigger(
     withdraw_channel(channel_identifier, A, deposit_A + deposit_B - 7, B)
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_withdraw_wrong_signers(
         web3,
         token_network,
@@ -235,6 +239,7 @@ def test_withdraw_wrong_signers(
     ).transact({'from': C})
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_withdraw_wrong_signature_content(
         web3,
         token_network,
@@ -333,6 +338,7 @@ def test_withdraw_wrong_signature_content(
     ).transact({'from': A})
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_withdraw_channel_state(
         get_accounts,
         token_network,
@@ -421,6 +427,7 @@ def test_withdraw_channel_state(
     )
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_withdraw_replay_reopened_channel(
         web3,
         token_network,
@@ -500,6 +507,7 @@ def test_withdraw_replay_reopened_channel(
     ).transact({'from': A})
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_withdraw_event(
         token_network,
         create_channel_and_deposit,

--- a/raiden_contracts/tests/test_channel_withdraw.py
+++ b/raiden_contracts/tests/test_channel_withdraw.py
@@ -17,7 +17,7 @@ from raiden_contracts.tests.fixtures.config import (
 )
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_withdraw_call(
         token_network,
         create_channel_and_deposit,
@@ -110,7 +110,7 @@ def test_withdraw_call(
     ).transact({'from': A})
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_withdraw_wrong_state(
         web3,
         token_network,
@@ -163,7 +163,7 @@ def test_withdraw_wrong_state(
         withdraw_channel(channel_identifier, A, withdraw_A, B)
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_withdraw_bigger(
         web3,
         token_network,
@@ -192,7 +192,7 @@ def test_withdraw_bigger(
     withdraw_channel(channel_identifier, A, deposit_A + deposit_B - 7, B)
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_withdraw_wrong_signers(
         web3,
         token_network,
@@ -239,7 +239,7 @@ def test_withdraw_wrong_signers(
     ).transact({'from': C})
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_withdraw_wrong_signature_content(
         web3,
         token_network,
@@ -338,7 +338,7 @@ def test_withdraw_wrong_signature_content(
     ).transact({'from': A})
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_withdraw_channel_state(
         get_accounts,
         token_network,
@@ -427,7 +427,7 @@ def test_withdraw_channel_state(
     )
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_withdraw_replay_reopened_channel(
         web3,
         token_network,
@@ -507,7 +507,7 @@ def test_withdraw_replay_reopened_channel(
     ).transact({'from': A})
 
 
-@pytest.mark.skip(reason='Delayed to another milestone')
+@pytest.mark.skip(reason='Delayed until another milestone')
 def test_withdraw_event(
         token_network,
         create_channel_and_deposit,

--- a/raiden_contracts/tests/unit/test_unit_signatures.py
+++ b/raiden_contracts/tests/unit/test_unit_signatures.py
@@ -3,6 +3,7 @@ from eth_tester.exceptions import TransactionFailed
 from raiden_contracts.tests.fixtures import fake_bytes
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_recover_address_from_withdraw_message(
         token_network_test_signatures,
         create_withdraw_signatures,

--- a/raiden_contracts/tests/unit/test_unit_signatures.py
+++ b/raiden_contracts/tests/unit/test_unit_signatures.py
@@ -169,6 +169,7 @@ def test_recover_address_from_balance_proof_update(
     ).call()
 
 
+@pytest.mark.skip(reason='Delayed to another milestone')
 def test_recover_address_from_cooperative_settle_signature(
         token_network_test_signatures,
         create_cooperative_settle_signatures,

--- a/raiden_contracts/tests/utils/utils.py
+++ b/raiden_contracts/tests/utils/utils.py
@@ -27,7 +27,9 @@ class ChannelValues():
             additional_hash=EMPTY_ADDITIONAL_HASH,
     ):
         self.deposit = deposit
-        self.withdrawn = withdrawn
+        # FIXME after setTotalWithdraw is enabled again
+        self.withdrawn = 0
+        # self.withdrawn = withdrawn
         self.nonce = nonce
         self.transferred = transferred
         self.claimable_locked = claimable_locked or locked


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden-contracts/issues/265

Please do not merge this until I have the contract limits PR functional on top of this one.

Issue: TokenNetworkRegistry bytecode is too big for deployment if we try to implement https://github.com/raiden-network/raiden-contracts/issues/262 and https://github.com/raiden-network/raiden-contracts/issues/263

We might go with either:
- (**favorite option until now**) remove code that is unimplemented in Raiden: https://github.com/raiden-network/raiden-contracts/pull/270 (remove `cooperativeSettle` & `setTotalWithdraw`)
- move some part of the code in a library https://github.com/raiden-network/raiden-contracts/pull/264 (implemented just in case)

Please do not merge this until I have the contract limits PR functional on top of this one.