### PR TITLE
New deployment script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,30 @@
-env/
-build/
+__pycache__/
+*.py[cod]
 /.idea
 credentials/
-*.egg-info
-__pycache__
-build/docs/
 .cache
 .pytest_cache
 venv/
+
+# Distribution / packaging
+.Python
+env/
+devenv/
+build/
+build/docs/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
 
 # ignore private keys
 *.pem
@@ -16,3 +33,5 @@ venv/
 .vscode/
 
 raiden_contracts/data/contracts.json.gz
+
+tags

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -1,45 +1,108 @@
 """
 A simple Python script to deploy compiled contracts.
 """
+import json
 import logging
 from logging import getLogger
-from getpass import getpass
+from typing import Dict
 
 import click
-import json
-
-from raiden_contracts.contract_manager import ContractManager, CONTRACTS_SOURCE_DIRS
-from web3 import Web3, HTTPProvider
-from eth_utils import (
-    is_address,
-    to_checksum_address,
-)
-
-from raiden_contracts.utils.utils import (
-    check_succesful_tx,
-)
-from raiden_contracts.constants import (
-    CONTRACT_ENDPOINT_REGISTRY,
-    CONTRACT_TOKEN_NETWORK_REGISTRY,
-    CONTRACT_SECRET_REGISTRY,
-    CONTRACT_CUSTOM_TOKEN,
-    DEPLOY_SETTLE_TIMEOUT_MIN,
-    DEPLOY_SETTLE_TIMEOUT_MAX,
-)
+from eth_utils import denoms, encode_hex, is_address, to_checksum_address
+from web3 import HTTPProvider, Web3
 from web3.middleware import geth_poa_middleware
+
+from raiden_contracts.constants import (
+    CONTRACT_CUSTOM_TOKEN,
+    CONTRACT_ENDPOINT_REGISTRY,
+    CONTRACT_SECRET_REGISTRY,
+    CONTRACT_TOKEN_NETWORK_REGISTRY,
+    DEPLOY_SETTLE_TIMEOUT_MAX,
+    DEPLOY_SETTLE_TIMEOUT_MIN,
+)
+from raiden_contracts.contract_manager import CONTRACTS_SOURCE_DIRS, ContractManager
+from raiden_contracts.utils.utils import check_succesful_tx
+from raiden_libs.private_contract import PrivateContract
+from raiden_libs.utils import get_private_key, private_key_to_address
 
 log = getLogger(__name__)
 
 
-@click.command()
+def validate_address(ctx, param, value):
+    if not value:
+        return None
+    try:
+        is_address(value)
+        return to_checksum_address(value)
+    except ValueError:
+        raise click.BadParameter('must be a valid ethereum address')
+
+
+class ContractDeployer:
+    def __init__(
+        self,
+        web3: Web3,
+        private_key: str,
+        gas_limit: int,
+        gas_price: int=1,
+        wait: int=10,
+    ):
+        self.web3 = web3
+        self.private_key = private_key
+        self.wait = wait
+        owner = private_key_to_address(private_key)
+        self.transaction = {'from': owner, 'gas_limit': gas_limit}
+        if gas_price != 0:
+            self.transaction['gasPrice'] = gas_price * denoms.gwei
+        self.contract_manager = ContractManager(CONTRACTS_SOURCE_DIRS)
+        self.contract_manager._compile_all_contracts()
+
+    def deploy(
+        self,
+        contract_name: str,
+        args=None,
+    ):
+        if args is None:
+            args = list()
+        contract_interface = self.contract_manager.get_contract(
+            contract_name,
+        )
+
+        # Instantiate and deploy contract
+        contract = self.web3.eth.contract(
+            abi=contract_interface['abi'],
+            bytecode=contract_interface['bin'],
+        )
+        contract = PrivateContract(contract)
+
+        # Get transaction hash from deployed contract
+        txhash = contract.constructor(*args).transact(
+            self.transaction,
+            private_key=self.private_key,
+        )
+
+        # Get tx receipt to get contract address
+        log.debug("Deploying %s txHash=%s" % (contract_name, encode_hex(txhash)))
+        receipt = check_succesful_tx(self.web3, txhash, self.wait)
+        log.info(
+            '{0} address: {1}. Gas used: {2}'.format(
+                contract_name,
+                receipt['contractAddress'],
+                receipt['gasUsed'],
+            ),
+        )
+        return receipt['contractAddress']
+
+
+@click.group(chain=True)
 @click.option(
     '--rpc-provider',
     default='http://127.0.0.1:8545',
     help='Address of the Ethereum RPC provider',
 )
 @click.option(
-    '--owner',
-    help='Contracts owner, default: web3.eth.accounts[0]',
+    '--private-key',
+    required=True,
+    help='Path to a private key store',
 )
 @click.option(
     '--wait',
@@ -54,14 +117,57 @@ log = getLogger(__name__)
 )
 @click.option(
     '--gas-limit',
-    default=5_500_00,
+    default=5_500_000,
 )
+@click.pass_context
+def main(
+    ctx,
+    rpc_provider,
+    private_key,
+    wait,
+    gas_price,
+    gas_limit,
+):
+
+    logging.basicConfig(level=logging.DEBUG)
+    logging.getLogger('web3').setLevel(logging.INFO)
+    logging.getLogger('urllib3').setLevel(logging.INFO)
+
+    web3 = Web3(HTTPProvider(rpc_provider, request_kwargs={'timeout': 60}))
+    web3.middleware_stack.inject(geth_poa_middleware, layer=0)
+    print('Web3 provider is', web3.providers[0])
+
+    private_key = get_private_key(private_key)
+    assert private_key is not None
+    owner = private_key_to_address(private_key)
+    assert web3.eth.getBalance(owner) > 0, 'Account with insuficient funds.'
+    deployer = ContractDeployer(
+        web3,
+        private_key,
+        gas_limit,
+        gas_price,
+        wait,
+    )
+    ctx.obj = {}
+    ctx.obj['deployer'] = deployer
+    ctx.obj['deployed_contracts'] = {}
+    ctx.obj['token_type'] = 'CustomToken'
+    ctx.obj['wait'] = wait
+
+
+@main.command()
+@click.pass_context
+def raiden(ctx):
+    deployed_contracts = deploy_raiden_contracts(
+        ctx.obj['deployer'],
+    )
+    print(json.dumps(deployed_contracts, indent=4))
+    ctx.obj['deployed_contracts'].update(deployed_contracts)
+
+
+@main.command()
 @click.option(
-    '--deploy-token',
-    is_flag=True,
-    help='Also deploy a test token and register with the newly deployed token network contract')
-@click.option(
-    '--supply',
+    '--token-supply',
     default=10000000,
     help='Token contract supply (number of total issued tokens).',
 )
@@ -80,166 +186,148 @@ log = getLogger(__name__)
     default='TKN',
     help='Token contract symbol.',
 )
-@click.option(
-    '--token-address',
-    help='Already deployed token address.',
-)
-def main(
-    rpc_provider,
-    owner,
-    wait,
-    gas_price,
-    gas_limit,
-    deploy_token,
-    supply,
+@click.pass_context
+def token(
+    ctx,
+    token_supply,
     token_name,
     token_decimals,
     token_symbol,
-    token_address,
 ):
-    supply *= 10 ** token_decimals
+    deployer = ctx.obj['deployer']
+    token_supply *= 10 ** token_decimals
+    deployed_token = deploy_token_contract(
+        deployer,
+        token_supply,
+        token_decimals,
+        token_name,
+        token_symbol,
+        token_type=ctx.obj['token_type'],
+    )
+    print(json.dumps(deployed_token, indent=4))
+    ctx.obj['deployed_contracts'].update(deployed_token)
 
-    logging.basicConfig(level=logging.DEBUG)
-    logging.getLogger('web3').setLevel(logging.INFO)
-    logging.getLogger('urllib3').setLevel(logging.INFO)
 
-    web3 = Web3(HTTPProvider(rpc_provider, request_kwargs={'timeout': 60}))
-    web3.middleware_stack.inject(geth_poa_middleware, layer=0)
-    print('Web3 provider is', web3.providers[0])
+@main.command()
+@click.pass_context
+@click.option(
+    '--token-address',
+    default=None,
+    callback=validate_address,
+    help='Already deployed token address.',
+)
+@click.option(
+    '--registry-address',
+    default=None,
+    callback=validate_address,
+    help='Address of token network registry',
+)
+def register(
+    ctx,
+    token_address,
+    registry_address,
+):
+    token_type = ctx.obj['token_type']
+    deployer = ctx.obj['deployer']
+    if token_address:
+        ctx.obj['deployed_contracts'][token_type] = token_address
+    if registry_address:
+        ctx.obj['deployed_contracts'][CONTRACT_TOKEN_NETWORK_REGISTRY] = registry_address
+    assert CONTRACT_TOKEN_NETWORK_REGISTRY in ctx.obj['deployed_contracts']
+    assert token_type in ctx.obj['deployed_contracts']
+    abi = deployer.contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK_REGISTRY)
+    register_token_network(
+        web3=deployer.web3,
+        private_key=deployer.private_key,
+        token_registry_abi=abi,
+        token_registry_address=ctx.obj['deployed_contracts'][CONTRACT_TOKEN_NETWORK_REGISTRY],
+        token_address=ctx.obj['deployed_contracts'][token_type],
+        wait=ctx.obj['wait'],
+    )
 
-    owner = owner or web3.eth.accounts[0]
-    assert owner and is_address(owner), 'Invalid owner provided.'
-    owner = to_checksum_address(owner)
-    print('Owner is', owner)
-    assert web3.eth.getBalance(owner) > 0, 'Account with insuficient funds.'
 
-    password = getpass(f'Enter password for {owner}:')
-
-    transaction = {'from': owner, 'gas': gas_limit}
-    if gas_price != 0:
-        transaction['gasPrice'] = gas_price * 10 ** 9
-
-    contract_manager = ContractManager(CONTRACTS_SOURCE_DIRS)
-    contract_manager._compile_all_contracts()
-    contracts_compiled_data = contract_manager._contracts
-
+def deploy_raiden_contracts(
+    deployer: ContractDeployer,
+):
+    """Deploy all required raiden contracts and return a dict of contract_name:address"""
     deployed_contracts = {}
 
-    web3.personal.unlockAccount(owner, password)
-    deployed_contracts[CONTRACT_ENDPOINT_REGISTRY] = deploy_contract(
-        web3,
-        contracts_compiled_data,
+    deployed_contracts[CONTRACT_ENDPOINT_REGISTRY] = deployer.deploy(
         CONTRACT_ENDPOINT_REGISTRY,
-        transaction,
-        wait,
     )
 
-    web3.personal.unlockAccount(owner, password)
-    secret_registry_address = deploy_contract(
-        web3,
-        contracts_compiled_data,
+    deployed_contracts[CONTRACT_SECRET_REGISTRY] = deployer.deploy(
         CONTRACT_SECRET_REGISTRY,
-        transaction,
-        wait,
     )
-    deployed_contracts[CONTRACT_SECRET_REGISTRY] = secret_registry_address
-
-    web3.personal.unlockAccount(owner, password)
-    token_network_registry_address = deploy_contract(
-        web3,
-        contracts_compiled_data,
+    deployed_contracts[CONTRACT_TOKEN_NETWORK_REGISTRY] = deployer.deploy(
         CONTRACT_TOKEN_NETWORK_REGISTRY,
-        transaction,
-        wait,
         [
-            secret_registry_address,
-            int(web3.version.network),
+            deployed_contracts[CONTRACT_SECRET_REGISTRY],
+            int(deployer.web3.version.network),
             DEPLOY_SETTLE_TIMEOUT_MIN,
             DEPLOY_SETTLE_TIMEOUT_MAX,
         ],
     )
-    deployed_contracts[CONTRACT_TOKEN_NETWORK_REGISTRY] = token_network_registry_address
-
-    if deploy_token:
-        if not token_address:
-            web3.personal.unlockAccount(owner, password)
-            deployed_contracts['CustomToken'] = token_address = deploy_contract(
-                web3,
-                contracts_compiled_data,
-                'CustomToken',
-                transaction,
-                wait,
-                [supply, token_decimals, token_name, token_symbol],
-            )
-
-        assert token_address and is_address(token_address)
-        token_address = to_checksum_address(token_address)
-
-        token_network_registry = instantiate_contract(
-            web3,
-            contracts_compiled_data,
-            CONTRACT_TOKEN_NETWORK_REGISTRY,
-            token_network_registry_address,
-        )
-
-        web3.personal.unlockAccount(owner, password)
-        txhash = token_network_registry.transact(transaction).createERC20TokenNetwork(
-            token_address,
-        )
-        receipt = check_succesful_tx(web3, txhash, wait)
-
-        print(
-            'TokenNetwork address: {0}. Gas used: {1}'.format(
-                token_network_registry.functions.token_to_token_networks(token_address).call(),
-                receipt['gasUsed'],
-            ),
-        )
-    print(json.dumps(deployed_contracts, indent=4))
+    return deployed_contracts
 
 
-def instantiate_contract(web3, contracts_compiled_data, contract_name, contract_address):
-    contract_interface = contracts_compiled_data[contract_name]
-
-    contract = web3.eth.contract(
-        abi=contract_interface['abi'],
-        bytecode=contract_interface['bin'],
-        address=contract_address,
-    )
-
-    return contract
-
-
-def deploy_contract(
-        web3,
-        contracts_compiled_data,
-        contract_name,
-        transaction,
-        txn_wait=200,
-        args=None,
+def deploy_token_contract(
+    deployer: ContractDeployer,
+    token_supply: int,
+    token_decimals: int,
+    token_name: str,
+    token_symbol: str,
+    token_type: str='CustomToken',
 ):
-    contract_interface = contracts_compiled_data[contract_name]
-
-    # Instantiate and deploy contract
-    contract = web3.eth.contract(
-        abi=contract_interface['abi'],
-        bytecode=contract_interface['bin'],
+    """Deploy a token contract."""
+    deployed_contracts = {}
+    deployed_contracts[token_type] = deployer.deploy(
+        token_type,
+        [token_supply, token_decimals, token_name, token_symbol],
     )
 
-    log.info(f'Deploying {contract_name}')
-    # Get transaction hash from deployed contract
-    txhash = contract.deploy(transaction=transaction, args=args)
+    token_address = deployed_contracts[token_type]
+    assert token_address and is_address(token_address)
+    token_address = to_checksum_address(token_address)
+    return {token_type: token_address}
 
-    # Get tx receipt to get contract address
-    log.debug(f"TxHash: {txhash}")
-    receipt = check_succesful_tx(web3, txhash, txn_wait)
-    log.info(
-        '{0} address: {1}. Gas used: {2}'.format(
-            contract_name,
-            receipt['contractAddress'],
+
+def register_token_network(
+    web3: Web3,
+    private_key: str,
+    token_registry_abi: Dict,
+    token_registry_address: str,
+    token_address: str,
+    wait=10,
+    gas_limit=4000000,
+):
+    """Register token with a TokenNetworkRegistry contract."""
+    token_network_registry = web3.eth.contract(
+        abi=token_registry_abi,
+        address=token_registry_address,
+    )
+    token_network_registry = PrivateContract(token_network_registry)
+    txhash = token_network_registry.functions.createERC20TokenNetwork(
+        token_address,
+    ).transact(
+        {'gas_limit': gas_limit},
+        private_key=private_key,
+    )
+    log.debug(
+        "calling createERC20TokenNetwork(%s) txHash=%s" %
+        (
+            token_address,
+            encode_hex(txhash),
+        ),
+    )
+    receipt = check_succesful_tx(web3, txhash, wait)
+
+    print(
+        'TokenNetwork address: {0} Gas used: {1}'.format(
+            token_network_registry.functions.token_to_token_networks(token_address).call(),
             receipt['gasUsed'],
         ),
     )
-    return receipt['contractAddress']
 
 
 if __name__ == '__main__':

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -1,0 +1,47 @@
+import pytest
+from eth_utils import ValidationError
+
+from raiden_contracts.constants import (
+    CONTRACT_ENDPOINT_REGISTRY,
+    CONTRACT_SECRET_REGISTRY,
+    CONTRACT_TOKEN_NETWORK_REGISTRY,
+)
+from raiden_contracts.deploy.__main__ import ContractDeployer, deploy_raiden_contracts
+
+
+def test_deploy_script(
+    web3,
+    contracts_manager,
+    utils_contract,
+    faucet_private_key,
+    faucet_address,
+    get_random_privkey,
+):
+    # normal deployment
+    gas_limit = 5900000
+    deployer = ContractDeployer(
+        web3=web3,
+        private_key=faucet_private_key,
+        gas_limit=gas_limit,
+        gas_price=1,
+        wait=10,
+    )
+    res = deploy_raiden_contracts(
+        deployer,
+    )
+    assert CONTRACT_ENDPOINT_REGISTRY in res
+    assert CONTRACT_TOKEN_NETWORK_REGISTRY in res
+    assert CONTRACT_SECRET_REGISTRY in res
+
+    # check that it fails if sender has no eth
+    deployer = ContractDeployer(
+        web3=web3,
+        private_key=get_random_privkey(),
+        gas_limit=gas_limit,
+        gas_price=1,
+        wait=10,
+    )
+    with pytest.raises(ValidationError):
+        deploy_raiden_contracts(
+            deployer,
+        )

--- a/raiden_contracts/utils/utils.py
+++ b/raiden_contracts/utils/utils.py
@@ -19,6 +19,7 @@ def check_succesful_tx(web3: Web3, txid: str, timeout=180) -> dict:
     '''
     receipt = wait_for_transaction_receipt(web3, txid, timeout=timeout)
     txinfo = web3.eth.getTransaction(txid)
+    assert receipt['status'] != 0
     assert txinfo['gas'] != receipt['gasUsed']
     return receipt
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-eth-tester[py-evm]==0.1.0-beta.28,<1.0
+eth-tester[py-evm]==0.1.0-beta.32,<1.0
 pytest
 flake8
 flake8-commas>=2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,12 @@ omit =
     */.pyenv/*
     */tests/*
     */site-packages/*
+
+[isort]
+line_length=99
+known_future_library=future
+multi_line_output=3
+known_first_party=raiden,raiden_contracts,raiden_libs
+include_trailing_comma=1
+default_section=THIRDPARTY
+combine_as_imports=1


### PR DESCRIPTION
- unlocked account on the ethereum node is no longer required
- script now uses user-supplied privkey
- better deployment options (raiden contracts/token/token registration)
- test for the functions used by the scripts

Fixes #259