### PR TITLE
Add a test for the token network limit

### DIFF
--- a/raiden_contracts/tests/test_contract_limits.py
+++ b/raiden_contracts/tests/test_contract_limits.py
@@ -91,3 +91,97 @@ def test_participant_deposit_limit(
         MAX_ETH_CHANNEL_PARTICIPANT,
         A,
     ).transact({'from': B})
+
+
+@pytest.mark.skip(reason='Only for local testing, otherwise it takes too much time to run.')
+def test_network_deposit_limit(
+        web3,
+        create_account,
+        custom_token,
+        token_network,
+        create_channel,
+        assign_tokens,
+):
+    last_deposit = 100
+
+    # ! Only for testing, otherwise we need 1300+ channels and test needs a lot of time to complete
+    # ! The token_network_deposit_limit also needs to be changed for this to work
+    MAX_ETH_TOKEN_NETWORK_TESTING = int(1 * 10**18)
+
+    def remaining():
+        return MAX_ETH_TOKEN_NETWORK_TESTING - custom_token.functions.balanceOf(
+            token_network.address,
+        ).call() - last_deposit
+
+    def send_remaining(channel_identifier, participant1, participant2):
+        remaining_to_reach_limit = remaining()
+        assign_tokens(participant1, remaining_to_reach_limit)
+        token_network.functions.setTotalDeposit(
+            channel_identifier,
+            participant1,
+            remaining_to_reach_limit,
+            participant2,
+        ).transact({'from': participant1})
+
+    remaining_to_reach_limit = remaining()
+    while remaining_to_reach_limit > 0:
+        A = create_account()
+        B = create_account()
+        assign_tokens(A, MAX_ETH_CHANNEL_PARTICIPANT)
+        assign_tokens(B, MAX_ETH_CHANNEL_PARTICIPANT)
+        channel_identifier = create_channel(A, B)[0]
+
+        try:
+            token_network.functions.setTotalDeposit(
+                channel_identifier,
+                A,
+                MAX_ETH_CHANNEL_PARTICIPANT,
+                B,
+            ).transact({'from': A})
+        except TransactionFailed:
+            send_remaining(channel_identifier, A, B)
+            break
+
+        try:
+            token_network.functions.setTotalDeposit(
+                channel_identifier,
+                B,
+                MAX_ETH_CHANNEL_PARTICIPANT,
+                A,
+            ).transact({'from': B})
+        except TransactionFailed:
+            send_remaining(channel_identifier, B, A)
+            break
+
+        remaining_to_reach_limit = remaining()
+
+    assert MAX_ETH_TOKEN_NETWORK_TESTING - custom_token.functions.balanceOf(
+        token_network.address,
+    ).call() == last_deposit
+
+    A = create_account()
+    B = create_account()
+    assign_tokens(A, last_deposit + 10)
+    channel_identifier = create_channel(A, B)[0]
+
+    token_network.functions.setTotalDeposit(
+        channel_identifier,
+        A,
+        last_deposit,
+        B,
+    ).transact({'from': A})
+
+    # After token network limit is reached, we cannot deposit anymore tokens in existent channels
+    with pytest.raises(TransactionFailed):
+        token_network.functions.setTotalDeposit(
+            channel_identifier,
+            A,
+            1,
+            B,
+        ).transact({'from': A})
+
+    # After token network limit is reached, we cannot open new channels
+    C = create_account()
+    D = create_account()
+    with pytest.raises(TransactionFailed):
+        create_channel(C, D)


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden-contracts/issues/281

- test that users cannot deposit anymore tokens or create new channels after the token network limit is reached
- skipped because it takes >4h to run with the hardcoded values; it can be run faster locally by lowering the `token_network_deposit_limit`.

This can be more easily tested if the limits were not hardcoded, but I DO NOT advise for not hardcoding the limits, which would mean passing them as constructor arguments for the `TokenNetworkRegistry` contract.