### PR TITLE
Uncomment balance proof value in tests, fix test

### DIFF
--- a/raiden_contracts/tests/fixtures/channel_test_values.py
+++ b/raiden_contracts/tests/fixtures/channel_test_values.py
@@ -101,13 +101,13 @@ channel_settle_test_values = [
             # participant2 provides an old participant1 balance proof, with a higher
             # unclaimable locked amount can happen if expired transfers are removed
             # from the merkle tree
-            # ChannelValues(
-            #     deposit=35,
-            #     withdrawn=5,
-            #     transferred=20020,
-            #     claimable_locked=3,
-            #     unclaimable_locked=12,
-            # ),
+            ChannelValues(
+                deposit=35,
+                withdrawn=5,
+                transferred=20020,
+                claimable_locked=3,
+                unclaimable_locked=12,
+            ),
             # participant2 provides an old participant1 balance proof with a higher
             # claimable locked amount, but lower transferred + claimable_locked
             # A higher claimable locked amount can happen even if the locked tokens are

--- a/raiden_contracts/tests/test_channel_settle_unlock_state.py
+++ b/raiden_contracts/tests/test_channel_settle_unlock_state.py
@@ -338,28 +338,34 @@ def test_channel_settle_old_balance_proof_values(
         if 'old_last' in channel_test_values and 'last_old' in channel_test_values:
             for vals_A in channel_test_values['old_last'][:5]:
                 for vals_B in channel_test_values['last_old'][:5]:
-                    test_settlement_outcome(
-                        (A, B),
-                        (vals_A, vals_B, 'invalid'),
-                        expected_settlement0,
-                        expected_settlement_onchain0,
-                        expected_final_balance_A0,
-                        expected_final_balance_B0,
-                    )
+                    # We only need to test for cases  where the we have the same argument ordering
+                    # for settleChannel, keeping the order of balance calculations
+                    if vals_B.transferred + vals_B.locked >= vals_A.transferred + vals_A.locked:
+                        test_settlement_outcome(
+                            (A, B),
+                            (vals_A, vals_B, 'invalid'),
+                            expected_settlement0,
+                            expected_settlement_onchain0,
+                            expected_final_balance_A0,
+                            expected_final_balance_B0,
+                        )
 
     else:
 
         if 'old_last' in channel_test_values and 'last_old' in channel_test_values:
             for vals_A in channel_test_values['old_last'][5:]:
                 for vals_B in channel_test_values['last_old'][5:]:
-                    test_settlement_outcome(
-                        (A, B),
-                        (vals_A, vals_B, 'invalid'),
-                        expected_settlement0,
-                        expected_settlement_onchain0,
-                        expected_final_balance_A0,
-                        expected_final_balance_B0,
-                    )
+                    # We only need to test for cases  where the we have the same argument ordering
+                    # for settleChannel, keeping the order of balance calculations
+                    if vals_B.transferred + vals_B.locked >= vals_A.transferred + vals_A.locked:
+                        test_settlement_outcome(
+                            (A, B),
+                            (vals_A, vals_B, 'invalid'),
+                            expected_settlement0,
+                            expected_settlement_onchain0,
+                            expected_final_balance_A0,
+                            expected_final_balance_B0,
+                        )
 
 
 @pytest.mark.parametrize('channel_test_values', channel_settle_invalid_test_values)


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden-contracts/issues/271

`test_channel_settle_unlock_state.py::test_channel_settle_old_balance_proof_values[custom_token_params0-both_old_2-channel_test_values0]`
The tests were failing for the following balance proof:
```
            ChannelValues(
                deposit=35,
                withdrawn=5,
                transferred=20020,
                claimable_locked=3,
                unclaimable_locked=12,
            ),
```

 when it was used in combination with
```
            ChannelValues(
                deposit=40,
                withdrawn=10,
                transferred=19990,
                claimable_locked=40,
                unclaimable_locked=2,
            ),
```

to test what happens when both balance proofs were old. The reason was that `settleChannel` enforces an ordering of arguments based on `vals_B.transferred + vals_B.locked >= vals_A.transferred + vals_A.locked`.
This particular case does not need to be tested, because here we only write edge cases for one particular ordering of balance calculations.

Also, the edge case of having 2 old balance proofs, one of them with a bigger `unclaimable_locked` amount is covered by:
```
            # participant2 provides an old participant1 balance proof with a higher
            # unclaimable locked amount and a higher claimable locked amount but lower
            # transferred + claimable_locked
            ChannelValues(
                deposit=35,
                withdrawn=5,
                transferred=10020,
                claimable_locked=17,
                unclaimable_locked=10,
            ),
```