### PR TITLE
Added nonce=0 closeChannel test, clarified state test for closeChannel

### DIFF
--- a/raiden_contracts/tests/test_channel_close.py
+++ b/raiden_contracts/tests/test_channel_close.py
@@ -209,6 +209,18 @@ def test_close_nonce_zero(
         vals_B.locksroot,
     )
 
+    (
+        _, _,
+        B_is_the_closer,
+        B_balance_hash,
+        B_nonce,
+        _,
+        _,
+    ) = token_network.functions.getChannelParticipantInfo(channel_identifier, B, A).call()
+    assert B_is_the_closer is False
+    assert B_balance_hash == EMPTY_BALANCE_HASH
+    assert B_nonce == 0
+
     token_network.functions.closeChannel(
         channel_identifier,
         B,


### PR DESCRIPTION
- added `closeChannel` test, to check that if `nonce = 0`, then no balance data is stored in the `TokenNetwork` contract
- cleaned up `test_close_channel_state` test for `closeChannel` and added ETH & token balance checks