### PR TITLE
More tests merkle tree

### DIFF
--- a/raiden_contracts/tests/fixtures/config.py
+++ b/raiden_contracts/tests/fixtures/config.py
@@ -1,3 +1,6 @@
+from enum import IntEnum
+
+
 raiden_contracts_version = '0.3.0'
 MAX_UINT256 = 2 ** 256 - 1
 MAX_UINT192 = 2 ** 192 - 1
@@ -9,6 +12,13 @@ EMPTY_ADDITIONAL_HASH = b'\x00' * 32
 EMPTY_LOCKSROOT = b'\x00' * 32
 EMPTY_SIGNATURE = b'\x00' * 65
 passphrase = '0'
+
+
+class TestLockIndex(IntEnum):
+    EXPIRATION = 0
+    AMOUNT = 1
+    SECRETHASH = 2
+    SECRET = 3
 
 
 def fake_hex(size, fill='00'):

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -14,7 +14,7 @@ from raiden_contracts.utils.utils import (
 )
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN
 from raiden_contracts.tests.utils import ChannelValues
-from raiden_contracts.tests.fixtures.config import fake_bytes
+from raiden_contracts.tests.fixtures.config import fake_bytes, TestLockIndex
 from raiden_contracts.tests.fixtures.channel import call_settle
 from raiden_contracts.constants import ParticipantInfoIndex
 from raiden_contracts.tests.fixtures.config import EMPTY_LOCKSROOT
@@ -39,10 +39,10 @@ def test_merkle_root_1_item_unlockable(
     pending_transfers_tree = get_pending_transfers_tree(web3, [6])
 
     secret_registry_contract.functions.registerSecret(
-        pending_transfers_tree.unlockable[0][3],
+        pending_transfers_tree.unlockable[0][TestLockIndex.SECRET],
     ).transact({'from': A})
     assert secret_registry_contract.functions.getSecretRevealBlockHeight(
-        pending_transfers_tree.unlockable[0][2],
+        pending_transfers_tree.unlockable[0][TestLockIndex.SECRETHASH],
     ).call() == web3.eth.blockNumber
 
     (
@@ -68,10 +68,10 @@ def test_merkle_tree_length_fail(
     pending_transfers_tree = get_pending_transfers_tree(web3, [2, 3, 6], [5])
 
     secret_registry_contract.functions.registerSecret(
-        pending_transfers_tree.unlockable[0][3],
+        pending_transfers_tree.unlockable[0][TestLockIndex.SECRET],
     ).transact({'from': A})
     assert secret_registry_contract.functions.getSecretRevealBlockHeight(
-        pending_transfers_tree.unlockable[0][2],
+        pending_transfers_tree.unlockable[0][TestLockIndex.SECRETHASH],
     ).call() == web3.eth.blockNumber
 
     packed = pending_transfers_tree.packed_transfers

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -91,7 +91,7 @@ def test_merkle_tree_length_fail(
     network_utils.functions.getMerkleRootAndUnlockedAmountPublic(packed[0:-96]).call()
 
 
-def test_merkle_root(
+def test_merkle_root_odd_even_components(
         web3,
         get_accounts,
         token_network_test_utils,
@@ -99,8 +99,24 @@ def test_merkle_root(
         reveal_secrets,
 ):
     (A, B) = get_accounts(2)
-    pending_transfers_tree = get_pending_transfers_tree(web3, [1, 3, 5], [2, 8, 3])
 
+    # Even number of merkle tree components
+    pending_transfers_tree = get_pending_transfers_tree(web3, [1, 3, 5], [2, 8, 3])
+    reveal_secrets(A, pending_transfers_tree.unlockable)
+
+    (
+        locksroot,
+        unlocked_amount,
+    ) = token_network_test_utils.functions.getMerkleRootAndUnlockedAmountPublic(
+        pending_transfers_tree.packed_transfers,
+    ).call()
+    merkle_root = pending_transfers_tree.merkle_root
+
+    assert locksroot == merkle_root
+    assert unlocked_amount == 9
+
+    # Odd number of merkle tree components
+    pending_transfers_tree = get_pending_transfers_tree(web3, [1, 3, 5], [2, 8])
     reveal_secrets(A, pending_transfers_tree.unlockable)
 
     (

--- a/raiden_contracts/utils/utils.py
+++ b/raiden_contracts/utils/utils.py
@@ -78,6 +78,7 @@ def get_pending_transfers_tree(
             hashed_pending_transfers,
             pending_transfers,
         )))
+        pending_transfers = list(pending_transfers)
         packed_transfers = get_packed_transfers(pending_transfers, types)
 
     merkle_tree = compute_merkle_tree(hashed_pending_transfers)


### PR DESCRIPTION
To be merged after https://github.com/raiden-network/raiden-contracts/pull/289

Add tests for `getMerkleRootAndUnlockedAmount`
- check merkle tree components length
- check odd & even number of merkle tree components
- check wrong order of lockhashes - compare resulted merkle roots when the order of lockhashes is changed.

Add test for `getLockDataFromMerkleTree`