### PR TITLE
Remove MonitoringService and RaidenServiceBundle from bumpversion

### DIFF
--- a/.bumpversion_contracts.cfg
+++ b/.bumpversion_contracts.cfg
@@ -7,14 +7,6 @@ tag = False
 parse = contract_version = "(?P<major>\d+)\.(?P<minor>\d+)\._";
 serialize = contract_version = "{major}.{minor}._";
 
-[bumpversion:file:raiden_contracts/contracts/MonitoringService.sol]
-parse = contract_version = "(?P<major>\d+)\.(?P<minor>\d+)\._";
-serialize = contract_version = "{major}.{minor}._";
-
-[bumpversion:file:raiden_contracts/contracts/RaidenServiceBundle.sol]
-parse = contract_version = "(?P<major>\d+)\.(?P<minor>\d+)\._";
-serialize = contract_version = "{major}.{minor}._";
-
 [bumpversion:file:raiden_contracts/contracts/SecretRegistry.sol]
 parse = contract_version = "(?P<major>\d+)\.(?P<minor>\d+)\._";
 serialize = contract_version = "{major}.{minor}._";


### PR DESCRIPTION
They are temporarily removed from the contracts releases, due the development being delayed to another milestone.