### PR TITLE
Update raiden-libs dev dependency to use pypi release

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,6 @@ flake8
 flake8-commas>=2.0.0
 flake8-tuple>=0.2.13
 flake8-bugbear>=18.2.0
-git+https://github.com/raiden-network/raiden-libs.git
+raiden-libs>=0.1.6
 bump2version
 hypothesis==3.44.14


### PR DESCRIPTION
Use the pip `raiden-libs` release instead of installing from git.
We need `raiden-libs>=0.1.6` because previous versions cause errors in the deploy script.