### PR TITLE
Pin to py-evm==0.2.0a26

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 eth-tester[py-evm]==0.1.0-beta.32,<1.0
+py-evm==0.2.0a26
 pytest
 flake8
 flake8-commas>=2.0.0


### PR DESCRIPTION
`py-evm>0.2.0a26` have dependencies on incompatible `eth-utils` and `eth-typing` versions.