### PR TITLE
Share common options through subcommand decorator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,12 +117,12 @@ Check deployment options::
 
 Deploying the main Raiden Network contracts with the ``raiden`` command::
 
-    python -m raiden_contracts.deploy --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --gas-limit 6000000 raiden
+    python -m raiden_contracts.deploy raiden --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --gas-limit 6000000
 
 Deploying a token for testing purposes (please DO NOT use this for production purposes) with the ``token`` command::
 
-    python -m raiden_contracts.deploy --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 token --token-supply 10000000 --token-name TestToken --token-decimals 18 --token-symbol TTT
+    python -m raiden_contracts.deploy token --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --token-supply 10000000 --token-name TestToken --token-decimals 18 --token-symbol TTT
 
 Registering a token with the ``TokenNetworkRegistry`` contract, so it can be used by the Raiden Network, with the ``register`` command::
 
-    python -m raiden_contracts.deploy --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 register --token-address TOKEN_TO_BE_REGISTERED_ADDRESS --registry-address TOKEN_NETWORK_REGISTRY_ADDRESS
+    python -m raiden_contracts.deploy register --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --token-address TOKEN_TO_BE_REGISTERED_ADDRESS --registry-address TOKEN_NETWORK_REGISTRY_ADDRESS

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -121,7 +121,7 @@ def common_options(func):
     )
     @click.option(
         '--gas-price',
-        default=0,
+        default=5,
         type=int,
         help='Gas price to use in gwei',
     )

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -1,6 +1,7 @@
 """
 A simple Python script to deploy compiled contracts.
 """
+import functools
 import json
 import logging
 from logging import getLogger
@@ -20,9 +21,9 @@ from raiden_contracts.constants import (
     DEPLOY_SETTLE_TIMEOUT_MIN,
 )
 from raiden_contracts.contract_manager import (
-    ContractManager,
-    CONTRACTS_SOURCE_DIRS,
     CONTRACTS_PRECOMPILED_PATH,
+    CONTRACTS_SOURCE_DIRS,
+    ContractManager,
 )
 from raiden_contracts.utils.utils import check_succesful_tx
 from raiden_libs.private_contract import PrivateContract
@@ -100,9 +101,6 @@ class ContractDeployer:
             ),
         )
         return receipt['contractAddress']
-
-
-import functools
 
 
 def common_options(func):

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -102,42 +102,56 @@ class ContractDeployer:
         return receipt['contractAddress']
 
 
-@click.group(chain=True)
-@click.option(
-    '--rpc-provider',
-    default='http://127.0.0.1:8545',
-    help='Address of the Ethereum RPC provider',
-)
-@click.option(
-    '--private-key',
-    required=True,
-    help='Path to a private key store',
-)
-@click.option(
-    '--wait',
-    default=300,
-    help='Max tx wait time in s.',
-)
-@click.option(
-    '--gas-price',
-    default=5,
-    type=int,
-    help='Gas price to use in gwei',
-)
-@click.option(
-    '--gas-limit',
-    default=5_500_000,
-)
-@click.pass_context
-def main(
+import functools
+
+
+def common_options(func):
+    @click.option(
+        '--private-key',
+        required=True,
+        expose_value=False,
+        help='Path to a private key store.',
+    )
+    @click.option(
+        '--rpc-provider',
+        default='http://127.0.0.1:8545',
+        help='Address of the Ethereum RPC provider',
+    )
+    @click.option(
+        '--wait',
+        default=300,
+        help='Max tx wait time in s.',
+    )
+    @click.option(
+        '--gas-price',
+        default=0,
+        type=int,
+        help='Gas price to use in gwei',
+    )
+    @click.option(
+        '--gas-limit',
+        default=5_500_000,
+    )
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
+
+
+def setup_ctx(
     ctx,
-    rpc_provider,
     private_key,
+    rpc_provider,
     wait,
     gas_price,
     gas_limit,
 ):
+    """Set up deployment context according to common options (shared among all
+    subcommands).
+    """
 
+    if private_key is None:
+        return
     logging.basicConfig(level=logging.DEBUG)
     logging.getLogger('web3').setLevel(logging.INFO)
     logging.getLogger('urllib3').setLevel(logging.INFO)
@@ -145,7 +159,6 @@ def main(
     web3 = Web3(HTTPProvider(rpc_provider, request_kwargs={'timeout': 60}))
     web3.middleware_stack.inject(geth_poa_middleware, layer=0)
     print('Web3 provider is', web3.providers[0])
-
     private_key = get_private_key(private_key)
     assert private_key is not None
     owner = private_key_to_address(private_key)
@@ -164,9 +177,23 @@ def main(
     ctx.obj['wait'] = wait
 
 
+@click.group(chain=True)
+def main():
+    pass
+
+
 @main.command()
+@common_options
 @click.pass_context
-def raiden(ctx):
+def raiden(
+    ctx,
+    private_key,
+    rpc_provider,
+    wait,
+    gas_price,
+    gas_limit,
+):
+    setup_ctx(ctx, private_key, rpc_provider, wait, gas_price, gas_limit)
     deployed_contracts = deploy_raiden_contracts(
         ctx.obj['deployer'],
     )
@@ -175,6 +202,7 @@ def raiden(ctx):
 
 
 @main.command()
+@common_options
 @click.option(
     '--token-supply',
     default=10000000,
@@ -198,11 +226,17 @@ def raiden(ctx):
 @click.pass_context
 def token(
     ctx,
+    private_key,
+    rpc_provider,
+    wait,
+    gas_price,
+    gas_limit,
     token_supply,
     token_name,
     token_decimals,
     token_symbol,
 ):
+    setup_ctx(ctx, private_key, rpc_provider, wait, gas_price, gas_limit)
     deployer = ctx.obj['deployer']
     token_supply *= 10 ** token_decimals
     deployed_token = deploy_token_contract(
@@ -218,7 +252,7 @@ def token(
 
 
 @main.command()
-@click.pass_context
+@common_options
 @click.option(
     '--token-address',
     default=None,
@@ -231,11 +265,18 @@ def token(
     callback=validate_address,
     help='Address of token network registry',
 )
+@click.pass_context
 def register(
     ctx,
+    private_key,
+    rpc_provider,
+    wait,
+    gas_price,
+    gas_limit,
     token_address,
     registry_address,
 ):
+    setup_ctx(ctx, private_key, rpc_provider, wait, gas_price, gas_limit)
     token_type = ctx.obj['token_type']
     deployer = ctx.obj['deployer']
     if token_address:

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -107,7 +107,6 @@ def common_options(func):
     @click.option(
         '--private-key',
         required=True,
-        expose_value=False,
         help='Path to a private key store.',
     )
     @click.option(


### PR DESCRIPTION
Previously the common options where given for the base command `main`,
which destroyed the `--help` on subcommands (see
https://github.com/pallets/click/issues/295 ).

This solves it by moving all common options into a new decorator and
factoring the previous main commands logic into a setup function.

Now the common structure is `deploy CMD OPTIONS` instead of the previous
`deploy COMMON_OPTIONS CMD CMD_OPTIONS`.