### PR TITLE
Fix deployment test & restrict release files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,11 @@
 include requirements.txt
-recursive-include raiden_contracts/data/ *
-recursive-include raiden_contracts/data_pre_limits/ *
+include raiden_contracts/data/contracts.json
+include raiden_contracts/data/deployment_kovan.json
+include raiden_contracts/data/deployment_rinkeby.json
+include raiden_contracts/data/deployment_ropsten.json
+include raiden_contracts/data_pre_limits/contracts.json
+include raiden_contracts/data_pre_limits/deployment_kovan.json
+include raiden_contracts/data_pre_limits/deployment_rinkeby.json
+include raiden_contracts/data_pre_limits/deployment_ropsten.json
 recursive-include raiden_contracts/contracts/ *
 recursive-include raiden_contracts/contracts/test *

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -192,13 +192,20 @@ def contracts_source_path():
     }
 
 
+def contracts_data_path(version: Optional[str] = None):
+    if version is None or version == CONTRACTS_VERSION:
+        return _BASE.joinpath('data')
+    else:
+        return _BASE.joinpath(f'data_{version}')
+
+
 def contracts_precompiled_path(version: Optional[str] = None):
-    data_path = _BASE.joinpath('data') if version is None else _BASE.joinpath(f'data_{version}')
+    data_path = contracts_data_path(version)
     return _BASE.joinpath(data_path, 'contracts.json')
 
 
 def contracts_deployed_path(chain_id: int, version: Optional[str] = None):
-    data_path = _BASE.joinpath('data') if version is None else _BASE.joinpath(f'data_{version}')
+    data_path = contracts_data_path(version)
     chain_name = ID_TO_NETWORKNAME[chain_id] if chain_id in ID_TO_NETWORKNAME else 'private_net'
 
     return data_path.joinpath(f'deployment_{chain_name}.json')

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -188,6 +188,11 @@ def main():
 
 @main.command()
 @common_options
+@click.option(
+    '--save-info',
+    default=True,
+    help='Save deployment info to a file.',
+)
 @click.pass_context
 def raiden(
     ctx,
@@ -196,6 +201,7 @@ def raiden(
     wait,
     gas_price,
     gas_limit,
+    save_info,
 ):
     setup_ctx(ctx, private_key, rpc_provider, wait, gas_price, gas_limit)
     deployer = ctx.obj['deployer']
@@ -205,8 +211,15 @@ def raiden(
         for contract_name, info in deployed_contracts_info['contracts'].items()
     }
 
-    store_deployment_info(deployed_contracts_info)
-    verify_deployed_contracts(deployer.web3, deployer.contract_manager)
+    if save_info is True:
+        store_deployment_info(deployed_contracts_info)
+        verify_deployed_contracts(deployer.web3, deployer.contract_manager)
+    else:
+        verify_deployed_contracts(
+            deployer.web3,
+            deployer.contract_manager,
+            deployed_contracts_info,
+        )
 
     print(json.dumps(deployed_contracts, indent=4))
     ctx.obj['deployed_contracts'].update(deployed_contracts)

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -1,12 +1,18 @@
 import pytest
 from eth_utils import ValidationError
+from copy import deepcopy
 
 from raiden_contracts.constants import (
     CONTRACT_ENDPOINT_REGISTRY,
     CONTRACT_SECRET_REGISTRY,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
 )
-from raiden_contracts.deploy.__main__ import ContractDeployer, deploy_raiden_contracts
+from raiden_contracts.deploy.__main__ import (
+    ContractDeployer,
+    deploy_raiden_contracts,
+    verify_deployed_contracts,
+)
+from raiden_contracts.tests.fixtures.config import EMPTY_ADDRESS
 
 
 def test_deploy_script(
@@ -26,12 +32,86 @@ def test_deploy_script(
         gas_price=1,
         wait=10,
     )
-    res = deploy_raiden_contracts(
-        deployer,
-    )
-    assert CONTRACT_ENDPOINT_REGISTRY in res
-    assert CONTRACT_TOKEN_NETWORK_REGISTRY in res
-    assert CONTRACT_SECRET_REGISTRY in res
+
+    deployed_contracts_info = deploy_raiden_contracts(deployer)
+
+    verify_deployed_contracts(deployer.web3, deployer.contract_manager, deployed_contracts_info)
+
+    deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
+    deployed_contracts_info_fail['contracts_version'] = '0.0.0'
+    with pytest.raises(AssertionError):
+        verify_deployed_contracts(
+            deployer.web3,
+            deployer.contract_manager,
+            deployed_contracts_info_fail,
+        )
+
+    deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
+    deployed_contracts_info_fail['chain_id'] = 0
+    with pytest.raises(AssertionError):
+        verify_deployed_contracts(
+            deployer.web3,
+            deployer.contract_manager,
+            deployed_contracts_info_fail,
+        )
+
+    deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
+    deployed_contracts_info_fail['contracts'][
+        CONTRACT_ENDPOINT_REGISTRY
+    ]['address'] = EMPTY_ADDRESS
+    with pytest.raises(AssertionError):
+        verify_deployed_contracts(
+            deployer.web3,
+            deployer.contract_manager,
+            deployed_contracts_info_fail,
+        )
+
+    deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
+    deployed_contracts_info_fail['contracts'][CONTRACT_SECRET_REGISTRY]['address'] = EMPTY_ADDRESS
+    with pytest.raises(AssertionError):
+        verify_deployed_contracts(
+            deployer.web3,
+            deployer.contract_manager,
+            deployed_contracts_info_fail,
+        )
+
+    deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
+    deployed_contracts_info_fail['contracts'][
+        CONTRACT_TOKEN_NETWORK_REGISTRY
+    ]['address'] = EMPTY_ADDRESS
+    with pytest.raises(AssertionError):
+        verify_deployed_contracts(
+            deployer.web3,
+            deployer.contract_manager,
+            deployed_contracts_info_fail,
+        )
+
+    deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
+    deployed_contracts_info_fail['contracts'][CONTRACT_ENDPOINT_REGISTRY]['block_number'] = 0
+    with pytest.raises(AssertionError):
+        verify_deployed_contracts(
+            deployer.web3,
+            deployer.contract_manager,
+            deployed_contracts_info_fail,
+        )
+
+    deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
+    deployed_contracts_info_fail['contracts'][CONTRACT_SECRET_REGISTRY]['block_number'] = 0
+    with pytest.raises(AssertionError):
+        verify_deployed_contracts(
+            deployer.web3,
+            deployer.contract_manager,
+            deployed_contracts_info_fail,
+        )
+
+    deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
+    deployed_contracts_info_fail['contracts'][CONTRACT_TOKEN_NETWORK_REGISTRY]['block_number'] = 0
+    with pytest.raises(AssertionError):
+        verify_deployed_contracts(
+            deployer.web3,
+            deployer.contract_manager,
+            deployed_contracts_info_fail,
+        )
 
     # check that it fails if sender has no eth
     deployer = ContractDeployer(
@@ -42,6 +122,4 @@ def test_deploy_script(
         wait=10,
     )
     with pytest.raises(ValidationError):
-        deploy_raiden_contracts(
-            deployer,
-        )
+        deploy_raiden_contracts(deployer)


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden-contracts/issues/331

- added deployment info file save & verification as a separate step from the actual deployment
- used the above verification script in the deployment script test & added some more checks
- this removed the fake deployment info file that was created during the test & could be wrongly included in a package release
- restrict what files can go in the release, to avoid cases where we have private network deployment files created in the `data` directory.
- add option to not store deployment info when running the deploy script