### PR TITLE
Remove unused enum NetworkType

### DIFF
--- a/raiden_contracts/constants.py
+++ b/raiden_contracts/constants.py
@@ -106,8 +106,3 @@ NETWORKNAME_TO_ID = {
     name: id
     for id, name in ID_TO_NETWORKNAME.items()
 }
-
-
-class NetworkType(Enum):
-    MAIN = 1
-    TEST = 2


### PR DESCRIPTION
This Enum has been removed from the client and can safely be removed from here too