### PR TITLE
Fix comment about signature parsing

### DIFF
--- a/raiden_contracts/contracts/lib/ECVerify.sol
+++ b/raiden_contracts/contracts/lib/ECVerify.sol
@@ -20,7 +20,7 @@ library ECVerify {
             r := mload(add(signature, 32))
             s := mload(add(signature, 64))
 
-            // Here we are loading the last 32 bytes, including 31 bytes of 's'.
+            // Here we are loading the last 32 bytes, including 31 bytes following the signature.
             v := byte(0, mload(add(signature, 96)))
         }
 


### PR DESCRIPTION
The value `v` from the signature is one byte, but `mload` reads 32 bytes.  The code and the comment disagreed which 32 bytes are taken.

I could change the comment or change the code.  I'm playing safe and changing the comment in this PR.