### PR TITLE
Enable service contracts

### DIFF
--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -189,6 +189,7 @@ def contracts_source_path():
     return {
         'raiden': _BASE.joinpath('contracts'),
         'test': _BASE.joinpath('contracts', 'test'),
+        'services': _BASE.joinpath('contracts', 'services'),
     }
 
 

--- a/raiden_contracts/contracts/services/MonitoringService.sol
+++ b/raiden_contracts/contracts/services/MonitoringService.sol
@@ -4,7 +4,7 @@ import "raiden/Token.sol";
 import "raiden/Utils.sol";
 import "raiden/lib/ECVerify.sol";
 import "raiden/TokenNetwork.sol";
-import "raiden/RaidenServiceBundle.sol";
+import "services/RaidenServiceBundle.sol";
 
 contract MonitoringService is Utils {
     string constant public contract_version = "0.4.0";


### PR DESCRIPTION
These contracts are required to put the monitoring and path finding services to work. Merge https://github.com/raiden-network/raiden-contracts/pull/360 first, to avoid compilation errors.

Does this change make sense as it is? It does make some MS tests run, but it's hard for me to tell if this is the proper way to enable the contracts.

Can something like this be merged to master, or do we need a separate branch for the foreseeable future?