### PR TITLE
Move make_address

### DIFF
--- a/raiden_contracts/tests/utils/__init__.py
+++ b/raiden_contracts/tests/utils/__init__.py
@@ -1,6 +1,5 @@
 # flake8: noqa
 
-from .address import *
 from .contracts import *
 from .utils import *
 from .config import *

--- a/raiden_contracts/tests/utils/address.py
+++ b/raiden_contracts/tests/utils/address.py
@@ -1,6 +1,0 @@
-import random
-import string
-
-
-def make_address():
-    return bytes(''.join(random.choice(string.printable) for _ in range(20)), encoding='utf-8')

--- a/raiden_contracts/tests/utils/config.py
+++ b/raiden_contracts/tests/utils/config.py
@@ -1,3 +1,5 @@
+import random
+import string
 from enum import IntEnum
 
 
@@ -26,3 +28,7 @@ def fake_hex(size, fill='00'):
 
 def fake_bytes(size, fill='00'):
     return bytes.fromhex(fake_hex(size, fill)[2:])
+
+
+def make_address():
+    return bytes(''.join(random.choice(string.printable) for _ in range(20)), encoding='utf-8')


### PR DESCRIPTION
To be merged after https://github.com/raiden-network/raiden-contracts/pull/379

Moving `make_address` to `raiden_contracts/tests/utils/config.py`. Removed `raiden_contracts/tests/utils/address.py`, as it was the only thing that it contained.
