### PR TITLE
Fix bug in deployment that recompiled the contracts

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -73,9 +73,9 @@ class ContractDeployer:
         self.contract_manager = ContractManager(self.precompiled_path)
 
         # Check that the precompiled data is correct
-        self.contract_manager = ContractManager(contracts_source_path())
-        self.contract_manager.checksum_contracts()
-        self.contract_manager.verify_precompiled_checksums(self.precompiled_path)
+        contract_manager_source = ContractManager(contracts_source_path())
+        contract_manager_source.checksum_contracts()
+        contract_manager_source.verify_precompiled_checksums(self.precompiled_path)
 
     def deploy(
         self,


### PR DESCRIPTION
I introduced an overwrite of the `contract_manager` when adding checksum verification, that recompiled the contracts instead of using the precompiled data.

This PR fixes this issue, found in https://github.com/raiden-network/raiden-contracts/issues/397