### PR TITLE
Remainig docstring on tests

### DIFF
--- a/raiden_contracts/tests/test_channel_update_transfer.py
+++ b/raiden_contracts/tests/test_channel_update_transfer.py
@@ -28,6 +28,7 @@ def test_update_call(
         create_balance_proof,
         create_balance_proof_update_signature,
 ):
+    """ Call updateNonClosingBalanceProof() with various wrong arguments """
     (A, B, C) = get_accounts(3)
     channel_identifier = create_channel(A, B)[0]
     channel_deposit(channel_identifier, A, 15, B)
@@ -48,6 +49,7 @@ def test_update_call(
     )
     (balance_hash, nonce, additional_hash, closing_signature) = balance_proof_A
 
+    # Failure with the zero address instead of A's address
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
             channel_identifier,
@@ -56,6 +58,8 @@ def test_update_call(
             *balance_proof_A,
             balance_proof_update_signature_B,
         ).transact({'from': C})
+
+    # Failure with the zero address instead of B's address
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
             channel_identifier,
@@ -64,6 +68,8 @@ def test_update_call(
             *balance_proof_A,
             balance_proof_update_signature_B,
         ).transact({'from': C})
+
+    # Failure with the zero signature
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
             channel_identifier,
@@ -72,6 +78,8 @@ def test_update_call(
             *balance_proof_A,
             EMPTY_SIGNATURE,
         ).transact({'from': C})
+
+    # Failure with the empty balance hash
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
             channel_identifier,
@@ -83,6 +91,8 @@ def test_update_call(
             closing_signature,
             balance_proof_update_signature_B,
         ).transact({'from': C})
+
+    # Failure with nonce zero
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
             channel_identifier,
@@ -94,6 +104,8 @@ def test_update_call(
             closing_signature,
             balance_proof_update_signature_B,
         ).transact({'from': C})
+
+    # Failure with the empty signature
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
             channel_identifier,
@@ -106,6 +118,18 @@ def test_update_call(
             balance_proof_update_signature_B,
         ).transact({'from': C})
 
+    # See a success to make sure the above failures are not spurious
+    token_network.functions.updateNonClosingBalanceProof(
+        channel_identifier,
+        A,
+        B,
+        balance_hash,
+        nonce,
+        additional_hash,
+        closing_signature,
+        balance_proof_update_signature_B,
+    ).transact({'from': C})
+
 
 def test_update_nonexistent_fail(
         get_accounts,
@@ -113,6 +137,7 @@ def test_update_nonexistent_fail(
         create_balance_proof,
         create_balance_proof_update_signature,
 ):
+    """ updateNonClosingBalanceProof() on a not-yet openned channel should fail """
     (A, B, C) = get_accounts(3)
     channel_identifier = 1
 
@@ -148,6 +173,7 @@ def test_update_notclosed_fail(
         create_balance_proof,
         create_balance_proof_update_signature,
 ):
+    """ updateNonClosingBalanceProof() on an Opened channel should fail """
     (A, B, C) = get_accounts(3)
     channel_identifier = create_channel(A, B)[0]
     channel_deposit(channel_identifier, A, 25, B)
@@ -277,6 +303,7 @@ def test_update_wrong_signatures(
         create_balance_proof,
         create_balance_proof_update_signature,
 ):
+    """ updateNonClosingBalanceProof() should fail with wrong signatures """
     (A, B, C) = get_accounts(3)
     channel_identifier = create_channel(A, B)[0]
     channel_deposit(channel_identifier, A, 25, B)
@@ -320,6 +347,15 @@ def test_update_wrong_signatures(
             balance_proof_update_signature_B_fake,
         ).transact({'from': C})
 
+    # See a success to make sure that the above failures are not spurious
+    token_network.functions.updateNonClosingBalanceProof(
+        channel_identifier,
+        A,
+        B,
+        *balance_proof_A,
+        balance_proof_update_signature_B,
+    ).transact({'from': C})
+
 
 def test_update_channel_state(
         web3,
@@ -333,6 +369,7 @@ def test_update_channel_state(
         update_state_tests,
         txn_cost,
 ):
+    """ A successful updateNonClosingBalanceProof() call should not change token/ETH balances """
     (A, B, Delegate) = get_accounts(3)
     settle_timeout = 6
     deposit_A = 20
@@ -398,6 +435,7 @@ def test_update_channel_fail_no_offchain_transfers(
         create_balance_proof,
         create_balance_proof_update_signature,
 ):
+    """ Calls to updateNonClosingBalanceProof() fail with the zero nonce """
     (A, B) = get_accounts(2)
 
     channel_identifier = create_channel(A, B)[0]
@@ -448,7 +486,6 @@ def test_update_not_allowed_after_settlement_period(
         create_balance_proof_update_signature,
         web3,
 ):
-
     """ updateNonClosingBalanceProof cannot be called after the settlement period. """
     (A, B) = get_accounts(2)
     settle_timeout = TEST_SETTLE_TIMEOUT_MIN
@@ -486,7 +523,6 @@ def test_update_not_allowed_for_the_closing_address(
         create_balance_proof,
         create_balance_proof_update_signature,
 ):
-
     """ Closing address cannot call updateNonClosingBalanceProof. """
     (A, B, M) = get_accounts(3)
     settle_timeout = TEST_SETTLE_TIMEOUT_MIN
@@ -550,6 +586,7 @@ def test_update_invalid_balance_proof_arguments(
         create_balance_proof,
         create_balance_proof_update_signature,
 ):
+    """ updateNonClosingBalanceProof() should fail on balance proofs with various wrong params """
     (A, B, C) = get_accounts(3)
     settle_timeout = TEST_SETTLE_TIMEOUT_MIN
     deposit_A = 20
@@ -776,7 +813,7 @@ def test_update_signature_on_invalid_arguments(
         create_balance_proof_update_signature,
 ):
 
-    """ Call updateNonClosingBalanceProof with signature on invalid argument fails. """
+    """ Call updateNonClosingBalanceProof with signature on invalid argument fails """
     (A, B, C) = get_accounts(3)
     settle_timeout = TEST_SETTLE_TIMEOUT_MIN
     deposit_A = 20
@@ -949,6 +986,7 @@ def test_update_replay_reopened_channel(
         create_balance_proof,
         create_balance_proof_update_signature,
 ):
+    """ updateNonClosingBalanceProof() should refuse a balance proof with a stale channel id """
     (A, B) = get_accounts(2)
     nonce_B = 5
     values_A = ChannelValues(
@@ -1075,6 +1113,7 @@ def test_update_channel_event(
         create_balance_proof_update_signature,
         event_handler,
 ):
+    """ Successful updateNonClosingBalanceProof() emit BALANCE_PROOF_UPDATED events """
     ev_handler = event_handler(token_network)
     (A, B) = get_accounts(2)
     deposit_A = 10

--- a/raiden_contracts/tests/test_channel_update_transfer.py
+++ b/raiden_contracts/tests/test_channel_update_transfer.py
@@ -330,6 +330,16 @@ def test_update_wrong_signatures(
         *balance_proof_A,
     )
 
+    # Close the channel so updateNonClosingBalanceProof() is possible
+    token_network.functions.closeChannel(
+        channel_identifier,
+        B,
+        EMPTY_BALANCE_HASH,
+        0,
+        EMPTY_ADDITIONAL_HASH,
+        EMPTY_SIGNATURE,
+    ).transact({'from': A})
+
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
             channel_identifier,

--- a/raiden_contracts/tests/test_channel_withdraw.py
+++ b/raiden_contracts/tests/test_channel_withdraw.py
@@ -24,6 +24,7 @@ def test_withdraw_call(
         get_accounts,
         create_withdraw_signatures,
 ):
+    """ setTotalWithdraw() fails with various wrong arguments """
     (A, B) = get_accounts(2)
     withdraw_A = 3
     channel_identifier = create_channel_and_deposit(A, B, 10, 1)
@@ -35,6 +36,7 @@ def test_withdraw_call(
         withdraw_A,
     )
 
+    # Failure with zero (integer) instead of an address
     with pytest.raises(ValidationError):
         token_network.functions.setTotalWithdraw(
             channel_identifier,
@@ -43,6 +45,8 @@ def test_withdraw_call(
             signature_A_for_A,
             signature_B_for_A,
         ).transact({'from': A})
+
+    # Failure with the empty string instead of an address
     with pytest.raises(ValidationError):
         token_network.functions.setTotalWithdraw(
             channel_identifier,
@@ -51,6 +55,8 @@ def test_withdraw_call(
             signature_A_for_A,
             signature_B_for_A,
         ).transact({'from': A})
+
+    # Failure with a negative number as the total withdrawn amount
     with pytest.raises(ValidationError):
         token_network.functions.setTotalWithdraw(
             channel_identifier,
@@ -59,6 +65,8 @@ def test_withdraw_call(
             signature_A_for_A,
             signature_B_for_A,
         ).transact({'from': A})
+
+    # Failure with an overflown number as the total withdrawn amount
     with pytest.raises(ValidationError):
         token_network.functions.setTotalWithdraw(
             channel_identifier,
@@ -68,6 +76,7 @@ def test_withdraw_call(
             signature_B_for_A,
         ).transact({'from': A})
 
+    # Failure with the zero address insted of a participant's address
     with pytest.raises(TransactionFailed):
         token_network.functions.setTotalWithdraw(
             channel_identifier,
@@ -76,6 +85,8 @@ def test_withdraw_call(
             signature_A_for_A,
             signature_B_for_A,
         ).transact({'from': A})
+
+    # Failure with zero as the total withdrawn amount
     with pytest.raises(TransactionFailed):
         token_network.functions.setTotalWithdraw(
             channel_identifier,
@@ -84,6 +95,8 @@ def test_withdraw_call(
             signature_A_for_A,
             signature_B_for_A,
         ).transact({'from': A})
+
+    # Failure with the empty signature instead of A's
     with pytest.raises(TransactionFailed):
         token_network.functions.setTotalWithdraw(
             channel_identifier,
@@ -92,6 +105,8 @@ def test_withdraw_call(
             EMPTY_SIGNATURE,
             signature_B_for_A,
         ).transact({'from': A})
+
+    # Failure with the empty signature instead of B's
     with pytest.raises(TransactionFailed):
         token_network.functions.setTotalWithdraw(
             channel_identifier,
@@ -118,6 +133,7 @@ def test_withdraw_wrong_state(
         get_accounts,
         withdraw_channel,
 ):
+    """ setTotalWithdraw() should fail on a closed or settled channel """
     (A, B) = get_accounts(2)
     withdraw_A = 1
 

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -17,6 +17,7 @@ def test_token_network_registry(
         custom_token,
         print_gas,
 ):
+    """ Abusing pytest to print the deployment gas cost of TokenNetworkRegistry """
     txhash = deploy_tester_contract_txhash(
         CONTRACT_TOKEN_NETWORK_REGISTRY,
         [],
@@ -38,6 +39,7 @@ def test_token_network_deployment(
         secret_registry_contract,
         deploy_tester_contract_txhash,
 ):
+    """ Abusing pytest to print the deployment gas cost of TokenNetwork """
     deprecation_executor = get_accounts(1)[0]
     txhash = deploy_tester_contract_txhash(
         CONTRACT_TOKEN_NETWORK,
@@ -61,6 +63,7 @@ def test_token_network_create(
         token_network_registry_contract,
         contract_deployer_address,
 ):
+    """ Abusing pytest to print gas cost of TokenNetworkRegistry's createERC20TokenNetwork() """
     txn_hash = token_network_registry_contract.functions.createERC20TokenNetwork(
         custom_token.address,
     ).transact({'from': contract_deployer_address})
@@ -69,6 +72,7 @@ def test_token_network_create(
 
 
 def test_secret_registry(secret_registry_contract, print_gas):
+    """ Abusing pytest to print gas cost of SecretRegistry's registerSecret() """
     secret = b'secretsecretsecretsecretsecretse'
     txn_hash = secret_registry_contract.functions.registerSecret(secret).transact()
     print_gas(txn_hash, CONTRACT_SECRET_REGISTRY + '.registerSecret')
@@ -85,6 +89,7 @@ def test_channel_cycle(
         create_balance_proof,
         create_balance_proof_update_signature,
 ):
+    """ Abusing pytest to print gas costs of TokenNetwork's operations """
     (A, B, C, D) = get_accounts(4)
     settle_timeout = 11
 
@@ -192,6 +197,7 @@ def test_channel_cycle(
 
 
 def test_endpointregistry_gas(endpoint_registry_contract, get_accounts, print_gas):
+    """ Abusing pytest to print gas cost of EndpointRegistry's registerEndpoint() """
     (A, B) = get_accounts(2)
     ENDPOINT = '127.0.0.1:38647'
     txn_hash = endpoint_registry_contract.functions.registerEndpoint(ENDPOINT).transact({


### PR DESCRIPTION
This PR adds docstrings to the remaining tests (as pointed out https://github.com/raiden-network/raiden-contracts/issues/357#issuecomment-452009411).