### PR TITLE
Add missing contractAddress attribute

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -101,7 +101,10 @@ class ContractDeployer:
 
         # Get tx receipt to get contract address
         log.debug("Deploying %s txHash=%s" % (contract_name, encode_hex(txhash)))
-        receipt = check_succesful_tx(self.web3, txhash, self.wait)
+        (receipt, tx) = check_succesful_tx(self.web3, txhash, self.wait)
+        if not receipt['contractAddress']:  # happens with Parity
+            receipt = dict(receipt)
+            receipt['contractAddress'] = tx['creates']
         log.info(
             '{0} address: {1}. Gas used: {2}'.format(
                 contract_name,
@@ -463,7 +466,7 @@ def register_token_network(
             encode_hex(txhash),
         ),
     )
-    receipt = check_succesful_tx(web3, txhash, wait)
+    (receipt, _) = check_succesful_tx(web3, txhash, wait)
 
     token_network_address = token_network_registry.functions.token_to_token_networks(
         token_address,

--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -58,7 +58,7 @@ def add_and_register_token(
         txid = token_network_registry_contract.functions.createERC20TokenNetwork(
             token_contract.address,
         ).transact({'from': contract_deployer_address})
-        tx_receipt = check_succesful_tx(web3, txid)
+        (tx_receipt, _) = check_succesful_tx(web3, txid)
         assert len(tx_receipt['logs']) == 1
         event_abi = contracts_manager.get_event_abi(
             CONTRACT_TOKEN_NETWORK_REGISTRY,

--- a/raiden_contracts/utils/transaction.py
+++ b/raiden_contracts/utils/transaction.py
@@ -1,18 +1,20 @@
+from typing import Tuple
+
 from web3 import Web3
 from web3.utils.threads import (
     Timeout,
 )
 
 
-def check_succesful_tx(web3: Web3, txid: str, timeout=180) -> dict:
+def check_succesful_tx(web3: Web3, txid: str, timeout=180) -> Tuple[dict, dict]:
     '''See if transaction went through (Solidity code did not throw).
-    :return: Transaction receipt
+    :return: Transaction receipt and transaction info
     '''
     receipt = wait_for_transaction_receipt(web3, txid, timeout=timeout)
     txinfo = web3.eth.getTransaction(txid)
     assert receipt['status'] != 0
     assert txinfo['gas'] != receipt['gasUsed']
-    return receipt
+    return (receipt, txinfo)
 
 
 def wait_for_transaction_receipt(web3, txid, timeout=180):


### PR DESCRIPTION
When the transaction receipt misses a 'contractAddress' attribute, add it from the transaction info.

This fixes #416.