### PR TITLE
Add github highlighting for .sol

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
This adds nice syntax highlighting for solidity (`*.sol`) to the github web interface :)
See: ethereum/solidity#2681