### PR TITLE
Remove PrivateContract dependency

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -12,9 +12,8 @@ from typing import Any, Dict, Optional
 
 from eth_utils import denoms, encode_hex, is_address, to_checksum_address
 from web3 import HTTPProvider, Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import construct_sign_and_send_raw_middleware, geth_poa_middleware
 
-from raiden_libs.private_contract import PrivateContract
 
 from raiden_contracts.constants import (
     CONTRACT_CUSTOM_TOKEN,
@@ -62,16 +61,18 @@ class ContractDeployer:
         contracts_version: Optional[str]=None,
     ):
         self.web3 = web3
-        self.private_key = private_key
         self.wait = wait
         self.owner = private_key_to_address(private_key)
-        self.transaction = {'from': self.owner, 'gas_limit': gas_limit}
+        self.transaction = {'from': self.owner, 'gas': gas_limit}
         if gas_price != 0:
             self.transaction['gasPrice'] = gas_price * denoms.gwei
 
         self.contracts_version = contracts_version
         self.precompiled_path = contracts_precompiled_path(self.contracts_version)
         self.contract_manager = ContractManager(self.precompiled_path)
+        self.web3.middleware_stack.add(
+            construct_sign_and_send_raw_middleware(private_key),
+        )
 
         # Check that the precompiled data is correct
         contract_manager_source = ContractManager(contracts_source_path())
@@ -94,7 +95,6 @@ class ContractDeployer:
             abi=contract_interface['abi'],
             bytecode=contract_interface['bin'],
         )
-        contract = PrivateContract(contract)
 
         # Get transaction hash from deployed contract
         txhash = self.send_deployment_transaction(contract, args)
@@ -117,7 +117,6 @@ class ContractDeployer:
             try:
                 txhash = contract.constructor(*args).transact(
                     self.transaction,
-                    private_key=self.private_key,
                 )
             except ValueError as ex:
                 if ex.args[0]['code'] == -32015:
@@ -332,7 +331,7 @@ def register(
     abi = deployer.contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK_REGISTRY)
     register_token_network(
         web3=deployer.web3,
-        private_key=deployer.private_key,
+        caller=deployer.owner,
         token_registry_abi=abi,
         token_registry_address=ctx.obj['deployed_contracts'][CONTRACT_TOKEN_NETWORK_REGISTRY],
         token_address=ctx.obj['deployed_contracts'][token_type],
@@ -437,7 +436,7 @@ def deploy_token_contract(
 
 def register_token_network(
     web3: Web3,
-    private_key: str,
+    caller: str,
     token_registry_abi: Dict,
     token_registry_address: str,
     token_address: str,
@@ -449,12 +448,13 @@ def register_token_network(
         abi=token_registry_abi,
         address=token_registry_address,
     )
-    token_network_registry = PrivateContract(token_network_registry)
     txhash = token_network_registry.functions.createERC20TokenNetwork(
         token_address,
     ).transact(
-        {'gas_limit': gas_limit},
-        private_key=private_key,
+        {
+            'from': caller,
+            'gas': gas_limit,
+        },
     )
     log.debug(
         "calling createERC20TokenNetwork(%s) txHash=%s" %
@@ -515,7 +515,6 @@ def verify_deployed_contracts(web3: Web3, contract_manager: ContractManager, dep
         abi=endpoint_registry_abi,
         address=endpoint_registry_address,
     )
-    endpoint_registry = PrivateContract(endpoint_registry)
 
     # Check that the deployed bytecode matches the precompiled data
     blockchain_bytecode = web3.eth.getCode(endpoint_registry_address).hex()
@@ -555,7 +554,6 @@ def verify_deployed_contracts(web3: Web3, contract_manager: ContractManager, dep
         abi=secret_registry_abi,
         address=secret_registry_address,
     )
-    secret_registry = PrivateContract(secret_registry)
 
     # Check that the deployed bytecode matches the precompiled data
     blockchain_bytecode = web3.eth.getCode(secret_registry_address).hex()
@@ -597,7 +595,6 @@ def verify_deployed_contracts(web3: Web3, contract_manager: ContractManager, dep
         abi=token_registry_abi,
         address=token_registry_address,
     )
-    token_network_registry = PrivateContract(token_network_registry)
 
     # Check that the deployed bytecode matches the precompiled data
     blockchain_bytecode = web3.eth.getCode(token_registry_address).hex()

--- a/raiden_contracts/tests/deprecation_switch_testnet.py
+++ b/raiden_contracts/tests/deprecation_switch_testnet.py
@@ -2,8 +2,6 @@ import click
 from logging import getLogger
 from eth_utils import encode_hex
 
-from raiden_libs.private_contract import PrivateContract
-
 from raiden_contracts.utils.transaction import check_succesful_tx
 from raiden_contracts.deploy.__main__ import (
     setup_ctx,
@@ -83,7 +81,6 @@ def deprecation_test(
     assert token_network.functions.safety_deprecation_switch().call() is False
     txhash = token_network.functions.deprecate().transact(
         deployer.transaction,
-        private_key=deployer.private_key,
     )
     log.debug(f'Deprecation txHash={encode_hex(txhash)}')
     check_succesful_tx(deployer.web3, txhash, deployer.wait)
@@ -109,7 +106,6 @@ def deprecation_test_setup(deployer, token_amount):
         abi=token_network_registry_abi,
         address=deployed_contracts[CONTRACT_TOKEN_NETWORK_REGISTRY]['address'],
     )
-    token_network_registry = PrivateContract(token_network_registry)
 
     token_decimals = 18
     multiplier = 10 ** token_decimals
@@ -130,12 +126,10 @@ def deprecation_test_setup(deployer, token_amount):
         abi=token_abi,
         address=token_address,
     )
-    token_contract = PrivateContract(token_contract)
 
     # Mint some tokens for the owner
     txhash = token_contract.functions.mint(token_amount).transact(
         deployer.transaction,
-        private_key=deployer.private_key,
     )
 
     log.debug(f'Minting tokens txHash={encode_hex(txhash)}')
@@ -145,7 +139,7 @@ def deprecation_test_setup(deployer, token_amount):
     abi = deployer.contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK_REGISTRY)
     token_network_address = register_token_network(
         web3=deployer.web3,
-        private_key=deployer.private_key,
+        caller=deployer.owner,
         token_registry_abi=abi,
         token_registry_address=deployed_contracts[CONTRACT_TOKEN_NETWORK_REGISTRY]['address'],
         token_address=token_address,
@@ -157,15 +151,12 @@ def deprecation_test_setup(deployer, token_amount):
         abi=token_network_abi,
         address=token_network_address,
     )
-    token_network = PrivateContract(token_network)
-
     log.info(
         f'Registered the token and created a TokenNetwork contract at {token_network_address}.',
     )
 
     txhash = token_contract.functions.approve(token_network.address, token_amount).transact(
         deployer.transaction,
-        private_key=deployer.private_key,
     )
     log.debug(f'Approving tokens for the TokenNetwork contract txHash={encode_hex(txhash)}')
     check_succesful_tx(deployer.web3, txhash, deployer.wait)
@@ -193,7 +184,6 @@ def open_and_deposit(
     try:
         txhash = token_network.functions.openChannel(A, B, DEPLOY_SETTLE_TIMEOUT_MIN).transact(
             deployer.transaction,
-            private_key=deployer.private_key,
         )
         log.debug(f'Opening a channel between {A} and {B} txHash={encode_hex(txhash)}')
         check_succesful_tx(deployer.web3, txhash, deployer.wait)
@@ -217,7 +207,6 @@ def open_and_deposit(
             B,
         ).transact(
             deployer.transaction,
-            private_key=deployer.private_key,
         )
         log.debug(
             f'Depositing {MAX_ETH_CHANNEL_PARTICIPANT} tokens for {A} in a channel with '
@@ -240,7 +229,6 @@ def open_and_deposit(
             A,
         ).transact(
             deployer.transaction,
-            private_key=deployer.private_key,
         )
         log.debug(
             f'Depositing {MAX_ETH_CHANNEL_PARTICIPANT} tokens for {B} in a channel with '

--- a/raiden_contracts/utils/transaction.py
+++ b/raiden_contracts/utils/transaction.py
@@ -10,8 +10,10 @@ def check_succesful_tx(web3: Web3, txid: str, timeout=180) -> dict:
     '''
     receipt = wait_for_transaction_receipt(web3, txid, timeout=timeout)
     txinfo = web3.eth.getTransaction(txid)
-    assert receipt['status'] != 0
-    assert txinfo['gas'] != receipt['gasUsed']
+    if receipt['status'] == 0:
+        raise ValueError(f"Status 0 indicates failure")
+    if txinfo['gas'] == receipt['gasUsed']:
+        raise ValueError(f"Gas is completely used ({txinfo['gas']}). Failure?")
     return receipt
 
 


### PR DESCRIPTION
Some deployment scripts depended on raiden_libs.private_contract. This commit replaces that library with a web3 middleware `construct_sign_and_send_raw_middleware`.
https://github.com/raiden-network/raiden-contracts/issues/380#issuecomment-451871289

This fixes https://github.com/raiden-network/raiden-contracts/issues/380 .