### PR TITLE
Add service contracts to the deployment process

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,10 @@ Deploying the main Raiden Network contracts with the ``raiden`` command::
 
     python -m raiden_contracts.deploy raiden --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --gas-limit 6000000
 
+Deploying the 3rd party service contracts with the ``services`` command::
+
+    python -m raiden_contracts.deploy services --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --gas-limit 6000000 --token-address TOKEN_USED_TO_PAY_SERVICES
+
 Deploying a token for testing purposes (please DO NOT use this for production purposes) with the ``token`` command::
 
     python -m raiden_contracts.deploy token --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --token-supply 10000000 --token-name TestToken --token-decimals 18 --token-symbol TTT

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -267,15 +267,15 @@ def contracts_precompiled_path(version: Optional[str] = None):
     return data_path.joinpath('contracts.json')
 
 
-def contracts_deployed_path(chain_id: int, version: Optional[str] = None):
+def contracts_deployed_path(chain_id: int, version: Optional[str] = None, services: bool = False):
     data_path = contracts_data_path(version)
     chain_name = ID_TO_NETWORKNAME[chain_id] if chain_id in ID_TO_NETWORKNAME else 'private_net'
 
-    return data_path.joinpath(f'deployment_{chain_name}.json')
+    return data_path.joinpath(f'deployment_{"services_" if services else ""}{chain_name}.json')
 
 
-def get_contracts_deployed(chain_id: int, version: Optional[str] = None):
-    deployment_file_path = contracts_deployed_path(chain_id, version)
+def get_contracts_deployed(chain_id: int, version: Optional[str] = None, services: bool = False):
+    deployment_file_path = contracts_deployed_path(chain_id, version, services)
 
     try:
         with deployment_file_path.open() as deployment_file:

--- a/raiden_contracts/tests/test_token.py
+++ b/raiden_contracts/tests/test_token.py
@@ -74,20 +74,12 @@ def test_token_transfer_funds(web3, custom_token, get_accounts, txn_gas):
 def test_custom_token(custom_token, web3, contracts_manager):
     """ See custom_token.address contains the expected code """
     blockchain_bytecode = web3.eth.getCode(custom_token.address).hex()
-    compiled_bytecode = runtime_hexcode(
-        contracts_manager,
-        CONTRACT_CUSTOM_TOKEN,
-        len(blockchain_bytecode),
-    )
+    compiled_bytecode = runtime_hexcode(contracts_manager, CONTRACT_CUSTOM_TOKEN)
     assert blockchain_bytecode == compiled_bytecode
 
 
 def test_human_standard_token(human_standard_token, web3, contracts_manager):
     """ See human_standard_token.address contains the expected code """
     blockchain_bytecode = web3.eth.getCode(human_standard_token.address).hex()
-    compiled_bytecode = runtime_hexcode(
-        contracts_manager,
-        CONTRACT_HUMAN_STANDARD_TOKEN,
-        len(blockchain_bytecode),
-    )
+    compiled_bytecode = runtime_hexcode(contracts_manager, CONTRACT_HUMAN_STANDARD_TOKEN)
     assert blockchain_bytecode == compiled_bytecode

--- a/raiden_contracts/utils/bytecode.py
+++ b/raiden_contracts/utils/bytecode.py
@@ -1,9 +1,8 @@
-def runtime_hexcode(contracts_manager, name, length):
+def runtime_hexcode(contracts_manager, name):
     """ Calculate the runtime hexcode from the deployment bytecode
 
     Parameters:
         name: name of the contract such as CONTRACT_TOKEN_NETWORK
-        length: the length of the runtime code
     """
     compiled_bytecode = contracts_manager.contracts[name]['bin-runtime']
     compiled_bytecode = hex(int(compiled_bytecode, 16))


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden-contracts/issues/436


- Refactored & simplified post-deployment verification against the chain - moved the common post-deployment checks into `verify_deployed_contract()`:
  - verify that the runtime bytecode is the same: precompiled data against the chain
  - check information stored in `deployment_*.json` against the chain,
except for the constructor arguments, which have to be checked separately.
- Fix token test after `runtime_hexcode` change in number of args
- Add service contracts to deployment process. Deployment info for the service contracts will be under `data/deployment_services_<CHAIN_NAME>.json`. I preferred to save it separate from the core contracts, because:
  - it is additional & optional functionality
  - I did not want to overwrite the core deployment info file when saving the service contracts info
- Changes in package API:
  - `contracts_deployed_path(chain_id: int, version: Optional[str] = None, services: bool = False)` instead of `contracts_deployed_path(chain_id: int, version: Optional[str] = None)`
  - `get_contracts_deployed(chain_id: int, version: Optional[str] = None, services: bool = False)` instead of `get_contracts_deployed(chain_id: int, version: Optional[str] = None)`
