### PR TITLE
The release process has been tested

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,8 +1,6 @@
 Release Process Document
 ========================
 
-**This document has not been tested by someone else than @loredanacirstea.**
-
 Package Deliverables
 ^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
If `v0.9.0` is released properly, we can remove a warning in `RELEASE.rst`.