### PR TITLE
Uncomment checks for deployment files

### DIFF
--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -113,11 +113,10 @@ def test_current_development_version():
         assert source_path.exists()
     assert contracts_precompiled_path().exists()
 
-    # TODO: uncomment after testnet deployment
-    # see https://github.com/raiden-network/raiden-contracts/issues/444)
-    # assert contracts_deployed_path(NETWORKNAME_TO_ID['rinkeby']).exists()
-    # assert contracts_deployed_path(NETWORKNAME_TO_ID['ropsten']).exists()
-    # assert contracts_deployed_path(NETWORKNAME_TO_ID['kovan']).exists()
+    # deployment files exist
+    assert contracts_deployed_path(NETWORKNAME_TO_ID['rinkeby']).exists()
+    assert contracts_deployed_path(NETWORKNAME_TO_ID['ropsten']).exists()
+    assert contracts_deployed_path(NETWORKNAME_TO_ID['kovan']).exists()
 
 
 def test_red_eyes_version():

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -117,6 +117,10 @@ def test_current_development_version():
     assert contracts_deployed_path(NETWORKNAME_TO_ID['rinkeby']).exists()
     assert contracts_deployed_path(NETWORKNAME_TO_ID['ropsten']).exists()
     assert contracts_deployed_path(NETWORKNAME_TO_ID['kovan']).exists()
+    # deployment files for service contracts also exist
+    assert contracts_deployed_path(NETWORKNAME_TO_ID['rinkeby'], None, True).exists()
+    assert contracts_deployed_path(NETWORKNAME_TO_ID['ropsten'], None, True).exists()
+    assert contracts_deployed_path(NETWORKNAME_TO_ID['kovan'], None, True).exists()
 
 
 def test_red_eyes_version():

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -118,9 +118,9 @@ def test_current_development_version():
     assert contracts_deployed_path(NETWORKNAME_TO_ID['ropsten']).exists()
     assert contracts_deployed_path(NETWORKNAME_TO_ID['kovan']).exists()
     # deployment files for service contracts also exist
-    assert contracts_deployed_path(NETWORKNAME_TO_ID['rinkeby'], None, True).exists()
-    assert contracts_deployed_path(NETWORKNAME_TO_ID['ropsten'], None, True).exists()
-    assert contracts_deployed_path(NETWORKNAME_TO_ID['kovan'], None, True).exists()
+    assert contracts_deployed_path(NETWORKNAME_TO_ID['rinkeby'], services=True).exists()
+    assert contracts_deployed_path(NETWORKNAME_TO_ID['ropsten'], services=True).exists()
+    assert contracts_deployed_path(NETWORKNAME_TO_ID['kovan'], services=True).exists()
 
 
 def test_red_eyes_version():


### PR DESCRIPTION
This commit uncomments checks that the deployment files exist for the
test networks.

This fixes https://github.com/raiden-network/raiden-contracts/issues/444