### PR TITLE
More useful verify_deployed_contract() and fewer lines around its usage

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -689,14 +689,11 @@ def verify_deployed_contracts(web3: Web3, contract_manager: ContractManager, dep
         token_network_registry.functions.secret_registry_address().call(),
     ) == secret_registry.address
     assert secret_registry.address == constructor_arguments[0]
-
-    chain_id = token_network_registry.functions.chain_id().call()
-    assert chain_id == constructor_arguments[1]
-
-    settlement_timeout_min = token_network_registry.functions.settlement_timeout_min().call()
-    settlement_timeout_max = token_network_registry.functions.settlement_timeout_max().call()
-    assert settlement_timeout_min == constructor_arguments[2]
-    assert settlement_timeout_max == constructor_arguments[3]
+    assert token_network_registry.functions.chain_id().call() == constructor_arguments[1]
+    assert token_network_registry.functions.settlement_timeout_min().call() == \
+        constructor_arguments[2]
+    assert token_network_registry.functions.settlement_timeout_max().call() == \
+        constructor_arguments[3]
 
     if deployment_file_path is not None:
         print(f'Deployment info from {deployment_file_path} has been verified and it is CORRECT.')


### PR DESCRIPTION
Please review #512 first.

Whenever `verify_deployed_contract()` was called, very similar lines were printed, and `constructor_arguments` were computed.  This PR moves these common lines into the function body of `verify_deployed_contract()`.

I tried the resulting deploy script on Kovan.

This PR is a step in the refactoring of `verify_deployed_contracts()` (#502).  This is a second try after #505.