### PR TITLE
Remove upper version bound of coincurve

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
 rlp>=1.0.0
-coincurve>=8.0.0,<9.0
+coincurve>=8.0.0
 web3>=4.4.1
 py-solc>=3.0.0


### PR DESCRIPTION
Makes it possible to use up-to-date version of `coincurve` in dependent projects.