### PR TITLE
clearer error message when etherscan_verify.py gets an unknown chain_id

### DIFF
--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -43,8 +43,6 @@ def etherscan_verify(chain_id, apikey, guid, contract_name):
     contract_manager = ContractManager(contracts_precompiled_path())
     source_path = contracts_source_path()
 
-    deployment_info = get_contracts_deployed(chain_id)
-
     if chain_id == 3:
         etherscan_api = 'https://api-ropsten.etherscan.io/api'
     elif chain_id == 4:
@@ -53,6 +51,11 @@ def etherscan_verify(chain_id, apikey, guid, contract_name):
         etherscan_api = 'https://api-kovan.etherscan.io/api'
     elif chain_id == 1:
         etherscan_api = 'https://api.etherscan.io/api'
+    else:
+        click.echo(f"Unknown chain_id {chain_id}", err=True)
+        exit(1)
+
+    deployment_info = get_contracts_deployed(chain_id)
 
     if guid:
         guid_status(etherscan_api, guid)


### PR DESCRIPTION
Before this PR, when I gave an unknown chain_id to `etherscan_verify.py`, I got an irrelevant error message:

```
  File "raiden-contracts/raiden_contracts/contract_manager.py", line 284, in get_contracts_deployed
    raise ValueError(f'Cannot load deployment data file: {ex}') from ex                             
ValueError: Cannot load deployment data file: [Errno 2] No such file or directory: 'raiden-contracts/raiden_contracts/data/deployment_private_net.json'
```

After this PR, I get
```
Unknown chain_id 89
```