### PR TITLE
Fix join-contracts.py without --import-map

### DIFF
--- a/raiden_contracts/utils/join-contracts.py
+++ b/raiden_contracts/utils/join-contracts.py
@@ -16,7 +16,7 @@ resolving imports.
 example usage:
 
 $ cd raiden-contracts/raiden_contracts
-$ python ./utils/join-contracts.py --import-map {} ./contracts/TokenNetwork.sol joined.sol
+$ python ./utils/join-contracts.py ./contracts/TokenNetwork.sol joined.sol
 
 """
 
@@ -59,7 +59,11 @@ class ContractJoiner:
 
 
 @click.command()
-@click.option('--import-map', default='', help='JSON mapping {"path-prefix": "/file/system/path"}')
+@click.option(
+    '--import-map',
+    default='{}',
+    help='JSON mapping {"path-prefix": "/file/system/path"}',
+)
 @click.argument('contract', type=File())
 @click.argument('output', type=File('w'))
 def main(contract, output, import_map):


### PR DESCRIPTION
Before this commit, join-contracts.py without --import-map failed with
an error message:
```
  File "utils/join-contracts.py", line 66, in main
    import_map = json.loads(import_map)
  File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

This issue fixes the problem by changing the default value from "" to
"{}".

I know this script is not used anywhere yet, so [skip ci].