### PR TITLE
All Etherscan verification at once

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,19 +184,9 @@ Verification with Etherscan
 
 ::
 
-    python -m raiden_contracts.deploy.etherscan_verify --apikey ETHERSCAN_APIKEY --contract-name EndpointRegistry --chain-id 3
+    python -m raiden_contracts.deploy.etherscan_verify --apikey ETHERSCAN_APIKEY --chain-id 3
 
-    python -m raiden_contracts.deploy.etherscan_verify --apikey ETHERSCAN_APIKEY --contract-name SecretRegistry --chain-id 3
-
-    python -m raiden_contracts.deploy.etherscan_verify --apikey ETHERSCAN_APIKEY --contract-name TokenNetworkRegistry --chain-id 3
-
-    python -m raiden_contracts.deploy.etherscan_verify --apikey ETHERSCAN_APIKEY --contract-name ServiceRegistry --chain-id 3
-
-    python -m raiden_contracts.deploy.etherscan_verify --apikey ETHERSCAN_APIKEY --contract-name MonitoringService --chain-id 3
-
-    python -m raiden_contracts.deploy.etherscan_verify --apikey ETHERSCAN_APIKEY --contract-name OneToN --chain-id 3
-
-    python -m raiden_contracts.deploy.etherscan_verify --apikey ETHERSCAN_APIKEY --contract-name UserDeposit --chain-id 3
+If the command exists with status code 0, Etherscan has verified all contracts against Solidity sources.
 
 
 Making a Release

--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -211,6 +211,14 @@ def etherscan_verify_contract(chain_id: int, apikey: str, source_module: str, co
             print('Retrying...')
             sleep(5)
         raise TimeoutError(manual_submission_guide)
+    else:
+        if content["result"] == "Contract source code already verified":
+            return
+        else:
+            raise ValueError(
+                'Etherscan submission failed for an unknown reason\n' +
+                manual_submission_guide,
+            )
 
 
 def guid_status(etherscan_api: str, guid: str):


### PR DESCRIPTION
This commit
* fixes the exit status code when Etherscan submission fails
* changes README so it instructs just one etherscan_verify execution

@karlb  Here comes the change promised in https://github.com/raiden-network/raiden-contracts/pull/533#discussion_r254709542