### PR TITLE
Test service deploy script

### DIFF
--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -10,9 +10,11 @@ from raiden_contracts.constants import (
 from raiden_contracts.deploy.__main__ import (
     ContractDeployer,
     deploy_raiden_contracts,
+    deploy_service_contracts,
     deploy_token_contract,
     register_token_network,
     verify_deployed_contracts,
+    verify_deployed_service_contracts,
 )
 from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS
 from raiden_contracts.utils.type_aliases import T_Address
@@ -233,3 +235,42 @@ def test_deploy_script_register(
     )
     assert token_network_address is not None
     assert isinstance(token_network_address, T_Address)
+
+
+def test_deploy_script_service(
+        web3,
+        faucet_private_key,
+        get_random_privkey,
+):
+    """ Run deploy_service_contracts() used in the deployment script
+
+    This checks if deploy_service_contracts() works correctly in the happy case.
+    """
+    gas_limit = 5900000
+    deployer = ContractDeployer(
+        web3=web3,
+        private_key=faucet_private_key,
+        gas_limit=gas_limit,
+        gas_price=1,
+        wait=10,
+    )
+
+    token_type = 'CustomToken'
+    deployed_token = deploy_token_contract(
+        deployer,
+        token_supply=10000000,
+        token_decimals=18,
+        token_name='TestToken',
+        token_symbol='TTT',
+        token_type=token_type,
+    )
+    token_address = deployed_token[token_type]
+    assert isinstance(token_address, T_Address)
+
+    deployed_service_contracts = deploy_service_contracts(deployer, token_address)
+    verify_deployed_service_contracts(
+        deployer.web3,
+        deployer.contract_manager,
+        token_address,
+        deployed_service_contracts,
+    )

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -4,8 +4,12 @@ from copy import deepcopy
 
 from raiden_contracts.constants import (
     CONTRACT_ENDPOINT_REGISTRY,
+    CONTRACT_MONITORING_SERVICE,
+    CONTRACT_ONE_TO_N,
     CONTRACT_SECRET_REGISTRY,
+    CONTRACT_SERVICE_REGISTRY,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
+    CONTRACT_USER_DEPOSIT,
 )
 from raiden_contracts.deploy.__main__ import (
     ContractDeployer,
@@ -274,3 +278,34 @@ def test_deploy_script_service(
         token_address,
         deployed_service_contracts,
     )
+
+    deployed_info_fail = deepcopy(deployed_service_contracts)
+    deployed_info_fail['contracts_version'] = '0.0.0'
+    with pytest.raises(AssertionError):
+        verify_deployed_service_contracts(
+            deployer.web3,
+            deployer.contract_manager,
+            token_address=token_address,
+            deployment_data=deployed_info_fail,
+        )
+
+    def test_missing_deployment(contract_name):
+        deployed_info_fail = deepcopy(deployed_service_contracts)
+        deployed_info_fail['contracts'][
+            contract_name
+        ]['address'] = EMPTY_ADDRESS
+        with pytest.raises(AssertionError):
+            verify_deployed_service_contracts(
+                deployer.web3,
+                deployer.contract_manager,
+                token_address=token_address,
+                deployment_data=deployed_info_fail,
+            )
+
+    for contract_name in [
+            CONTRACT_SERVICE_REGISTRY,
+            CONTRACT_MONITORING_SERVICE,
+            CONTRACT_ONE_TO_N,
+            CONTRACT_USER_DEPOSIT,
+    ]:
+        test_missing_deployment(contract_name)


### PR DESCRIPTION
This PR extends `test_deploy_script` to cover the function `deploy_service_contracts()`  This closes #450.