### PR TITLE
Fix bumpversion_contracts.cfg for service contract

### DIFF
--- a/.bumpversion_contracts.cfg
+++ b/.bumpversion_contracts.cfg
@@ -12,7 +12,13 @@ serialize = contract_version = "{major}.{minor}.{patch}";
 [bumpversion:file:raiden_contracts/contracts/services/MonitoringService.sol]
 serialize = contract_version = "{major}.{minor}.{patch}";
 
-[bumpversion:file:raiden_contracts/contracts/services/RaidenServiceBundle.sol]
+[bumpversion:file:raiden_contracts/contracts/services/ServiceRegistry.sol]
+serialize = contract_version = "{major}.{minor}.{patch}";
+
+[bumpversion:file:raiden_contracts/contracts/services/UserDeposit.sol]
+serialize = contract_version = "{major}.{minor}.{patch}";
+
+[bumpversion:file:raiden_contracts/contracts/services/OneToN.sol]
 serialize = contract_version = "{major}.{minor}.{patch}";
 
 [bumpversion:file:raiden_contracts/contracts/SecretRegistry.sol]


### PR DESCRIPTION
This issue fixes the `bumpversion` configuration for service contracts.  See #551 for the problem description.

0.10.0 release is blocked for this PR now.