### PR TITLE
Enable mypy for functions without type declaration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ lint:
 	flake8 raiden_contracts/
 
 mypy:
-	mypy --ignore-missing-imports raiden_contracts
+	mypy --ignore-missing-imports --check-untyped-defs raiden_contracts
 
 clean:
 	rm -rf build/ *egg-info/ dist .eggs

--- a/raiden_contracts/tests/fixtures/contracts.py
+++ b/raiden_contracts/tests/fixtures/contracts.py
@@ -1,14 +1,5 @@
 import pytest
 import logging
-from web3.utils.events import get_event_data
-from eth_utils import is_address
-
-from raiden_contracts.utils.transaction import check_succesful_tx
-from raiden_contracts.constants import (
-    CONTRACT_TOKEN_NETWORK,
-    CONTRACT_TOKEN_NETWORK_REGISTRY,
-    EVENT_TOKEN_NETWORK_CREATED,
-)
 
 log = logging.getLogger(__name__)
 
@@ -99,30 +90,3 @@ def deploy_tester_contract_txhash(
 def utils_contract(deploy_tester_contract):
     """Deployed Utils contract"""
     return deploy_tester_contract('Utils')
-
-
-@pytest.fixture
-def standard_token_network_contract(
-        web3,
-        contracts_manager,
-        token_network_registry_contract,
-        standard_token_contract,
-        contract_deployer_address,
-):
-    """Return instance of a deployed TokenNetwork for HumanStandardToken."""
-    txid = token_network_registry_contract.functions.createERC20TokenNetwork(
-        standard_token_contract.address,
-    ).transact({'from': contract_deployer_address})
-    tx_receipt = check_succesful_tx(web3, txid)
-    assert len(tx_receipt['logs']) == 1
-    event_abi = contracts_manager.get_event_abi(
-        CONTRACT_TOKEN_NETWORK_REGISTRY,
-        EVENT_TOKEN_NETWORK_CREATED,
-    )
-    decoded_event = get_event_data(event_abi, tx_receipt['logs'][0])
-    assert decoded_event is not None
-    assert is_address(decoded_event['args']['token_address'])
-    assert is_address(decoded_event['args']['token_network_address'])
-    token_network_address = decoded_event['args']['token_network_address']
-    token_network_abi = contracts_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK)
-    return web3.eth.contract(abi=token_network_abi, address=token_network_address)

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -29,6 +29,7 @@ def test_verification_overall_checksum():
     manager.checksum_contracts()
     manager.verify_precompiled_checksums(contracts_precompiled_path())
 
+    assert manager.overall_checksum
     original_checksum = manager.overall_checksum
 
     # We change the source code overall checksum
@@ -62,12 +63,13 @@ def test_verification_contracts_checksums():
     manager.checksum_contracts()
     manager.verify_precompiled_checksums(contracts_precompiled_path())
 
+    assert manager.contracts_checksums
     for contract, checksum in manager.contracts_checksums.items():
         manager.contracts_checksums[contract] += '2'
         with pytest.raises(ContractManagerVerificationError):
             manager.verify_precompiled_checksums(contracts_precompiled_path())
 
-        manager.contracts_checksums[contract] = None
+        manager.contracts_checksums[contract] = None  # type: ignore
         with pytest.raises(ContractManagerVerificationError):
             manager.verify_precompiled_checksums(contracts_precompiled_path())
 

--- a/raiden_contracts/utils/join-contracts.py
+++ b/raiden_contracts/utils/join-contracts.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import sys
+from typing import Set
 
 import click
 from click.types import File
@@ -24,7 +25,7 @@ $ python ./utils/join-contracts.py ./contracts/TokenNetwork.sol joined.sol
 class ContractJoiner:
     def __init__(self, import_map=None):
         self.have_pragma = False
-        self.seen = set()
+        self.seen: Set[str] = set()
         self.import_map = import_map if import_map else {}
 
     def join(self, contract_file):
@@ -47,6 +48,7 @@ class ContractJoiner:
                 match = IMPORT_RE.match(stripped_line)
                 if match:
                     next_file = match.groupdict().get('contract')
+                    assert next_file
                     for prefix, path in self.import_map.items():
                         if next_file.startswith(prefix):
                             next_file = next_file.replace(prefix, path)

--- a/raiden_contracts/utils/logs.py
+++ b/raiden_contracts/utils/logs.py
@@ -1,5 +1,7 @@
+from typing import Dict, List
 import functools
 from collections import defaultdict
+
 from web3.utils.events import get_event_data
 from web3.utils.filters import construct_event_filter_params
 from inspect import getframeinfo, stack
@@ -13,10 +15,10 @@ class LogHandler:
         self.web3 = web3
         self.address = address
         self.abi = abi
-        self.event_waiting = {}
-        self.event_filters = {}
-        self.event_count = defaultdict(lambda: defaultdict(lambda: 0))
-        self.event_unknown = []
+        self.event_waiting: Dict[str, dict] = {}
+        self.event_filters: Dict[str, 'LogFilter'] = {}
+        self.event_count: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(lambda: 0))
+        self.event_unknown: List[dict] = []
 
     def add(self, txn_hash, event_name, callback=None, count=1):
         caller = getframeinfo(stack()[1][0])
@@ -40,7 +42,7 @@ class LogHandler:
 
         self.wait(timeout)
 
-    def handle_log(self, event):
+    def handle_log(self, event: dict):
         txn_hash = event['transactionHash']
         event_name = event['event']
 

--- a/raiden_contracts/utils/private_key.py
+++ b/raiden_contracts/utils/private_key.py
@@ -60,7 +60,7 @@ def get_private_key(key_path, password_path=None):
                 else:
                     password = getpass.getpass("Enter the private key password: ")
                 if json_data["crypto"]["kdf"] == "pbkdf2":
-                    password = password.encode()
+                    password = password.encode()  # type: ignore
                 private_key = encode_hex(decode_keyfile_json(json_data, password))
             except ValueError:
                 log.fatal("Invalid private key format or password!")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,4 @@ flake8-bugbear>=18.2.0
 bump2version
 hypothesis==3.44.14
 requests
-mypy==0.641
+mypy==0.670


### PR DESCRIPTION
Mypy will just assume `Any` for all types, but that still allows to
catch errors because types will be inferred from signatures in other
places.