### PR TITLE
Make sure that once a contract version works, it works forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Documents changes that result in:
 
 - Add data/gas.json that contains gas measurements on the development version.
 - Move Raiden contracts to "raiden" subdir, so that the imports match the directory layout.
+- Remove a shortcut `contracts_precompiled_path(version)` when `version` is the current development version. The same path is accessible with `contracts_precompiled_path(None)`.
 
 ## [0.11.0](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.11.0) - 2019-02-14
 

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -218,7 +218,7 @@ def contracts_source_path():
 
 
 def contracts_data_path(version: Optional[str] = None):
-    if version is None or version == CONTRACTS_VERSION:
+    if version is None:
         return _BASE.joinpath('data')
     else:
         return _BASE.joinpath(f'data_{version}')

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -28,6 +28,12 @@ def test_nonexistent_precompiled_path():
     nonexistent_version = '0.6.0'
     with pytest.raises(FileNotFoundError):
         ContractManager(contracts_precompiled_path(nonexistent_version))
+    nonexistent_version = '0.7.0'
+    with pytest.raises(FileNotFoundError):
+        ContractManager(contracts_precompiled_path(nonexistent_version))
+    nonexistent_version = CONTRACTS_VERSION
+    with pytest.raises(FileNotFoundError):
+        ContractManager(contracts_precompiled_path(nonexistent_version))
 
 
 def test_verification_overall_checksum():
@@ -114,7 +120,7 @@ def test_current_development_version():
         'ServiceRegistry',
     ]
 
-    manager = ContractManager(contracts_precompiled_path(contracts_version))
+    manager = ContractManager(contracts_precompiled_path(None))
     assert manager.contracts_version == contracts_version
     check_precompiled_content(manager, contract_names, PRECOMPILED_DATA_FIELDS)
 


### PR DESCRIPTION
Before this commit, when the user specified the latest version
explicitly, raiden-contracts automatically chose the latest 'data'.

This commit removes that behavior.  If the user wants to use the latest
version (without caring what version it is), the user should say
`precompiled_data_path(None)` with `None` as the contract version.

This closes #606.