### PR TITLE
Comment, cannot distinguish Settled and Removed

### DIFF
--- a/raiden_contracts/contracts/raiden/TokenNetwork.sol
+++ b/raiden_contracts/contracts/raiden/TokenNetwork.sol
@@ -985,6 +985,9 @@ contract TokenNetwork is Utils {
     /// @param participant1 Address of a channel participant.
     /// @param participant2 Address of the other channel participant.
     /// @return Channel settle_block_number and state.
+    /// @note The contract cannot really distinguish Settled and Removed
+    /// states, especially when wrong participants are given as input.
+    /// The contract does not remember the participants of the channel.
     function getChannelInfo(
         uint256 channel_identifier,
         address participant1,


### PR DESCRIPTION
This PR spawns out of https://github.com/raiden-network/raiden-contracts/issues/598 .  Now we noticed that the result of `getChannelInfo()` can be gamed.  This PR adds a comment explaining that.

[skip ci]