### PR TITLE
Consider flavors (Limited or Unlimited) to find directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Documents changes that result in:
 
 - Add data/gas.json that contains gas measurements on the development version.
 - Move Raiden contracts to "raiden" subdir, so that the imports match the directory layout.
+- `contracts_data_path`, `contracts_precompiled_path` and `contracts_gas_path` require an additional `flavor` argument (either `Limited` or `Unlimited`).
 
 ## [0.11.0](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.11.0) - 2019-02-14
 

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ If you are using the ``raiden-contracts`` package in your project, you can use::
     from raiden_contracts.contract_manager import (
         ContractManager,
         contracts_precompiled_path,
+        Flavor,
     )
     from raiden_contracts.constants import (
         CONTRACT_TOKEN_NETWORK_REGISTRY,
@@ -74,10 +75,10 @@ If you are using the ``raiden-contracts`` package in your project, you can use::
     # become available when anybody requests, or when there is a mainnet
     # deployment.
 
-    manager = ContractManager(contracts_precompiled_path(contracts_version))
+    manager = ContractManager(contracts_precompiled_path(Flavor.Limited, contracts_version))
     compiled_contract_data = manager.get_contract(CONTRACT_TOKEN_NETWORK_REGISTRY)
 
-    deployment_data = get_contracts_deployed(int(web3.version.network))
+    deployment_data = get_contracts_deployed(int(web3.version.network), Flavor.Limited)
     TOKEN_NETWORK_REGISTRY_ADDRESS = deployment_data['contracts'][CONTRACT_TOKEN_NETWORK_REGISTRY].address
 
     # And then use:
@@ -88,7 +89,7 @@ If you are using the ``raiden-contracts`` package in your project, you can use::
 
     # To use one of the 3rd party services contracts:
     compiled_ms_contract = manager.get_contract(CONTRACT_MONITORING_SERVICE)
-    deployed_services = get_contracts_deployed(int(web3.version.network), services=True)
+    deployed_services = get_contracts_deployed(int(web3.version.network), Flavor.Limited, services=True)
     MONITORING_SERVICE_ADDRESS = deployed_services['contracts'][CONTRACT_MONITORING_SERVICE].address
 
 
@@ -169,15 +170,15 @@ Check deployment options::
 
 Deploying the main Raiden Network contracts with the ``raiden`` command::
 
-    python -m raiden_contracts.deploy raiden --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --gas-limit 6000000
+    python -m raiden_contracts.deploy raiden --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --gas-limit 6000000 --flavor limited
 
 Deploying the mock token contract for paying for the services (not to be done on the mainnet)::
 
-    python -m raiden_contracts.deploy token --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --token-supply 20000000 --token-name ServiceToken --token-decimals 18 --token-symbol SVT
+    python -m raiden_contracts.deploy token --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --token-supply 20000000 --token-name ServiceToken --token-decimals 18 --token-symbol SVT --flavor limited
 
 Deploying the 3rd party service contracts with the ``services`` command::
 
-    python -m raiden_contracts.deploy services --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --gas-limit 6000000 --token-address TOKEN_USED_TO_PAY_SERVICES
+    python -m raiden_contracts.deploy services --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --gas-limit 6000000 --token-address TOKEN_USED_TO_PAY_SERVICES --flavor limited
 
 Deploying a token for testing purposes (please DO NOT use this for production purposes) with the ``token`` command::
 
@@ -185,7 +186,7 @@ Deploying a token for testing purposes (please DO NOT use this for production pu
 
 Registering a token with the ``TokenNetworkRegistry`` contract, so it can be used by the Raiden Network, with the ``register`` command::
 
-    python -m raiden_contracts.deploy register --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --token-address TOKEN_TO_BE_REGISTERED_ADDRESS --registry-address TOKEN_NETWORK_REGISTRY_ADDRESS
+    python -m raiden_contracts.deploy register --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --token-address TOKEN_TO_BE_REGISTERED_ADDRESS --registry-address TOKEN_NETWORK_REGISTRY_ADDRESS --flavor limited
 
 .. Note::
     Registering a token only works once. All subsequent transactions will fail.
@@ -194,7 +195,7 @@ Deployment information is stored in a ``deployment_[CHAIN_NAME].json`` file corr
 
 ::
 
-    python -m raiden_contracts.deploy verify --rpc-provider http://127.0.0.1:8545
+    python -m raiden_contracts.deploy verify --rpc-provider http://127.0.0.1:8545 --flavor limited
 
     # Based on the network id, the script verifies the corresponding deployment_[CHAIN_NAME].json file
     # using the chain name-id mapping from constants.py

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -31,6 +31,9 @@ lower_name_of_flavor = {
 }
 
 
+flavor_of_lower_name = {lower_name_of_flavor[k]: k for k in lower_name_of_flavor.keys()}
+
+
 class ContractManagerCompilationError(RuntimeError):
     pass
 
@@ -220,23 +223,23 @@ class ContractManager:
             )
 
 
-def contracts_source_path():
+def contracts_source_path(flavor: Flavor):
+    upper_dir = 'contracts' if flavor == Flavor.Limited else 'contracts_without_limits'
     return {
-        'lib': _BASE.joinpath('contracts', 'lib'),
-        'raiden': _BASE.joinpath('contracts', 'raiden'),
-        'test': _BASE.joinpath('contracts', 'test'),
-        'services': _BASE.joinpath('contracts', 'services'),
+        'lib': _BASE.joinpath(upper_dir, 'lib'),
+        'raiden': _BASE.joinpath(upper_dir, 'raiden'),
+        'test': _BASE.joinpath(upper_dir, 'test'),
+        'services': _BASE.joinpath(upper_dir, 'services'),
     }
 
 
 def contracts_data_path(flavor: Flavor, version: Optional[str] = None):
+    flavor_suffix = '_unlimited' if flavor == Flavor.Unlimited else ''
+
     if version is None or version == CONTRACTS_VERSION:
-        ret = _BASE.joinpath('data')
+        return _BASE.joinpath('data' + flavor_suffix)
     else:
-        ret = _BASE.joinpath(f'data_{version}')
-    if flavor == Flavor.Unlimited:
-        ret = ret + '_unlimited'
-    return ret
+        return _BASE.joinpath(f'data_{version}' + flavor_suffix)
 
 
 def contracts_precompiled_path(flavor: Flavor, version: Optional[str] = None):

--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -55,12 +55,16 @@ from raiden_contracts.contract_manager import (
 )
 def etherscan_verify(
         chain_id: int,
-        flavor: str,
+        flavor: Optional[str],
         apikey: str,
         guid: Optional[str],
         contract_name: Optional[str],
 ):
-    flavor_enum = flavor_of_lower_name[flavor]
+    try:
+        flavor_enum = flavor_of_lower_name[flavor]
+    except KeyError:
+        print("specify --flavor unlimited or --flavor limited")
+        exit(1)
     if guid:
         guid_status(api_of_chain_id[chain_id], guid)
         return

--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -61,6 +61,8 @@ def etherscan_verify(
         contract_name: Optional[str],
 ):
     try:
+        if flavor is None:  # To silence mypy
+            raise KeyError
         flavor_enum = flavor_of_lower_name[flavor]
     except KeyError:
         print("specify --flavor unlimited or --flavor limited")
@@ -70,10 +72,22 @@ def etherscan_verify(
         return
 
     if contract_name is None or contract_name == CONTRACT_ENDPOINT_REGISTRY:
-        etherscan_verify_contract(chain_id, flavor_enum, apikey, 'raiden', CONTRACT_ENDPOINT_REGISTRY)
+        etherscan_verify_contract(
+            chain_id,
+            flavor_enum,
+            apikey,
+            'raiden',
+            CONTRACT_ENDPOINT_REGISTRY,
+        )
 
     if contract_name is None or contract_name == CONTRACT_SECRET_REGISTRY:
-        etherscan_verify_contract(chain_id, flavor_enum, apikey, 'raiden', CONTRACT_SECRET_REGISTRY)
+        etherscan_verify_contract(
+            chain_id,
+            flavor_enum,
+            apikey,
+            'raiden',
+            CONTRACT_SECRET_REGISTRY,
+        )
 
     if contract_name is None or contract_name == CONTRACT_TOKEN_NETWORK_REGISTRY:
         etherscan_verify_contract(
@@ -85,7 +99,13 @@ def etherscan_verify(
         )
 
     if contract_name is None or contract_name == CONTRACT_SERVICE_REGISTRY:
-        etherscan_verify_contract(chain_id, flavor_enum, apikey, 'services', CONTRACT_SERVICE_REGISTRY)
+        etherscan_verify_contract(
+            chain_id,
+            flavor_enum,
+            apikey,
+            'services',
+            CONTRACT_SERVICE_REGISTRY,
+        )
 
     if contract_name is None or contract_name == CONTRACT_MONITORING_SERVICE:
         etherscan_verify_contract(

--- a/raiden_contracts/tests/fixtures/base/contract_manager.py
+++ b/raiden_contracts/tests/fixtures/base/contract_manager.py
@@ -1,7 +1,7 @@
 import pytest
-from raiden_contracts.contract_manager import ContractManager, contracts_source_path
+from raiden_contracts.contract_manager import ContractManager, contracts_source_path, Flavor
 
 
 @pytest.fixture
 def contracts_manager():
-    return ContractManager(contracts_source_path())
+    return ContractManager(contracts_source_path(Flavor.Limited))

--- a/raiden_contracts/tests/fixtures/base/utils.py
+++ b/raiden_contracts/tests/fixtures/base/utils.py
@@ -2,7 +2,7 @@ import json
 import pytest
 from typing import Dict
 from eth_tester.exceptions import TransactionFailed
-from raiden_contracts.contract_manager import contracts_gas_path
+from raiden_contracts.contract_manager import contracts_gas_path, Flavor
 from raiden_contracts.utils.logs import LogHandler
 from raiden_contracts.utils.signature import private_key_to_address
 from raiden_contracts.tests.utils.constants import passphrase
@@ -134,7 +134,7 @@ def print_gas(web3, txn_gas, gas_measurement_results):
         print('GAS USED ' + message, gas_used + additional_gas)
         print('----------------------------------')
         gas_measurement_results[message] = gas_used + additional_gas
-        with contracts_gas_path().open(mode='w') as target_file:
+        with contracts_gas_path(Flavor.Limited).open(mode='w') as target_file:
             target_file.write(json.dumps(
                 gas_measurement_results,
                 sort_keys=True,

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -7,6 +7,7 @@ from raiden_contracts.contract_manager import (
     contracts_precompiled_path,
     contracts_deployed_path,
     ContractManagerVerificationError,
+    Flavor,
 )
 from raiden_contracts.constants import (
     CONTRACTS_VERSION,
@@ -27,14 +28,17 @@ def test_nonexistent_precompiled_path():
     """ An exception occurs when trying to access a field in a non-existent precompiled path """
     nonexistent_version = '0.6.0'
     with pytest.raises(FileNotFoundError):
-        ContractManager(contracts_precompiled_path(nonexistent_version))
+        ContractManager(contracts_precompiled_path(
+            Flavor.Limited,
+            nonexistent_version,
+        ))
 
 
 def test_verification_overall_checksum():
     """ Tamper with the overall checksum and see failures in verify_precompiled_checksums() """
-    manager = ContractManager(contracts_source_path())
+    manager = ContractManager(contracts_source_path(Flavor.Limited))
     manager.checksum_contracts()
-    manager.verify_precompiled_checksums(contracts_precompiled_path())
+    manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
 
     assert manager.overall_checksum
     original_checksum = manager.overall_checksum
@@ -43,61 +47,61 @@ def test_verification_overall_checksum():
     manager.overall_checksum += '2'
     # Now the verification should fail
     with pytest.raises(ContractManagerVerificationError):
-        manager.verify_precompiled_checksums(contracts_precompiled_path())
+        manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
 
     manager.overall_checksum = None
     with pytest.raises(ContractManagerVerificationError):
-        manager.verify_precompiled_checksums(contracts_precompiled_path())
+        manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
 
     manager.overall_checksum = ''
     with pytest.raises(ContractManagerVerificationError):
-        manager.verify_precompiled_checksums(contracts_precompiled_path())
+        manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
 
     checksum_fail = list(original_checksum)
     # Replace the first char with a different one
     checksum_fail[0] = list(filter(lambda x: x != checksum_fail[0], ['2', 'a']))[0]
     manager.overall_checksum = "".join(checksum_fail)
     with pytest.raises(ContractManagerVerificationError):
-        manager.verify_precompiled_checksums(contracts_precompiled_path())
+        manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
 
     manager.overall_checksum = original_checksum
-    manager.verify_precompiled_checksums(contracts_precompiled_path())
+    manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
 
 
 def test_verification_contracts_checksums():
     """ Tamper with the contract checksums and see failures in verify_precompiled_checksums() """
-    manager = ContractManager(contracts_source_path())
+    manager = ContractManager(contracts_source_path(Flavor.Limited))
     manager.checksum_contracts()
-    manager.verify_precompiled_checksums(contracts_precompiled_path())
+    manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
 
     assert manager.contracts_checksums
     for contract, checksum in manager.contracts_checksums.items():
         manager.contracts_checksums[contract] += '2'
         with pytest.raises(ContractManagerVerificationError):
-            manager.verify_precompiled_checksums(contracts_precompiled_path())
+            manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
 
         manager.contracts_checksums[contract] = None  # type: ignore
         with pytest.raises(ContractManagerVerificationError):
-            manager.verify_precompiled_checksums(contracts_precompiled_path())
+            manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
 
         manager.contracts_checksums[contract] = ''
         with pytest.raises(ContractManagerVerificationError):
-            manager.verify_precompiled_checksums(contracts_precompiled_path())
+            manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
 
         checksum_fail = list(checksum)
         # Replace the first char with a different one
         checksum_fail[0] = list(filter(lambda x: x != checksum_fail[0], ['2', 'a']))[0]
         manager.contracts_checksums[contract] = "".join(checksum_fail)
         with pytest.raises(ContractManagerVerificationError):
-            manager.verify_precompiled_checksums(contracts_precompiled_path())
+            manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
 
         manager.contracts_checksums[contract] = checksum
-        manager.verify_precompiled_checksums(contracts_precompiled_path())
+        manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
 
 
 def test_contracts_version():
     """ Check the value of contracts_version """
-    manager = ContractManager(contracts_precompiled_path())
+    manager = ContractManager(contracts_precompiled_path(Flavor.Limited))
     assert manager.contracts_version == CONTRACTS_VERSION
 
 
@@ -114,22 +118,35 @@ def test_current_development_version():
         'ServiceRegistry',
     ]
 
-    manager = ContractManager(contracts_precompiled_path(contracts_version))
+    manager = ContractManager(contracts_precompiled_path(Flavor.Limited, contracts_version))
     assert manager.contracts_version == contracts_version
     check_precompiled_content(manager, contract_names, PRECOMPILED_DATA_FIELDS)
 
-    for _, source_path in contracts_source_path().items():
+    for _, source_path in contracts_source_path(Flavor.Limited).items():
         assert source_path.exists()
-    assert contracts_precompiled_path().exists()
+    assert contracts_precompiled_path(Flavor.Limited).exists()
 
-    # deployment files exist
-    assert contracts_deployed_path(NETWORKNAME_TO_ID['rinkeby']).exists()
-    assert contracts_deployed_path(NETWORKNAME_TO_ID['ropsten']).exists()
-    assert contracts_deployed_path(NETWORKNAME_TO_ID['kovan']).exists()
-    # deployment files for service contracts also exist
-    assert contracts_deployed_path(NETWORKNAME_TO_ID['rinkeby'], services=True).exists()
-    assert contracts_deployed_path(NETWORKNAME_TO_ID['ropsten'], services=True).exists()
-    assert contracts_deployed_path(NETWORKNAME_TO_ID['kovan'], services=True).exists()
+    for flavor in {Flavor.Limited}:  # TODO: addd Flavor.Unlimited when ready
+        # deployment files exist
+        assert contracts_deployed_path(NETWORKNAME_TO_ID['rinkeby'], flavor).exists()
+        assert contracts_deployed_path(NETWORKNAME_TO_ID['ropsten'], flavor).exists()
+        assert contracts_deployed_path(NETWORKNAME_TO_ID['kovan'], flavor).exists()
+        # deployment files for service contracts also exist
+        assert contracts_deployed_path(
+            NETWORKNAME_TO_ID['rinkeby'],
+            flavor,
+            services=True,
+        ).exists()
+        assert contracts_deployed_path(
+            NETWORKNAME_TO_ID['ropsten'],
+            flavor,
+            services=True,
+        ).exists()
+        assert contracts_deployed_path(
+            NETWORKNAME_TO_ID['kovan'],
+            flavor,
+            services=True,
+        ).exists()
 
 
 def test_red_eyes_version():
@@ -143,15 +160,31 @@ def test_red_eyes_version():
         'TokenNetwork',
     ]
 
-    manager = ContractManager(contracts_precompiled_path(contracts_version))
+    manager = ContractManager(contracts_precompiled_path(Flavor.Limited, contracts_version))
     assert manager.contracts_version == contracts_version
     check_precompiled_content(manager, contract_names, PRECOMPILED_DATA_FIELDS)
 
-    assert contracts_precompiled_path(contracts_version).exists()
-    assert contracts_deployed_path(NETWORKNAME_TO_ID['mainnet'], contracts_version).exists()
-    assert contracts_deployed_path(NETWORKNAME_TO_ID['rinkeby'], contracts_version).exists()
-    assert contracts_deployed_path(NETWORKNAME_TO_ID['ropsten'], contracts_version).exists()
-    assert contracts_deployed_path(NETWORKNAME_TO_ID['kovan'], contracts_version).exists()
+    assert contracts_precompiled_path(Flavor.Limited, contracts_version).exists()
+    assert contracts_deployed_path(
+        NETWORKNAME_TO_ID['mainnet'],
+        Flavor.Limited,
+        contracts_version,
+    ).exists()
+    assert contracts_deployed_path(
+        NETWORKNAME_TO_ID['rinkeby'],
+        Flavor.Limited,
+        contracts_version,
+    ).exists()
+    assert contracts_deployed_path(
+        NETWORKNAME_TO_ID['ropsten'],
+        Flavor.Limited,
+        contracts_version,
+    ).exists()
+    assert contracts_deployed_path(
+        NETWORKNAME_TO_ID['kovan'],
+        Flavor.Limited,
+        contracts_version,
+    ).exists()
 
 
 def test_pre_limits_version():
@@ -165,14 +198,26 @@ def test_pre_limits_version():
         'TokenNetwork',
     ]
 
-    manager = ContractManager(contracts_precompiled_path(contracts_version))
+    manager = ContractManager(contracts_precompiled_path(Flavor.Limited, contracts_version))
     assert manager.contracts_version == contracts_version
     check_precompiled_content(manager, contract_names, PRECOMPILED_DATA_FIELDS)
 
-    assert contracts_precompiled_path(contracts_version).exists()
-    assert contracts_deployed_path(NETWORKNAME_TO_ID['rinkeby'], contracts_version).exists()
-    assert contracts_deployed_path(NETWORKNAME_TO_ID['ropsten'], contracts_version).exists()
-    assert contracts_deployed_path(NETWORKNAME_TO_ID['kovan'], contracts_version).exists()
+    assert contracts_precompiled_path(Flavor.Limited, contracts_version).exists()
+    assert contracts_deployed_path(
+        NETWORKNAME_TO_ID['rinkeby'],
+        Flavor.Limited,
+        contracts_version,
+    ).exists()
+    assert contracts_deployed_path(
+        NETWORKNAME_TO_ID['ropsten'],
+        Flavor.Limited,
+        contracts_version,
+    ).exists()
+    assert contracts_deployed_path(
+        NETWORKNAME_TO_ID['kovan'],
+        Flavor.Limited,
+        contracts_version,
+    ).exists()
 
 
 def contract_manager_meta(contracts_path):
@@ -192,12 +237,12 @@ def contract_manager_meta(contracts_path):
 
 def test_contract_manager_compile():
     """ Check the ABI in the sources """
-    contract_manager_meta(contracts_source_path())
+    contract_manager_meta(contracts_source_path(Flavor.Limited))
 
 
 def test_contract_manager_json(tmpdir):
     """ Check the ABI in contracts.json """
     precompiled_path = Path(str(tmpdir)).joinpath('contracts.json')
-    ContractManager(contracts_source_path()).compile_contracts(precompiled_path)
+    ContractManager(contracts_source_path(Flavor.Limited)).compile_contracts(precompiled_path)
     # try to load contracts from a precompiled file
     contract_manager_meta(precompiled_path)

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,8 @@ class CompileContracts(Command):
         )
 
         contract_manager = ContractManager(contracts_source_path())
-        contract_manager.compile_contracts(contracts_precompiled_path(Flavor.Limited)
+        contract_manager.compile_contracts(
+            contracts_precompiled_path(Flavor.Limited),
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ class VerifyContracts(Command):
             contracts_source_path,
             Flavor,
         )
-        manager = ContractManager(contracts_source_path())
+        manager = ContractManager(contracts_source_path(Flavor.Limited))
         manager.checksum_contracts()
         manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
 
@@ -74,7 +74,7 @@ class CompileContracts(Command):
             Flavor,
         )
 
-        contract_manager = ContractManager(contracts_source_path())
+        contract_manager = ContractManager(contracts_source_path(Flavor.Limited))
         contract_manager.compile_contracts(
             contracts_precompiled_path(Flavor.Limited),
         )

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,11 @@ class VerifyContracts(Command):
             ContractManager,
             contracts_precompiled_path,
             contracts_source_path,
+            Flavor,
         )
         manager = ContractManager(contracts_source_path())
         manager.checksum_contracts()
-        manager.verify_precompiled_checksums(contracts_precompiled_path())
+        manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
 
 
 class CompileContracts(Command):
@@ -70,10 +71,11 @@ class CompileContracts(Command):
             ContractManager,
             contracts_precompiled_path,
             contracts_source_path,
+            Flavor,
         )
 
         contract_manager = ContractManager(contracts_source_path())
-        contract_manager.compile_contracts(contracts_precompiled_path()
+        contract_manager.compile_contracts(contracts_precompiled_path(Flavor.Limited)
         )
 
 


### PR DESCRIPTION
For #599, `raiden-contracts` needs to provide both `limited` and `unlimited` deployment data.  This PR computes the directory names for these flavors.  This changes the ABI.  See the diff of Changelog.