### PR TITLE
Reorder release process

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -130,6 +130,14 @@ Copy ``data`` directory into ``data_x.y.z`` where ``x.y.z`` is the contract vers
 
 Also ``data_unlimited`` has to be copied into ``data_x.y.z_unlimited``.
 
+.. _change-changelog:
+
+Change the Versions of CHANGELOG.md
+-----------------------------------
+
+* Make sure all significant changes from the last release are listed.
+* Turn the existing ``Unreleased`` section into a new release section.
+
 .. _bump-package:
 
 Bump Package Version
@@ -150,14 +158,6 @@ Before bumping the package version, ``git add`` the deployment data at ``data/de
 * ``patch`` bumps are made for any other fix
 
 This command triggers a commit and a local tag is created. A PR must be made with the commit changes.
-
-.. _change-changelog:
-
-Change the Versions of CHANGELOG.md
------------------------------------
-
-* Make sure all significant changes from the last release are listed.
-* Turn the existing ``Unreleased`` section into a new release section.
 
 .. _release-package:
 


### PR DESCRIPTION
Update the changelog before actually bump the version.

This closes #625.

[skip ci]