### PR TITLE
Add a method in ContractDeployer to simplify common usage of verify_deployment_data

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -175,6 +175,20 @@ class ContractDeployer:
             deployment_data=deployment_data,
         )
 
+    def verify_service_deployment(
+            self,
+            token_address: str,
+            user_deposit_whole_balance_limit: int,
+            deployment_data: 'DeployedContracts',
+    ):
+        return verify_service_contracts_deployment_data(
+            web3=self.web3,
+            contract_manager=self.contract_manager,
+            token_address=token_address,
+            user_deposit_whole_balance_limit=user_deposit_whole_balance_limit,
+            deployment_data=deployment_data,
+        )
+
 
 def common_options(func):
     """A decorator that combines commonly appearing @click.option decorators."""
@@ -848,7 +862,7 @@ def store_deployment_info(deployment_file_path: Path, deployment_info: 'Deployed
 def verify_deployment_data(
         web3: Web3,
         contract_manager: ContractManager,
-        deployment_data,
+        deployment_data: 'DeployedContracts',
 ):
     chain_id = int(web3.version.network)
     assert deployment_data is not None

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -168,6 +168,13 @@ class ContractDeployer:
     def contract_version_string(self):
         return contract_version_string(self.contracts_version)
 
+    def verify_deployment(self, deployment_data):
+        return verify_deployment_data(
+            web3=self.web3,
+            contract_manager=self.contract_manager,
+            deployment_data=deployment_data,
+        )
+
 
 def common_options(func):
     """A decorator that combines commonly appearing @click.option decorators."""
@@ -275,11 +282,7 @@ def store_and_verify_deployment_info_raiden(
             deployer.contract_manager,
         )
     else:
-        verify_deployment_data(
-            web3=deployer.web3,
-            contract_manager=deployer.contract_manager,
-            deployment_data=deployed_contracts_info,
-        )
+        deployer.verify_deployment(deployed_contracts_info)
 
 
 def store_and_verify_deployment_info_services(

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -27,7 +27,6 @@ from raiden_contracts.deploy.__main__ import (
     store_and_verify_deployment_info_raiden,
     store_and_verify_deployment_info_services,
     validate_address,
-    verify_service_contracts_deployment_data,
 )
 from raiden_contracts.tests.utils import get_random_privkey
 from raiden_contracts.tests.utils.constants import (
@@ -279,9 +278,7 @@ def test_deploy_script_service(
         token_address=token_address,
         user_deposit_whole_balance_limit=deposit_limit,
     )
-    verify_service_contracts_deployment_data(
-        web3=deployer.web3,
-        contract_manager=deployer.contract_manager,
+    deployer.verify_service_deployment(
         token_address=token_address,
         user_deposit_whole_balance_limit=deposit_limit,
         deployment_data=deployed_service_contracts,
@@ -290,9 +287,7 @@ def test_deploy_script_service(
     deployed_info_fail = deepcopy(deployed_service_contracts)
     deployed_info_fail['contracts_version'] = '0.0.0'
     with pytest.raises(AssertionError):
-        verify_service_contracts_deployment_data(
-            web3=deployer.web3,
-            contract_manager=deployer.contract_manager,
+        deployer.verify_service_deployment(
             token_address=token_address,
             user_deposit_whole_balance_limit=deposit_limit,
             deployment_data=deployed_info_fail,
@@ -304,9 +299,7 @@ def test_deploy_script_service(
             contract_name
         ]['address'] = EMPTY_ADDRESS
         with pytest.raises(AssertionError):
-            verify_service_contracts_deployment_data(
-                web3=deployer.web3,
-                contract_manager=deployer.contract_manager,
+            deployer.verify_service_deployment(
                 token_address=token_address,
                 user_deposit_whole_balance_limit=deposit_limit,
                 deployment_data=deployed_info_fail,

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -27,7 +27,6 @@ from raiden_contracts.deploy.__main__ import (
     store_and_verify_deployment_info_raiden,
     store_and_verify_deployment_info_services,
     validate_address,
-    verify_deployment_data,
     verify_service_contracts_deployment_data,
 )
 from raiden_contracts.tests.utils import get_random_privkey
@@ -79,87 +78,51 @@ def test_deploy_script_raiden(
 
     deployed_contracts_info = deploy_raiden_contracts(deployer, max_num_of_token_networks)
 
-    verify_deployment_data(
-        web3=deployer.web3,
-        contract_manager=deployer.contract_manager,
-        deployment_data=deployed_contracts_info,
-    )
+    deployer.verify_deployment(deployed_contracts_info)
 
     deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
     deployed_contracts_info_fail['contracts_version'] = '0.0.0'
     with pytest.raises(AssertionError):
-        verify_deployment_data(
-            web3=deployer.web3,
-            contract_manager=deployer.contract_manager,
-            deployment_data=deployed_contracts_info_fail,
-        )
+        deployer.verify_deployment(deployed_contracts_info_fail)
 
     deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
     deployed_contracts_info_fail['chain_id'] = 0
     with pytest.raises(AssertionError):
-        verify_deployment_data(
-            web3=deployer.web3,
-            contract_manager=deployer.contract_manager,
-            deployment_data=deployed_contracts_info_fail,
-        )
+        deployer.verify_deployment(deployed_contracts_info_fail)
 
     deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
     deployed_contracts_info_fail['contracts'][
         CONTRACT_ENDPOINT_REGISTRY
     ]['address'] = EMPTY_ADDRESS
     with pytest.raises(AssertionError):
-        verify_deployment_data(
-            deployer.web3,
-            deployer.contract_manager,
-            deployed_contracts_info_fail,
-        )
+        deployer.verify_deployment(deployed_contracts_info_fail)
 
     deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
     deployed_contracts_info_fail['contracts'][CONTRACT_SECRET_REGISTRY]['address'] = EMPTY_ADDRESS
     with pytest.raises(AssertionError):
-        verify_deployment_data(
-            deployer.web3,
-            deployer.contract_manager,
-            deployed_contracts_info_fail,
-        )
+        deployer.verify_deployment(deployed_contracts_info_fail)
 
     deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
     deployed_contracts_info_fail['contracts'][
         CONTRACT_TOKEN_NETWORK_REGISTRY
     ]['address'] = EMPTY_ADDRESS
     with pytest.raises(AssertionError):
-        verify_deployment_data(
-            deployer.web3,
-            deployer.contract_manager,
-            deployed_contracts_info_fail,
-        )
+        deployer.verify_deployment(deployed_contracts_info_fail)
 
     deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
     deployed_contracts_info_fail['contracts'][CONTRACT_ENDPOINT_REGISTRY]['block_number'] = 0
     with pytest.raises(AssertionError):
-        verify_deployment_data(
-            deployer.web3,
-            deployer.contract_manager,
-            deployed_contracts_info_fail,
-        )
+        deployer.verify_deployment(deployed_contracts_info_fail)
 
     deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
     deployed_contracts_info_fail['contracts'][CONTRACT_SECRET_REGISTRY]['block_number'] = 0
     with pytest.raises(AssertionError):
-        verify_deployment_data(
-            deployer.web3,
-            deployer.contract_manager,
-            deployed_contracts_info_fail,
-        )
+        deployer.verify_deployment(deployed_contracts_info_fail)
 
     deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
     deployed_contracts_info_fail['contracts'][CONTRACT_TOKEN_NETWORK_REGISTRY]['block_number'] = 0
     with pytest.raises(AssertionError):
-        verify_deployment_data(
-            deployer.web3,
-            deployer.contract_manager,
-            deployed_contracts_info_fail,
-        )
+        deployer.verify_deployment(deployed_contracts_info_fail)
 
     # check that it fails if sender has no eth
     deployer = ContractDeployer(


### PR DESCRIPTION
This closes #638.