### PR TITLE
Prevent writing to 0.8.0_unlimited_unlimited

### DIFF
--- a/.bumpversion_contracts.cfg
+++ b/.bumpversion_contracts.cfg
@@ -4,5 +4,5 @@ commit = True
 tag = False
 
 [bumpversion:file:raiden_contracts/constants.py]
-serialize = CONTRACTS_VERSION = "{major}.{minor}.{patch}"
+serialize = CONTRACTS_VERSION = PlainVersion("{major}.{minor}.{patch}")
 

--- a/.bumpversion_contracts.cfg
+++ b/.bumpversion_contracts.cfg
@@ -4,5 +4,5 @@ commit = True
 tag = False
 
 [bumpversion:file:raiden_contracts/constants.py]
-serialize = CONTRACTS_VERSION = PlainVersion("{major}.{minor}.{patch}")
+serialize = _CONTRACTS_VERSION = "{major}.{minor}.{patch}"
 

--- a/.bumpversion_contracts.cfg
+++ b/.bumpversion_contracts.cfg
@@ -4,5 +4,5 @@ commit = True
 tag = False
 
 [bumpversion:file:raiden_contracts/constants.py]
-serialize = _CONTRACTS_VERSION = "{major}.{minor}.{patch}"
+serialize = _CONTRACTS_VERSION = '{major}.{minor}.{patch}'
 

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ If you are using the ``raiden-contracts`` package in your project, you can use::
         ContractManager,
         contracts_precompiled_path,
         Flavor,
+        PlainVersion,
     )
     from raiden_contracts.constants import (
         CONTRACT_TOKEN_NETWORK_REGISTRY,
@@ -54,22 +55,26 @@ If you are using the ``raiden-contracts`` package in your project, you can use::
         EVENT_TOKEN_NETWORK_CREATED,
     )
 
-    # ``raiden-contracts`` provides only three kinds of ``contracts_version``s.
-    # ``None``, ``'0.4.0'`` and ``'0.3._'``.  They are explained below.
+    # ``raiden-contracts`` provides some kinds of ``contracts_version``s.
+    # ``None``, ``PlainVersion(0.8.0)``, ``PlainVersion('0.4.0')``
+    # and ``PlainVersion('0.3._')``.  They are explained below.
 
     # Uses the newest version. Available on Kovan, Rinkeby and Ropsten.
     # Mainnet deployments should not be accessed with contract_version == None.
     contracts_version = None
 
+    # Uses 0.8.0 version. Available on Kovan, Rinkeby and Ropsten.
+    contracts_version = PlainVersion('0.8.0')
+
     # Uses Red Eyes, Mainnet enabled version with deposit limits.
     # The version is also available on Kovan, Rinkeby and Ropsten.
-    contracts_version = '0.4.0'
+    contracts_version = PlainVersion('0.4.0')
 
     # Uses the pre-red-eyes development version, probably without
     # deposit limits. Available only on Kovan, Rinkeby and Ropsten.
     # The Solidity source of this version is unknown on Etherscan.
     # See https://github.com/raiden-network/raiden-contracts/issues/543
-    contracts_version = '0.3._'
+    contracts_version = PlainVersion('0.3._')
 
     # Other contract versions like ``'0.6.0'`` do not work. Contract versions
     # become available when anybody requests, or when there is a mainnet

--- a/raiden_contracts/constants.py
+++ b/raiden_contracts/constants.py
@@ -8,7 +8,8 @@ FlavoredVersion = NewType('FlavoredVersion', str)
 PlainVersion = NewType('PlainVersion', str)
 
 # Do not change this, this is handled by bumpversion with .bumpversion_contracts.cfg
-CONTRACTS_VERSION = PlainVersion("0.8.0")
+_CONTRACTS_VERSION = "0.8.0"
+CONTRACTS_VERSION = PlainVersion(_CONTRACTS_VERSION)
 
 PRECOMPILED_DATA_FIELDS = ['abi', 'bin', 'bin-runtime', 'metadata']
 

--- a/raiden_contracts/constants.py
+++ b/raiden_contracts/constants.py
@@ -1,7 +1,14 @@
 from enum import Enum, IntEnum
+from typing import NewType
+
+# Something like '0.8.0_unlimited' or '0.8.0' depending on limted/unlimited
+FlavoredVersion = NewType('FlavoredVersion', str)
+
+# Something like '0.8.0' before adding '_unlimited'
+PlainVersion = NewType('PlainVersion', str)
 
 # Do not change this, this is handled by bumpversion with .bumpversion_contracts.cfg
-CONTRACTS_VERSION = "0.8.0"
+CONTRACTS_VERSION = PlainVersion("0.8.0")
 
 PRECOMPILED_DATA_FIELDS = ['abi', 'bin', 'bin-runtime', 'metadata']
 

--- a/raiden_contracts/constants.py
+++ b/raiden_contracts/constants.py
@@ -8,7 +8,7 @@ FlavoredVersion = NewType('FlavoredVersion', str)
 PlainVersion = NewType('PlainVersion', str)
 
 # Do not change this, this is handled by bumpversion with .bumpversion_contracts.cfg
-_CONTRACTS_VERSION = "0.8.0"
+_CONTRACTS_VERSION = '0.8.0'
 CONTRACTS_VERSION = PlainVersion(_CONTRACTS_VERSION)
 
 PRECOMPILED_DATA_FIELDS = ['abi', 'bin', 'bin-runtime', 'metadata']

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -85,7 +85,7 @@ class ContractManager:
                         self.plain_version = PlainVersion(
                             precompiled_content['plain_version'],
                         )
-                    except KeyError: # Assuming an older format
+                    except KeyError:  # Assuming an older format
                         self.plain_version = PlainVersion(
                             precompiled_content['contracts_version'],
                         )

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -268,7 +268,7 @@ def contract_version_string(
     return version + flavor_suffix(flavor)
 
 
-def contracts_data_path(flavor: Flavor, version: Optional[str] = None):
+def contracts_data_path(flavor: Flavor, version: Optional[PlainVersion] = None):
     if version is None or version == CONTRACTS_VERSION:
         return _BASE.joinpath('data' + flavor_suffix(flavor))
     else:
@@ -321,12 +321,12 @@ contracts_mustache_hashes: List[Tuple[Path, Dict]] = [
 ]
 
 
-def contracts_precompiled_path(flavor: Flavor, version: Optional[str] = None):
+def contracts_precompiled_path(flavor: Flavor, version: Optional[PlainVersion] = None):
     data_path = contracts_data_path(flavor, version)
     return data_path.joinpath('contracts.json')
 
 
-def contracts_gas_path(flavor: Flavor, version: Optional[str] = None):
+def contracts_gas_path(flavor: Flavor, version: Optional[PlainVersion] = None):
     data_path = contracts_data_path(flavor, version)
     return data_path.joinpath('gas.json')
 

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -81,9 +81,14 @@ class ContractManager:
                     self.contracts = precompiled_content['contracts']
                     self.overall_checksum = precompiled_content['overall_checksum']
                     self.contracts_checksums = precompiled_content['contracts_checksums']
-                    self.plain_version = PlainVersion(
-                        precompiled_content['plain_version'],
-                    )
+                    try:
+                        self.plain_version = PlainVersion(
+                            precompiled_content['plain_version'],
+                        )
+                    except KeyError: # Assuming an older format
+                        self.plain_version = PlainVersion(
+                            precompiled_content['contracts_version'],
+                        )
                     self.contracts_version = FlavoredVersion(
                         precompiled_content['contracts_version'],
                     )

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -23,13 +23,13 @@ _BASE = Path(__file__).parent
 
 
 class Flavor(Enum):
-    Unlimited = 1
-    Limited = 2
+    UNLIMITED = 1
+    LIMITED = 2
 
 
 lower_name_of_flavor = {
-    Flavor.Unlimited: 'unlimited',
-    Flavor.Limited: 'limited',
+    Flavor.UNLIMITED: 'unlimited',
+    Flavor.LIMITED: 'limited',
 }
 
 
@@ -246,14 +246,14 @@ class ContractManager:
 
 
 def contracts_source_path(flavor: Flavor):
-    upper_dir = 'contracts' if flavor == Flavor.Limited else 'contracts_without_limits'
+    upper_dir = 'contracts' if flavor == Flavor.LIMITED else 'contracts_without_limits'
     return contracts_source_path_with_stem(upper_dir)
 
 
 def flavor_suffix(flavor: Flavor):
-    if flavor == Flavor.Unlimited:
+    if flavor == Flavor.UNLIMITED:
         return '_unlimited'
-    elif flavor == Flavor.Limited:
+    elif flavor == Flavor.LIMITED:
         return ''
     else:
         raise ValueError(f'Unknowon Flavor {flavor}')
@@ -289,9 +289,9 @@ def contracts_template_path():
 
 
 def contracts_source_root(flavor: Flavor):
-    if flavor == Flavor.Limited:
+    if flavor == Flavor.LIMITED:
         return _BASE.joinpath('contracts')
-    if flavor == Flavor.Unlimited:
+    if flavor == Flavor.UNLIMITED:
         return _BASE.joinpath('contracts_without_limits')
     else:
         raise ValueError(f"unknown flavor {flavor}")
@@ -303,7 +303,7 @@ def contracts_template_root():
 
 contracts_mustache_hashes: List[Tuple[Path, Dict]] = [
     (
-        contracts_source_root(Flavor.Unlimited),
+        contracts_source_root(Flavor.UNLIMITED),
         {
             "limited": False,
             "contracts_version": CONTRACTS_VERSION,
@@ -311,7 +311,7 @@ contracts_mustache_hashes: List[Tuple[Path, Dict]] = [
         },
     ),
     (
-        contracts_source_root(Flavor.Limited),
+        contracts_source_root(Flavor.LIMITED),
         {
             "limited": True,
             "contracts_version": CONTRACTS_VERSION,

--- a/raiden_contracts/data/contracts.json
+++ b/raiden_contracts/data/contracts.json
@@ -6379,5 +6379,6 @@
         "Utils.sol": "68ef4cb42233e9ec38d7558112eb554114d4c4d56b78d00071110d14a565d15c"
     },
     "contracts_version": "0.8.0",
-    "overall_checksum": "b444cb63de8963c1ed77e96e86d55061044c95882e0d9459a1579cf5faef3486"
+    "overall_checksum": "b444cb63de8963c1ed77e96e86d55061044c95882e0d9459a1579cf5faef3486",
+    "plain_version": "0.8.0"
 }

--- a/raiden_contracts/data_unlimited/contracts.json
+++ b/raiden_contracts/data_unlimited/contracts.json
@@ -6087,5 +6087,6 @@
         "Utils.sol": "acc55da2b96dedfc7e8bb6af6782ae4bee02bacfaa5376607daf615d64b24d01"
     },
     "contracts_version": "0.8.0_unlimited",
-    "overall_checksum": "8a323468142ad17ad5d2ff5bddb925686985e7f08071217c4734819e3be3a8f4"
+    "overall_checksum": "8a323468142ad17ad5d2ff5bddb925686985e7f08071217c4734819e3be3a8f4",
+    "plain_version": "0.8.0"
 }

--- a/raiden_contracts/data_unlimited/contracts.json
+++ b/raiden_contracts/data_unlimited/contracts.json
@@ -6086,6 +6086,6 @@
         "UserDeposit.sol": "38e1a4fdbcd70c7283535f3235e60c8eb15709675eee13ed7d7f5f6d2c72617e",
         "Utils.sol": "acc55da2b96dedfc7e8bb6af6782ae4bee02bacfaa5376607daf615d64b24d01"
     },
-    "contracts_version": "0.8.0",
+    "contracts_version": "0.8.0_unlimited",
     "overall_checksum": "8a323468142ad17ad5d2ff5bddb925686985e7f08071217c4734819e3be3a8f4"
 }

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -28,6 +28,8 @@ from raiden_contracts.constants import (
     DEPLOY_SETTLE_TIMEOUT_MAX,
     DEPLOY_SETTLE_TIMEOUT_MIN,
     CONTRACTS_VERSION,
+    FlavoredVersion,
+    PlainVersion,
 )
 from raiden_contracts.contract_manager import (
     ContractManager,
@@ -68,7 +70,7 @@ class ContractDeployer:
         gas_limit: int,
         gas_price: int=1,
         wait: int=10,
-        contracts_version: Optional[str]=None,
+        contracts_version: Optional[PlainVersion]=None,
     ):
         self.web3 = web3
         self.flavor = flavor
@@ -160,7 +162,7 @@ class ContractDeployer:
 
         return txhash
 
-    def contract_version_string(self):
+    def contract_version_string(self) -> FlavoredVersion:
         return contract_version_string(self.flavor, self.contracts_version)
 
 
@@ -295,9 +297,9 @@ def raiden(
     if save_info is True:
         store_deployment_info(deployed_contracts_info, flavor_enum)
         verify_deployed_contracts_in_filesystem(
-            deployer.web3,
-            deployer.contract_manager,
-            flavor_enum,
+            web3=deployer.web3,
+            contract_manager=deployer.contract_manager,
+            flavor=flavor_enum,
         )
     else:
         verify_deployment_data(
@@ -793,11 +795,15 @@ def verify_deployed_contracts_in_filesystem(
 ):
     chain_id = int(web3.version.network)
 
-    deployment_data = get_contracts_deployed(chain_id, flavor, contract_manager.contracts_version)
+    deployment_data = get_contracts_deployed(
+        chain_id=chain_id,
+        flavor=flavor,
+        version=contract_manager.plain_version,
+    )
     deployment_file_path = contracts_deployed_path(
-        chain_id,
-        flavor,
-        contract_manager.contracts_version,
+        chain_id=chain_id,
+        flavor=flavor,
+        version=contract_manager.plain_version,
     )
     assert deployment_data is not None
 
@@ -889,15 +895,15 @@ def verify_deployed_service_contracts_in_filesystem(
     chain_id = int(web3.version.network)
 
     deployment_data = get_contracts_deployed(
-        chain_id,
-        flavor,
-        contract_manager.contracts_version,
+        chain_id=chain_id,
+        flavor=flavor,
+        version=contract_manager.plain_version,
         services=True,
     )
     deployment_file_path = contracts_deployed_path(
-        chain_id,
-        flavor,
-        contract_manager.contracts_version,
+        chain_id=chain_id,
+        flavor=flavor,
+        version=contract_manager.plain_version,
         services=True,
     )
     assert deployment_data is not None

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -68,9 +68,9 @@ class ContractDeployer:
         flavor: Flavor,
         private_key: str,
         gas_limit: int,
-        gas_price: int=1,
-        wait: int=10,
-        contracts_version: Optional[PlainVersion]=None,
+        gas_price: int = 1,
+        wait: int = 10,
+        contracts_version: Optional[PlainVersion] = None,
     ):
         self.web3 = web3
         self.flavor = flavor

--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -223,7 +223,7 @@ def etherscan_verify_contract(
         flavor,
         services=(source_module == 'services'),
     )
-    contract_manager = ContractManager(contracts_precompiled_path(flavor))
+    contract_manager = ContractManager(flavor=flavor, path=contracts_precompiled_path(flavor))
 
     data = post_data_for_etherscan_verification(
         apikey,

--- a/raiden_contracts/tests/fixtures/base/contract_manager.py
+++ b/raiden_contracts/tests/fixtures/base/contract_manager.py
@@ -4,4 +4,4 @@ from raiden_contracts.contract_manager import ContractManager, contracts_source_
 
 @pytest.fixture
 def contracts_manager():
-    return ContractManager(flavor=Flavor.Limited, path=contracts_source_path(Flavor.Limited))
+    return ContractManager(flavor=Flavor.LIMITED, path=contracts_source_path(Flavor.LIMITED))

--- a/raiden_contracts/tests/fixtures/base/contract_manager.py
+++ b/raiden_contracts/tests/fixtures/base/contract_manager.py
@@ -4,4 +4,4 @@ from raiden_contracts.contract_manager import ContractManager, contracts_source_
 
 @pytest.fixture
 def contracts_manager():
-    return ContractManager(contracts_source_path(Flavor.Limited))
+    return ContractManager(flavor=Flavor.Limited, path=contracts_source_path(Flavor.Limited))

--- a/raiden_contracts/tests/fixtures/base/utils.py
+++ b/raiden_contracts/tests/fixtures/base/utils.py
@@ -134,7 +134,7 @@ def print_gas(web3, txn_gas, gas_measurement_results):
         print('GAS USED ' + message, gas_used + additional_gas)
         print('----------------------------------')
         gas_measurement_results[message] = gas_used + additional_gas
-        with contracts_gas_path(Flavor.Limited).open(mode='w') as target_file:
+        with contracts_gas_path(Flavor.LIMITED).open(mode='w') as target_file:
             target_file.write(json.dumps(
                 gas_measurement_results,
                 sort_keys=True,

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -28,7 +28,7 @@ def test_nonexistent_precompiled_path():
     """ An exception occurs when trying to access a field in a non-existent precompiled path """
     nonexistent_version = '0.6.0'
     with pytest.raises(FileNotFoundError):
-        ContractManager(contracts_precompiled_path(
+        ContractManager(flavor=Flavor.Limited, path=contracts_precompiled_path(
             Flavor.Limited,
             nonexistent_version,
         ))
@@ -36,7 +36,7 @@ def test_nonexistent_precompiled_path():
 
 def test_verification_overall_checksum():
     """ Tamper with the overall checksum and see failures in verify_precompiled_checksums() """
-    manager = ContractManager(contracts_source_path(Flavor.Limited))
+    manager = ContractManager(flavor=Flavor.Limited, path=contracts_source_path(Flavor.Limited))
     manager.checksum_contracts()
     manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
 
@@ -70,7 +70,7 @@ def test_verification_overall_checksum():
 
 def test_verification_contracts_checksums():
     """ Tamper with the contract checksums and see failures in verify_precompiled_checksums() """
-    manager = ContractManager(contracts_source_path(Flavor.Limited))
+    manager = ContractManager(flavor=Flavor.Limited, path=contracts_source_path(Flavor.Limited))
     manager.checksum_contracts()
     manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
 
@@ -101,7 +101,10 @@ def test_verification_contracts_checksums():
 
 def test_contracts_version():
     """ Check the value of contracts_version """
-    manager = ContractManager(contracts_precompiled_path(Flavor.Limited))
+    manager = ContractManager(
+        flavor=Flavor.Limited,
+        path=contracts_precompiled_path(Flavor.Limited),
+    )
     assert manager.contracts_version == CONTRACTS_VERSION
 
 
@@ -118,7 +121,10 @@ def test_current_development_version():
         'ServiceRegistry',
     ]
 
-    manager = ContractManager(contracts_precompiled_path(Flavor.Limited, contracts_version))
+    manager = ContractManager(
+        flavor=Flavor.Limited,
+        path=contracts_precompiled_path(Flavor.Limited, contracts_version),
+    )
     assert manager.contracts_version == contracts_version
     check_precompiled_content(manager, contract_names, PRECOMPILED_DATA_FIELDS)
 
@@ -160,7 +166,10 @@ def test_red_eyes_version():
         'TokenNetwork',
     ]
 
-    manager = ContractManager(contracts_precompiled_path(Flavor.Limited, contracts_version))
+    manager = ContractManager(
+        flavor=Flavor.Limited,
+        path=contracts_precompiled_path(Flavor.Limited, contracts_version),
+    )
     assert manager.contracts_version == contracts_version
     check_precompiled_content(manager, contract_names, PRECOMPILED_DATA_FIELDS)
 
@@ -198,7 +207,10 @@ def test_pre_limits_version():
         'TokenNetwork',
     ]
 
-    manager = ContractManager(contracts_precompiled_path(Flavor.Limited, contracts_version))
+    manager = ContractManager(
+        flavor=Flavor.Limited,
+        path=contracts_precompiled_path(Flavor.Limited, contracts_version),
+    )
     assert manager.contracts_version == contracts_version
     check_precompiled_content(manager, contract_names, PRECOMPILED_DATA_FIELDS)
 
@@ -222,7 +234,7 @@ def test_pre_limits_version():
 
 def contract_manager_meta(contracts_path):
     """ See failures in looking up non-existent ABI entries of TokenNetwork and CLOSED """
-    manager = ContractManager(contracts_path)
+    manager = ContractManager(flavor=Flavor.Limited, path=contracts_path)
 
     abi = manager.get_contract_abi(CONTRACT_TOKEN_NETWORK)
     assert isinstance(abi, list)
@@ -243,6 +255,9 @@ def test_contract_manager_compile():
 def test_contract_manager_json(tmpdir):
     """ Check the ABI in contracts.json """
     precompiled_path = Path(str(tmpdir)).joinpath('contracts.json')
-    ContractManager(contracts_source_path(Flavor.Limited)).compile_contracts(precompiled_path)
+    ContractManager(
+        flavor=Flavor.Limited,
+        path=contracts_source_path(Flavor.Limited),
+    ).compile_contracts(precompiled_path)
     # try to load contracts from a precompiled file
     contract_manager_meta(precompiled_path)

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -29,17 +29,17 @@ def test_nonexistent_precompiled_path():
     """ An exception occurs when trying to access a field in a non-existent precompiled path """
     nonexistent_version = PlainVersion('0.6.0')
     with pytest.raises(FileNotFoundError):
-        ContractManager(flavor=Flavor.Limited, path=contracts_precompiled_path(
-            Flavor.Limited,
+        ContractManager(flavor=Flavor.LIMITED, path=contracts_precompiled_path(
+            Flavor.LIMITED,
             nonexistent_version,
         ))
 
 
 def test_verification_overall_checksum():
     """ Tamper with the overall checksum and see failures in verify_precompiled_checksums() """
-    manager = ContractManager(flavor=Flavor.Limited, path=contracts_source_path(Flavor.Limited))
+    manager = ContractManager(flavor=Flavor.LIMITED, path=contracts_source_path(Flavor.LIMITED))
     manager.checksum_contracts()
-    manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
+    manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.LIMITED))
 
     assert manager.overall_checksum
     original_checksum = manager.overall_checksum
@@ -48,63 +48,63 @@ def test_verification_overall_checksum():
     manager.overall_checksum += '2'
     # Now the verification should fail
     with pytest.raises(ContractManagerVerificationError):
-        manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
+        manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.LIMITED))
 
     manager.overall_checksum = None
     with pytest.raises(ContractManagerVerificationError):
-        manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
+        manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.LIMITED))
 
     manager.overall_checksum = ''
     with pytest.raises(ContractManagerVerificationError):
-        manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
+        manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.LIMITED))
 
     checksum_fail = list(original_checksum)
     # Replace the first char with a different one
     checksum_fail[0] = list(filter(lambda x: x != checksum_fail[0], ['2', 'a']))[0]
     manager.overall_checksum = "".join(checksum_fail)
     with pytest.raises(ContractManagerVerificationError):
-        manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
+        manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.LIMITED))
 
     manager.overall_checksum = original_checksum
-    manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
+    manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.LIMITED))
 
 
 def test_verification_contracts_checksums():
     """ Tamper with the contract checksums and see failures in verify_precompiled_checksums() """
-    manager = ContractManager(flavor=Flavor.Limited, path=contracts_source_path(Flavor.Limited))
+    manager = ContractManager(flavor=Flavor.LIMITED, path=contracts_source_path(Flavor.LIMITED))
     manager.checksum_contracts()
-    manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
+    manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.LIMITED))
 
     assert manager.contracts_checksums
     for contract, checksum in manager.contracts_checksums.items():
         manager.contracts_checksums[contract] += '2'
         with pytest.raises(ContractManagerVerificationError):
-            manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
+            manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.LIMITED))
 
         manager.contracts_checksums[contract] = None  # type: ignore
         with pytest.raises(ContractManagerVerificationError):
-            manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
+            manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.LIMITED))
 
         manager.contracts_checksums[contract] = ''
         with pytest.raises(ContractManagerVerificationError):
-            manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
+            manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.LIMITED))
 
         checksum_fail = list(checksum)
         # Replace the first char with a different one
         checksum_fail[0] = list(filter(lambda x: x != checksum_fail[0], ['2', 'a']))[0]
         manager.contracts_checksums[contract] = "".join(checksum_fail)
         with pytest.raises(ContractManagerVerificationError):
-            manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
+            manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.LIMITED))
 
         manager.contracts_checksums[contract] = checksum
-        manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.Limited))
+        manager.verify_precompiled_checksums(contracts_precompiled_path(Flavor.LIMITED))
 
 
 def test_contracts_version():
     """ Check the value of contracts_version """
     manager = ContractManager(
-        flavor=Flavor.Limited,
-        path=contracts_precompiled_path(Flavor.Limited),
+        flavor=Flavor.LIMITED,
+        path=contracts_precompiled_path(Flavor.LIMITED),
     )
     assert manager.contracts_version == CONTRACTS_VERSION
 
@@ -123,17 +123,17 @@ def test_current_development_version():
     ]
 
     manager = ContractManager(
-        flavor=Flavor.Limited,
-        path=contracts_precompiled_path(Flavor.Limited, contracts_version),
+        flavor=Flavor.LIMITED,
+        path=contracts_precompiled_path(Flavor.LIMITED, contracts_version),
     )
     assert manager.contracts_version == contracts_version
     check_precompiled_content(manager, contract_names, PRECOMPILED_DATA_FIELDS)
 
-    for _, source_path in contracts_source_path(Flavor.Limited).items():
+    for _, source_path in contracts_source_path(Flavor.LIMITED).items():
         assert source_path.exists()
-    assert contracts_precompiled_path(Flavor.Limited).exists()
+    assert contracts_precompiled_path(Flavor.LIMITED).exists()
 
-    for flavor in {Flavor.Limited}:  # TODO: addd Flavor.Unlimited when ready
+    for flavor in {Flavor.LIMITED}:  # TODO: addd Flavor.Unlimited when ready
         # deployment files exist
         assert contracts_deployed_path(NETWORKNAME_TO_ID['rinkeby'], flavor).exists()
         assert contracts_deployed_path(NETWORKNAME_TO_ID['ropsten'], flavor).exists()
@@ -168,31 +168,31 @@ def test_red_eyes_version():
     ]
 
     manager = ContractManager(
-        flavor=Flavor.Limited,
-        path=contracts_precompiled_path(Flavor.Limited, contracts_version),
+        flavor=Flavor.LIMITED,
+        path=contracts_precompiled_path(Flavor.LIMITED, contracts_version),
     )
     assert manager.contracts_version == contracts_version
     check_precompiled_content(manager, contract_names, PRECOMPILED_DATA_FIELDS)
 
-    assert contracts_precompiled_path(Flavor.Limited, contracts_version).exists()
+    assert contracts_precompiled_path(Flavor.LIMITED, contracts_version).exists()
     assert contracts_deployed_path(
         NETWORKNAME_TO_ID['mainnet'],
-        Flavor.Limited,
+        Flavor.LIMITED,
         contracts_version,
     ).exists()
     assert contracts_deployed_path(
         NETWORKNAME_TO_ID['rinkeby'],
-        Flavor.Limited,
+        Flavor.LIMITED,
         contracts_version,
     ).exists()
     assert contracts_deployed_path(
         NETWORKNAME_TO_ID['ropsten'],
-        Flavor.Limited,
+        Flavor.LIMITED,
         contracts_version,
     ).exists()
     assert contracts_deployed_path(
         NETWORKNAME_TO_ID['kovan'],
-        Flavor.Limited,
+        Flavor.LIMITED,
         contracts_version,
     ).exists()
 
@@ -209,33 +209,33 @@ def test_pre_limits_version():
     ]
 
     manager = ContractManager(
-        flavor=Flavor.Limited,
-        path=contracts_precompiled_path(Flavor.Limited, contracts_version),
+        flavor=Flavor.LIMITED,
+        path=contracts_precompiled_path(Flavor.LIMITED, contracts_version),
     )
     assert manager.contracts_version == contracts_version
     check_precompiled_content(manager, contract_names, PRECOMPILED_DATA_FIELDS)
 
-    assert contracts_precompiled_path(Flavor.Limited, contracts_version).exists()
+    assert contracts_precompiled_path(Flavor.LIMITED, contracts_version).exists()
     assert contracts_deployed_path(
         NETWORKNAME_TO_ID['rinkeby'],
-        Flavor.Limited,
+        Flavor.LIMITED,
         contracts_version,
     ).exists()
     assert contracts_deployed_path(
         NETWORKNAME_TO_ID['ropsten'],
-        Flavor.Limited,
+        Flavor.LIMITED,
         contracts_version,
     ).exists()
     assert contracts_deployed_path(
         NETWORKNAME_TO_ID['kovan'],
-        Flavor.Limited,
+        Flavor.LIMITED,
         contracts_version,
     ).exists()
 
 
 def contract_manager_meta(contracts_path):
     """ See failures in looking up non-existent ABI entries of TokenNetwork and CLOSED """
-    manager = ContractManager(flavor=Flavor.Limited, path=contracts_path)
+    manager = ContractManager(flavor=Flavor.LIMITED, path=contracts_path)
 
     abi = manager.get_contract_abi(CONTRACT_TOKEN_NETWORK)
     assert isinstance(abi, list)
@@ -250,15 +250,15 @@ def contract_manager_meta(contracts_path):
 
 def test_contract_manager_compile():
     """ Check the ABI in the sources """
-    contract_manager_meta(contracts_source_path(Flavor.Limited))
+    contract_manager_meta(contracts_source_path(Flavor.LIMITED))
 
 
 def test_contract_manager_json(tmpdir):
     """ Check the ABI in contracts.json """
     precompiled_path = Path(str(tmpdir)).joinpath('contracts.json')
     ContractManager(
-        flavor=Flavor.Limited,
-        path=contracts_source_path(Flavor.Limited),
+        flavor=Flavor.LIMITED,
+        path=contracts_source_path(Flavor.LIMITED),
     ).compile_contracts(precompiled_path)
     # try to load contracts from a precompiled file
     contract_manager_meta(precompiled_path)

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -27,7 +27,7 @@ def check_precompiled_content(manager, contract_names, fields):
 
 def test_nonexistent_precompiled_path():
     """ An exception occurs when trying to access a field in a non-existent precompiled path """
-    nonexistent_version = '0.6.0'
+    nonexistent_version = PlainVersion('0.6.0')
     with pytest.raises(FileNotFoundError):
         ContractManager(flavor=Flavor.Limited, path=contracts_precompiled_path(
             Flavor.Limited,

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -14,6 +14,7 @@ from raiden_contracts.constants import (
     PRECOMPILED_DATA_FIELDS,
     CONTRACT_TOKEN_NETWORK,
     NETWORKNAME_TO_ID,
+    PlainVersion,
     ChannelEvent,
 )
 
@@ -157,7 +158,7 @@ def test_current_development_version():
 
 def test_red_eyes_version():
     """ contracts_source_path('0.4.0') exists and contains the expected files """
-    contracts_version = '0.4.0'
+    contracts_version = PlainVersion('0.4.0')
     contract_names = [
         'Utils',
         'EndpointRegistry',
@@ -198,7 +199,7 @@ def test_red_eyes_version():
 
 def test_pre_limits_version():
     """ contracts_source_path('0.3._') exists and contains the expected files """
-    contracts_version = '0.3._'
+    contracts_version = PlainVersion('0.3._')
     contract_names = [
         'Utils',
         'EndpointRegistry',

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -25,7 +25,7 @@ from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS
 from raiden_contracts.utils.type_aliases import T_Address
 
 
-@pytest.mark.parametrize("flavor", [Flavor.Limited, Flavor.Unlimited])
+@pytest.mark.parametrize("flavor", Flavor)
 def test_deploy_script_raiden(
     web3,
     flavor,
@@ -157,7 +157,7 @@ def test_deploy_script_raiden(
         deploy_raiden_contracts(deployer)
 
 
-@pytest.mark.parametrize("flavor", [Flavor.Limited, Flavor.Unlimited])
+@pytest.mark.parametrize("flavor", Flavor)
 def test_deploy_script_token(
     web3,
     flavor,
@@ -214,7 +214,7 @@ def test_deploy_script_token(
         )
 
 
-@pytest.mark.parametrize("flavor", [Flavor.Limited, Flavor.Unlimited])
+@pytest.mark.parametrize("flavor", Flavor)
 def test_deploy_script_register(
     web3,
     flavor,
@@ -267,7 +267,7 @@ def test_deploy_script_register(
     assert isinstance(token_network_address, T_Address)
 
 
-@pytest.mark.parametrize("flavor", [Flavor.Limited, Flavor.Unlimited])
+@pytest.mark.parametrize("flavor", Flavor)
 def test_deploy_script_service(
         web3,
         flavor,

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ class VerifyContracts(Command):
             contracts_source_path,
             Flavor,
         )
-        for flavor in {Flavor.Limited, Flavor.Unlimited}:
+        for flavor in Flavor:
             manager = ContractManager(
                 flavor=flavor,
                 path=contracts_source_path(flavor),
@@ -131,7 +131,7 @@ class CompileContracts(Command):
             Flavor,
         )
 
-        for flavor in {Flavor.Limited, Flavor.Unlimited}:
+        for flavor in Flavor:
             contract_manager = ContractManager(flavor=flavor, path=contracts_source_path(flavor))
             contract_manager.compile_contracts(
                 contracts_precompiled_path(flavor),

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,10 @@ class VerifyContracts(Command):
             Flavor,
         )
         for flavor in {Flavor.Limited, Flavor.Unlimited}:
-            manager = ContractManager(contracts_source_path(flavor))
+            manager = ContractManager(
+                flavor=flavor,
+                path=contracts_source_path(flavor),
+            )
             manager.checksum_contracts()
             manager.verify_precompiled_checksums(contracts_precompiled_path(flavor))
 
@@ -129,7 +132,7 @@ class CompileContracts(Command):
         )
 
         for flavor in {Flavor.Limited, Flavor.Unlimited}:
-            contract_manager = ContractManager(contracts_source_path(flavor))
+            contract_manager = ContractManager(flavor=flavor, path=contracts_source_path(flavor))
             contract_manager.compile_contracts(
                 contracts_precompiled_path(flavor),
             )


### PR DESCRIPTION
This fixes #637.  More importantly, this PR fixes a bug of the deployment script that tries to write to `data_0.8.0_unlimited_unlimited`.