### PR TITLE
Remove unused `token_network` argument introduced in

### DIFF
--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -24,12 +24,7 @@ def get_token_network_registry(deploy_tester_contract):
 
 
 @pytest.fixture
-def token_network_registry_contract(
-        deploy_tester_contract,
-        secret_registry_contract,
-        web3,
-        custom_token,
-):
+def token_network_registry_contract(deploy_tester_contract, secret_registry_contract, web3):
     """Deployed TokenNetworkRegistry contract"""
     return deploy_tester_contract(
         CONTRACT_TOKEN_NETWORK_REGISTRY,


### PR DESCRIPTION
14451796913a2942e00f13fa9fcf1404c3a200ce