### PR TITLE
Allow fixtures to be reused across multiple tests

### DIFF
--- a/raiden_contracts/tests/fixtures/base/address.py
+++ b/raiden_contracts/tests/fixtures/base/address.py
@@ -4,7 +4,7 @@ from typing import Callable
 import pytest
 from eth_utils import denoms, is_address
 
-from raiden_contracts.tests.utils.constants import MAX_UINT256
+from raiden_contracts.tests.utils.constants import MAX_UINT256, FAUCET_ADDRESS
 from raiden_contracts.utils.signature import private_key_to_address
 
 
@@ -25,35 +25,16 @@ def get_random_address(get_random_privkey) -> Callable:
     return f
 
 
-@pytest.fixture(scope='session')
-def faucet_private_key():
-    """Returns private key of a faucet used in tests"""
-    return '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-
-
-@pytest.fixture(scope='session')
-def faucet_address(faucet_private_key):
-    """Returns address of a faucet used in tests"""
-    return private_key_to_address(faucet_private_key)
-
-
-@pytest.fixture(scope='session')
-def contract_deployer_address(faucet_address):
-    """Returns address of the contract deployer used in tests"""
-    return faucet_address
-
-
 @pytest.fixture
 def send_funds(
     ethereum_tester,
     custom_token,
-    faucet_address,
 ):
     """Send some tokens and eth to specified address."""
     def f(target: str):
         assert is_address(target)
         ethereum_tester.send_transaction({
-            'from': faucet_address,
+            'from': FAUCET_ADDRESS,
             'to': target,
             'gas': 21000,
             'value': 1 * denoms.ether,  # pylint: disable=E1101
@@ -61,5 +42,5 @@ def send_funds(
         custom_token.functions.transfer(
             target,
             10000,
-        ).transact({'from': faucet_address})
+        ).transact({'from': FAUCET_ADDRESS})
     return f

--- a/raiden_contracts/tests/fixtures/base/address.py
+++ b/raiden_contracts/tests/fixtures/base/address.py
@@ -1,28 +1,7 @@
-import random
-from typing import Callable
-
 import pytest
 from eth_utils import denoms, is_address
 
-from raiden_contracts.tests.utils.constants import MAX_UINT256, FAUCET_ADDRESS
-from raiden_contracts.utils.signature import private_key_to_address
-
-
-@pytest.fixture
-def get_random_privkey() -> Callable:
-    """Returns a random private key"""
-    return lambda: "0x%064x" % random.randint(
-        1,
-        MAX_UINT256,
-    )
-
-
-@pytest.fixture
-def get_random_address(get_random_privkey) -> Callable:
-    """Returns a random valid ethereum address"""
-    def f():
-        return private_key_to_address(get_random_privkey())
-    return f
+from raiden_contracts.tests.utils.constants import FAUCET_ADDRESS
 
 
 @pytest.fixture

--- a/raiden_contracts/tests/fixtures/base/contract_manager.py
+++ b/raiden_contracts/tests/fixtures/base/contract_manager.py
@@ -2,6 +2,6 @@ import pytest
 from raiden_contracts.contract_manager import ContractManager, contracts_source_path
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def contracts_manager():
     return ContractManager(contracts_source_path())

--- a/raiden_contracts/tests/fixtures/base/utils.py
+++ b/raiden_contracts/tests/fixtures/base/utils.py
@@ -5,7 +5,7 @@ from eth_tester.exceptions import TransactionFailed
 from raiden_contracts.contract_manager import contracts_gas_path
 from raiden_contracts.utils.logs import LogHandler
 from raiden_contracts.utils.signature import private_key_to_address
-from raiden_contracts.tests.utils.constants import passphrase, CONTRACT_DEPLOYER_ADDRESS
+from raiden_contracts.tests.utils.constants import passphrase
 from raiden_contracts.tests.utils import get_random_privkey
 from eth_utils import denoms, is_same_address
 
@@ -28,7 +28,7 @@ def create_accounts(web3):
     return get
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def create_account(web3, ethereum_tester):
     def get():
         privkey = get_random_privkey()
@@ -48,7 +48,7 @@ def create_account(web3, ethereum_tester):
     return get
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def get_accounts(create_account):
     def get(number):
         return [
@@ -59,7 +59,7 @@ def get_accounts(create_account):
     return get
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def get_private_key(web3, ethereum_tester):
     def get(account_address):
         keys = [
@@ -74,22 +74,7 @@ def get_private_key(web3, ethereum_tester):
     return get
 
 
-@pytest.fixture
-def create_contract(chain):
-    def get(contract_type, arguments, transaction=None):
-        if not transaction:
-            transaction = {}
-        if 'from' not in transaction:
-            transaction['from'] = CONTRACT_DEPLOYER_ADDRESS
-
-        deploy_txn_hash = contract_type.deploy(transaction=transaction, args=arguments)
-        contract_address = chain.wait.for_contract_address(deploy_txn_hash)
-        contract = contract_type(address=contract_address)
-        return contract
-    return get
-
-
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def event_handler(contracts_manager, web3):
     def get(contract=None, address=None, abi=None):
         if contract:

--- a/raiden_contracts/tests/fixtures/base/utils.py
+++ b/raiden_contracts/tests/fixtures/base/utils.py
@@ -6,6 +6,7 @@ from raiden_contracts.contract_manager import contracts_gas_path
 from raiden_contracts.utils.logs import LogHandler
 from raiden_contracts.utils.signature import private_key_to_address
 from raiden_contracts.tests.utils.constants import passphrase, CONTRACT_DEPLOYER_ADDRESS
+from raiden_contracts.tests.utils import get_random_privkey
 from eth_utils import denoms, is_same_address
 
 
@@ -28,7 +29,7 @@ def create_accounts(web3):
 
 
 @pytest.fixture
-def create_account(web3, ethereum_tester, get_random_privkey):
+def create_account(web3, ethereum_tester):
     def get():
         privkey = get_random_privkey()
         address = private_key_to_address(privkey)

--- a/raiden_contracts/tests/fixtures/base/utils.py
+++ b/raiden_contracts/tests/fixtures/base/utils.py
@@ -5,7 +5,7 @@ from eth_tester.exceptions import TransactionFailed
 from raiden_contracts.contract_manager import contracts_gas_path
 from raiden_contracts.utils.logs import LogHandler
 from raiden_contracts.utils.signature import private_key_to_address
-from raiden_contracts.tests.utils.constants import passphrase
+from raiden_contracts.tests.utils.constants import passphrase, CONTRACT_DEPLOYER_ADDRESS
 from eth_utils import denoms, is_same_address
 
 
@@ -74,12 +74,12 @@ def get_private_key(web3, ethereum_tester):
 
 
 @pytest.fixture
-def create_contract(chain, contract_deployer_address):
+def create_contract(chain):
     def get(contract_type, arguments, transaction=None):
         if not transaction:
             transaction = {}
         if 'from' not in transaction:
-            transaction['from'] = contract_deployer_address
+            transaction['from'] = CONTRACT_DEPLOYER_ADDRESS
 
         deploy_txn_hash = contract_type.deploy(transaction=transaction, args=arguments)
         contract_address = chain.wait.for_contract_address(deploy_txn_hash)

--- a/raiden_contracts/tests/fixtures/base/web3_fixtures.py
+++ b/raiden_contracts/tests/fixtures/base/web3_fixtures.py
@@ -6,7 +6,7 @@ from eth_tester import EthereumTester, PyEVMBackend
 from web3 import Web3
 from web3.providers.eth_tester import EthereumTesterProvider
 
-from raiden_contracts.utils.type_aliases import Address
+from raiden_contracts.tests.utils.constants import FAUCET_PRIVATE_KEY, FAUCET_ADDRESS
 
 DEFAULT_TIMEOUT = 5
 DEFAULT_RETRY_INTERVAL = 3
@@ -37,8 +37,6 @@ def patch_genesis_gas_limit():
 @pytest.fixture(scope='session')
 def web3(
         patch_genesis_gas_limit,
-        faucet_private_key: str,
-        faucet_address: Address,
         ethereum_tester,
 ):
     """Returns an initialized Web3 instance"""
@@ -46,12 +44,12 @@ def web3(
     web3 = Web3(provider)
 
     # add faucet account to tester
-    ethereum_tester.add_account(faucet_private_key)
+    ethereum_tester.add_account(FAUCET_PRIVATE_KEY)
 
     # make faucet rich
     ethereum_tester.send_transaction({
         'from': ethereum_tester.get_accounts()[0],
-        'to': faucet_address,
+        'to': FAUCET_ADDRESS,
         'gas': 21000,
         'value': FAUCET_ALLOWANCE,
     })

--- a/raiden_contracts/tests/fixtures/base/web3_fixtures.py
+++ b/raiden_contracts/tests/fixtures/base/web3_fixtures.py
@@ -57,15 +57,15 @@ def web3(
     yield web3
 
 
-@pytest.fixture
-def revert_chain(web3: Web3):
-    """Reverts chain to its initial state.
-    If this fixture is used, the chain will revert on each test teardown.
+@pytest.fixture(autouse=True)
+def auto_revert_chain(web3: Web3):
+    """Reverts the chain to its before the test run
+
+    This reverts the side effects created during the test run, so that we can
+    reuse the same chain and contract deployments for other tests.
 
     This is useful especially when using ethereum tester - its log filtering
     is very slow once enough events are present on-chain.
-
-    Note that `deploy_contract` fixture uses `revert_chain` by default.
     """
     snapshot_id = web3.testing.snapshot()
     yield

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -19,6 +19,7 @@ from raiden_contracts.tests.utils import (
     EMPTY_LOCKSROOT,
     fake_bytes,
 )
+from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
 
 
 @pytest.fixture()
@@ -46,9 +47,9 @@ def create_channel(token_network):
 
 
 @pytest.fixture()
-def assign_tokens(contract_deployer_address, token_network, custom_token):
+def assign_tokens(token_network, custom_token):
     def get(participant, deposit):
-        owner = contract_deployer_address
+        owner = CONTRACT_DEPLOYER_ADDRESS
         balance = custom_token.functions.balanceOf(participant).call()
         owner_balance = custom_token.functions.balanceOf(owner).call()
         amount = max(deposit - balance, 0)

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -22,7 +22,7 @@ from raiden_contracts.tests.utils import (
 from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
 
 
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def create_channel(token_network):
     def get(A, B, settle_timeout=TEST_SETTLE_TIMEOUT_MIN):
         # Make sure there is no channel existent on chain
@@ -595,7 +595,7 @@ def withdraw_state_tests(custom_token, token_network):
     return get
 
 
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def create_balance_proof(token_network, get_private_key):
     def get(
             channel_identifier,
@@ -635,7 +635,7 @@ def create_balance_proof(token_network, get_private_key):
     return get
 
 
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def create_balance_proof_update_signature(token_network, get_private_key):
     def get(
             participant,

--- a/raiden_contracts/tests/fixtures/contracts.py
+++ b/raiden_contracts/tests/fixtures/contracts.py
@@ -6,7 +6,7 @@ from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def deploy_tester_contract(
         web3,
         contracts_manager,
@@ -27,8 +27,8 @@ def deploy_tester_contract(
     return f
 
 
-@pytest.fixture
-def deploy_contract_txhash(revert_chain):
+@pytest.fixture(scope='session')
+def deploy_contract_txhash():
     """Returns a function that deploys a compiled contract, returning a txhash"""
     def fn(
             web3,
@@ -44,8 +44,8 @@ def deploy_contract_txhash(revert_chain):
     return fn
 
 
-@pytest.fixture
-def deploy_contract(revert_chain, deploy_contract_txhash):
+@pytest.fixture(scope='session')
+def deploy_contract(deploy_contract_txhash):
     """Returns a function that deploys a compiled contract"""
     def fn(
             web3,

--- a/raiden_contracts/tests/fixtures/contracts.py
+++ b/raiden_contracts/tests/fixtures/contracts.py
@@ -11,7 +11,6 @@ def deploy_tester_contract(
         web3,
         contracts_manager,
         deploy_contract,
-        get_random_address,
 ):
     """Returns a function that can be used to deploy a named contract,
     using conract manager to compile the bytecode and get the ABI"""
@@ -69,7 +68,6 @@ def deploy_tester_contract_txhash(
         web3,
         contracts_manager,
         deploy_contract_txhash,
-        get_random_address,
 ):
     """Returns a function that can be used to deploy a named contract,
     but returning txhash only"""

--- a/raiden_contracts/tests/fixtures/contracts.py
+++ b/raiden_contracts/tests/fixtures/contracts.py
@@ -1,6 +1,8 @@
 import pytest
 import logging
 
+from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
+
 log = logging.getLogger(__name__)
 
 
@@ -9,7 +11,6 @@ def deploy_tester_contract(
         web3,
         contracts_manager,
         deploy_contract,
-        contract_deployer_address,
         get_random_address,
 ):
     """Returns a function that can be used to deploy a named contract,
@@ -18,7 +19,7 @@ def deploy_tester_contract(
         json_contract = contracts_manager.get_contract(contract_name)
         contract = deploy_contract(
             web3,
-            contract_deployer_address,
+            CONTRACT_DEPLOYER_ADDRESS,
             json_contract['abi'],
             json_contract['bin'],
             args,
@@ -68,7 +69,6 @@ def deploy_tester_contract_txhash(
         web3,
         contracts_manager,
         deploy_contract_txhash,
-        contract_deployer_address,
         get_random_address,
 ):
     """Returns a function that can be used to deploy a named contract,
@@ -77,7 +77,7 @@ def deploy_tester_contract_txhash(
         json_contract = contracts_manager.get_contract(contract_name)
         txhash = deploy_contract_txhash(
             web3,
-            contract_deployer_address,
+            CONTRACT_DEPLOYER_ADDRESS,
             json_contract['abi'],
             json_contract['bin'],
             args,

--- a/raiden_contracts/tests/fixtures/monitoring_service.py
+++ b/raiden_contracts/tests/fixtures/monitoring_service.py
@@ -3,29 +3,22 @@ from raiden_contracts.constants import CONTRACT_MONITORING_SERVICE
 from raiden_contracts.utils.proofs import sign_reward_proof
 
 
-@pytest.fixture()
-def get_monitoring_service(deploy_tester_contract):
-    def get(arguments, transaction=None):
-        return deploy_tester_contract(
-            CONTRACT_MONITORING_SERVICE,
-            {},
-            arguments,
-        )
-    return get
-
-
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def monitoring_service_external(
-    get_monitoring_service,
+    deploy_tester_contract,
     custom_token,
     service_registry,
     uninitialized_user_deposit_contract,
 ):
-    return get_monitoring_service([
-        custom_token.address,
-        service_registry.address,
-        uninitialized_user_deposit_contract.address,
-    ])
+    return deploy_tester_contract(
+        CONTRACT_MONITORING_SERVICE,
+        {},
+        [
+            custom_token.address,
+            service_registry.address,
+            uninitialized_user_deposit_contract.address,
+        ],
+    )
 
 
 @pytest.fixture()

--- a/raiden_contracts/tests/fixtures/one_to_n.py
+++ b/raiden_contracts/tests/fixtures/one_to_n.py
@@ -3,7 +3,7 @@ import pytest
 from raiden_contracts.constants import CONTRACT_ONE_TO_N
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def one_to_n_contract(
     deploy_tester_contract,
     uninitialized_user_deposit_contract,

--- a/raiden_contracts/tests/fixtures/secret_registry.py
+++ b/raiden_contracts/tests/fixtures/secret_registry.py
@@ -3,7 +3,7 @@ import pytest
 from raiden_contracts.constants import CONTRACT_SECRET_REGISTRY
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def secret_registry_contract(deploy_tester_contract):
     """Deployed SecretRegistry contract"""
     return deploy_tester_contract(CONTRACT_SECRET_REGISTRY)

--- a/raiden_contracts/tests/fixtures/service_registry_fixtures.py
+++ b/raiden_contracts/tests/fixtures/service_registry_fixtures.py
@@ -3,18 +3,9 @@ from raiden_contracts.constants import CONTRACT_SERVICE_REGISTRY
 
 
 @pytest.fixture()
-def get_service_registry(deploy_tester_contract):
-    def get(arguments, transaction=None):
-        return deploy_tester_contract(
-            CONTRACT_SERVICE_REGISTRY,
-            {},
-            arguments,
-        )
-    return get
-
-
-@pytest.fixture()
-def service_registry(get_service_registry, custom_token):
-    return get_service_registry([
-        custom_token.address,
-    ])
+def service_registry(deploy_tester_contract, custom_token):
+    return deploy_tester_contract(
+        CONTRACT_SERVICE_REGISTRY,
+        {},
+        [custom_token.address],
+    )

--- a/raiden_contracts/tests/fixtures/service_registry_fixtures.py
+++ b/raiden_contracts/tests/fixtures/service_registry_fixtures.py
@@ -2,7 +2,7 @@ import pytest
 from raiden_contracts.constants import CONTRACT_SERVICE_REGISTRY
 
 
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def service_registry(deploy_tester_contract, custom_token):
     return deploy_tester_contract(
         CONTRACT_SERVICE_REGISTRY,

--- a/raiden_contracts/tests/fixtures/token.py
+++ b/raiden_contracts/tests/fixtures/token.py
@@ -4,38 +4,31 @@ from raiden_contracts.constants import (
     CONTRACT_CUSTOM_TOKEN,
 )
 
-token_args = [
-    (10 ** 26, 18, CONTRACT_CUSTOM_TOKEN, 'TKN'),
-]
+token_args = (10 ** 26, 18, CONTRACT_CUSTOM_TOKEN, 'TKN')
 
 
-@pytest.fixture(params=token_args)
-def custom_token_params(request):
-    return request.param
-
-
-@pytest.fixture()
-def custom_token_factory(deploy_tester_contract, custom_token_params):
+@pytest.fixture(scope='session')
+def custom_token_factory(deploy_tester_contract):
     """A function that deploys a CustomToken contract"""
     def f():
         return deploy_tester_contract(
             CONTRACT_CUSTOM_TOKEN,
             [],
-            custom_token_params,
+            token_args,
         )
     return f
 
 
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def custom_token(custom_token_factory):
     """Deploy CustomToken contract"""
     return custom_token_factory()
 
 
 @pytest.fixture()
-def human_standard_token(deploy_token_contract, custom_token_params):
+def human_standard_token(deploy_token_contract):
     """Deploy HumanStandardToken contract"""
-    return deploy_token_contract(*custom_token_params)
+    return deploy_token_contract(*token_args)
 
 
 @pytest.fixture

--- a/raiden_contracts/tests/fixtures/token_network_fixtures.py
+++ b/raiden_contracts/tests/fixtures/token_network_fixtures.py
@@ -1,4 +1,6 @@
 import pytest
+from web3.contract import get_event_data
+
 from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
@@ -9,7 +11,7 @@ from raiden_contracts.constants import (
     MAX_ETH_CHANNEL_PARTICIPANT,
     MAX_ETH_TOKEN_NETWORK,
 )
-from web3.contract import get_event_data
+from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
 
 
 @pytest.fixture
@@ -26,10 +28,9 @@ def get_token_network(web3, deploy_tester_contract):
 
 @pytest.fixture
 def register_token_network(
-        contract_deployer_address,
-        web3,
-        token_network_registry_contract,
-        contracts_manager,
+    web3,
+    token_network_registry_contract,
+    contracts_manager,
 ):
     """Returns a function that uses token_network_registry fixture to register
     and deploy a new token network"""
@@ -42,7 +43,7 @@ def register_token_network(
             token_address,
             channel_participant_deposit_limit,
             token_network_deposit_limit,
-        ).transact({'from': contract_deployer_address})
+        ).transact({'from': CONTRACT_DEPLOYER_ADDRESS})
         tx_receipt = web3.eth.getTransactionReceipt(tx_hash)
         event_abi = contracts_manager.get_event_abi(
             CONTRACT_TOKEN_NETWORK_REGISTRY,
@@ -121,7 +122,6 @@ def token_network_contract(
 @pytest.fixture()
 def token_network_external(
         web3,
-        contract_deployer_address,
         get_token_network,
         custom_token,
         secret_registry_contract,
@@ -134,7 +134,7 @@ def token_network_external(
         int(web3.version.network),
         TEST_SETTLE_TIMEOUT_MIN,
         TEST_SETTLE_TIMEOUT_MAX,
-        contract_deployer_address,
+        CONTRACT_DEPLOYER_ADDRESS,
         channel_participant_deposit_limit,
         token_network_deposit_limit,
     ])

--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -24,7 +24,7 @@ def get_token_network_registry(deploy_tester_contract):
     return get
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def token_network_registry_contract(deploy_tester_contract, secret_registry_contract, web3):
     """Deployed TokenNetworkRegistry contract"""
     return deploy_tester_contract(

--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -10,6 +10,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MIN,
     TEST_SETTLE_TIMEOUT_MAX,
 )
+from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
 
 
 @pytest.fixture()
@@ -50,7 +51,6 @@ def add_and_register_token(
         web3,
         token_network_registry_contract,
         deploy_token_contract,
-        contract_deployer_address,
         contracts_manager,
         channel_participant_deposit_limit,
         token_network_deposit_limit,
@@ -62,7 +62,7 @@ def add_and_register_token(
             token_contract.address,
             channel_participant_deposit_limit,
             token_network_deposit_limit,
-        ).transact({'from': contract_deployer_address})
+        ).transact({'from': CONTRACT_DEPLOYER_ADDRESS})
         (tx_receipt, _) = check_succesful_tx(web3, txid)
         assert len(tx_receipt['logs']) == 1
         event_abi = contracts_manager.get_event_abi(

--- a/raiden_contracts/tests/fixtures/user_deposit.py
+++ b/raiden_contracts/tests/fixtures/user_deposit.py
@@ -3,7 +3,7 @@ import pytest
 from raiden_contracts.constants import CONTRACT_USER_DEPOSIT
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def uninitialized_user_deposit_contract(
         deploy_tester_contract,
         custom_token,
@@ -15,7 +15,7 @@ def uninitialized_user_deposit_contract(
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def user_deposit_contract(
         uninitialized_user_deposit_contract,
         monitoring_service_external,

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -22,12 +22,12 @@ from raiden_contracts.deploy.__main__ import (
     verify_service_contracts_deployment_data,
 )
 from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS, FAUCET_PRIVATE_KEY
+from raiden_contracts.tests.utils import get_random_privkey
 from raiden_contracts.utils.type_aliases import T_Address
 
 
 def test_deploy_script_raiden(
         web3,
-        get_random_privkey,
 ):
     """ Run raiden contracts deployment function and tamper with deployed_contracts_info
 
@@ -145,7 +145,6 @@ def test_deploy_script_raiden(
 
 def test_deploy_script_token(
     web3,
-    get_random_privkey,
 ):
     """ Run test token deployment function used in the deployment script
 
@@ -197,7 +196,6 @@ def test_deploy_script_token(
 
 def test_deploy_script_register(
         web3,
-        get_random_privkey,
         channel_participant_deposit_limit,
         token_network_deposit_limit,
 ):
@@ -253,7 +251,6 @@ def test_deploy_script_register(
 
 def test_deploy_script_service(
         web3,
-        get_random_privkey,
 ):
     """ Run deploy_service_contracts() used in the deployment script
 

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -21,13 +21,12 @@ from raiden_contracts.deploy.__main__ import (
     verify_deployment_data,
     verify_service_contracts_deployment_data,
 )
-from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS
+from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS, FAUCET_PRIVATE_KEY
 from raiden_contracts.utils.type_aliases import T_Address
 
 
 def test_deploy_script_raiden(
         web3,
-        faucet_private_key,
         get_random_privkey,
 ):
     """ Run raiden contracts deployment function and tamper with deployed_contracts_info
@@ -42,7 +41,7 @@ def test_deploy_script_raiden(
     gas_limit = 5860000
     deployer = ContractDeployer(
         web3=web3,
-        private_key=faucet_private_key,
+        private_key=FAUCET_PRIVATE_KEY,
         gas_limit=gas_limit,
         gas_price=1,
         wait=10,
@@ -146,7 +145,6 @@ def test_deploy_script_raiden(
 
 def test_deploy_script_token(
     web3,
-    faucet_private_key,
     get_random_privkey,
 ):
     """ Run test token deployment function used in the deployment script
@@ -160,7 +158,7 @@ def test_deploy_script_token(
     token_type = 'CustomToken'
     deployer = ContractDeployer(
         web3=web3,
-        private_key=faucet_private_key,
+        private_key=FAUCET_PRIVATE_KEY,
         gas_limit=gas_limit,
         gas_price=1,
         wait=10,
@@ -199,7 +197,6 @@ def test_deploy_script_token(
 
 def test_deploy_script_register(
         web3,
-        faucet_private_key,
         get_random_privkey,
         channel_participant_deposit_limit,
         token_network_deposit_limit,
@@ -215,7 +212,7 @@ def test_deploy_script_register(
     token_type = 'CustomToken'
     deployer = ContractDeployer(
         web3=web3,
-        private_key=faucet_private_key,
+        private_key=FAUCET_PRIVATE_KEY,
         gas_limit=gas_limit,
         gas_price=1,
         wait=10,
@@ -256,7 +253,6 @@ def test_deploy_script_register(
 
 def test_deploy_script_service(
         web3,
-        faucet_private_key,
         get_random_privkey,
 ):
     """ Run deploy_service_contracts() used in the deployment script
@@ -266,7 +262,7 @@ def test_deploy_script_service(
     gas_limit = 5860000
     deployer = ContractDeployer(
         web3=web3,
-        private_key=faucet_private_key,
+        private_key=FAUCET_PRIVATE_KEY,
         gas_limit=gas_limit,
         gas_price=1,
         wait=10,

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -9,7 +9,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MIN,
     TEST_SETTLE_TIMEOUT_MAX,
 )
-from raiden_contracts.tests.utils.constants import EMPTY_LOCKSROOT
+from raiden_contracts.tests.utils.constants import EMPTY_LOCKSROOT, CONTRACT_DEPLOYER_ADDRESS
 from raiden_contracts.utils.pending_transfers import get_pending_transfers_tree, get_locked_amount
 from raiden_contracts.utils.merkle import get_merkle_root
 from raiden_contracts.utils.proofs import sign_one_to_n_iou
@@ -71,7 +71,6 @@ def test_token_network_create(
         custom_token,
         secret_registry_contract,
         token_network_registry_contract,
-        contract_deployer_address,
         channel_participant_deposit_limit,
         token_network_deposit_limit,
 ):
@@ -80,7 +79,7 @@ def test_token_network_create(
         custom_token.address,
         channel_participant_deposit_limit,
         token_network_deposit_limit,
-    ).transact({'from': contract_deployer_address})
+    ).transact({'from': CONTRACT_DEPLOYER_ADDRESS})
 
     print_gas(txn_hash, CONTRACT_TOKEN_NETWORK_REGISTRY + ' createERC20TokenNetwork')
 

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -1,3 +1,4 @@
+import pytest
 from raiden_contracts.constants import (
     CONTRACT_ENDPOINT_REGISTRY,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
@@ -66,6 +67,7 @@ def test_token_network_deployment(
     print_gas(txhash, CONTRACT_TOKEN_NETWORK + ' DEPLOYMENT')
 
 
+@pytest.mark.usefixtures('no_token_network')
 def test_token_network_create(
         print_gas,
         custom_token,

--- a/raiden_contracts/tests/test_token_network.py
+++ b/raiden_contracts/tests/test_token_network.py
@@ -341,6 +341,7 @@ def test_token_network_variables(token_network, token_network_test_utils):
     assert token_network.functions.signature_prefix().call() == '\x19Ethereum Signed Message:\n'
 
 
+@pytest.mark.usefixtures('no_token_network')
 def test_constructor_not_registered(
         custom_token,
         secret_registry_contract,

--- a/raiden_contracts/tests/test_token_network_registry.py
+++ b/raiden_contracts/tests/test_token_network_registry.py
@@ -9,6 +9,7 @@ from raiden_contracts.constants import (
 from raiden_contracts.tests.utils.constants import (
     EMPTY_ADDRESS,
     FAKE_ADDRESS,
+    CONTRACT_DEPLOYER_ADDRESS,
 )
 from raiden_contracts.utils.events import check_token_network_created
 from web3.exceptions import ValidationError
@@ -209,7 +210,6 @@ def test_constructor_call_state(web3, get_token_network_registry, secret_registr
 
 def test_create_erc20_token_network_call(
         token_network_registry_contract,
-        contract_deployer_address,
         custom_token,
         get_accounts,
         channel_participant_deposit_limit,
@@ -277,7 +277,7 @@ def test_create_erc20_token_network_call(
         custom_token.address,
         channel_participant_deposit_limit,
         token_network_deposit_limit,
-    ).transact({'from': contract_deployer_address})
+    ).transact({'from': CONTRACT_DEPLOYER_ADDRESS})
 
 
 def test_create_erc20_token_network(
@@ -318,7 +318,6 @@ def test_create_erc20_token_network(
 
 
 def test_create_erc20_token_network_twice_fails(
-        contract_deployer_address,
         token_network_registry_contract,
         custom_token,
         channel_participant_deposit_limit,
@@ -327,7 +326,7 @@ def test_create_erc20_token_network_twice_fails(
     """ Only one TokenNetwork should be creatable from a TokenNetworkRegistry """
 
     token_network_registry_contract.transact(
-        {'from': contract_deployer_address},
+        {'from': CONTRACT_DEPLOYER_ADDRESS},
     ).createERC20TokenNetwork(
         custom_token.address,
         channel_participant_deposit_limit,
@@ -336,7 +335,7 @@ def test_create_erc20_token_network_twice_fails(
 
     with pytest.raises(TransactionFailed):
         token_network_registry_contract.transact(
-            {'from': contract_deployer_address},
+            {'from': CONTRACT_DEPLOYER_ADDRESS},
         ).createERC20TokenNetwork(
             custom_token.address,
             channel_participant_deposit_limit,

--- a/raiden_contracts/tests/test_token_network_registry.py
+++ b/raiden_contracts/tests/test_token_network_registry.py
@@ -21,6 +21,7 @@ def test_version(token_network_registry_contract):
     assert version == CONTRACTS_VERSION
 
 
+@pytest.mark.usefixtures('no_token_network')
 def test_constructor_call(
         web3,
         get_token_network_registry,
@@ -189,6 +190,7 @@ def test_constructor_call(
     ])
 
 
+@pytest.mark.usefixtures('no_token_network')
 def test_constructor_call_state(web3, get_token_network_registry, secret_registry_contract):
     """ The constructor should set the parameters into the storage of the contract """
 
@@ -208,6 +210,7 @@ def test_constructor_call_state(web3, get_token_network_registry, secret_registr
     assert 30 == registry.functions.max_token_networks().call()
 
 
+@pytest.mark.usefixtures('no_token_network')
 def test_create_erc20_token_network_call(
         token_network_registry_contract,
         custom_token,
@@ -280,6 +283,7 @@ def test_create_erc20_token_network_call(
     ).transact({'from': CONTRACT_DEPLOYER_ADDRESS})
 
 
+@pytest.mark.usefixtures('no_token_network')
 def test_create_erc20_token_network(
         register_token_network,
         token_network_registry_contract,
@@ -317,6 +321,7 @@ def test_create_erc20_token_network(
     assert token_network.functions.settlement_timeout_max().call() == settle_timeout_max
 
 
+@pytest.mark.usefixtures('no_token_network')
 def test_create_erc20_token_network_twice_fails(
         token_network_registry_contract,
         custom_token,
@@ -343,6 +348,7 @@ def test_create_erc20_token_network_twice_fails(
         )
 
 
+@pytest.mark.usefixtures('no_token_network')
 def test_events(
         register_token_network,
         token_network_registry_contract,

--- a/raiden_contracts/tests/utils/__init__.py
+++ b/raiden_contracts/tests/utils/__init__.py
@@ -4,3 +4,4 @@ from .constants import *
 from .mock import *
 from .contracts import *
 from .channel import *
+from .address import *

--- a/raiden_contracts/tests/utils/address.py
+++ b/raiden_contracts/tests/utils/address.py
@@ -1,0 +1,17 @@
+import random
+
+from raiden_contracts.tests.utils.constants import MAX_UINT256
+from raiden_contracts.utils.signature import private_key_to_address
+
+
+def get_random_privkey() -> str:
+    """Returns a random private key"""
+    return "0x%064x" % random.randint(
+        1,
+        MAX_UINT256,
+    )
+
+
+def get_random_address() -> str:
+    """Returns a random valid ethereum address"""
+    return private_key_to_address(get_random_privkey())

--- a/raiden_contracts/tests/utils/constants.py
+++ b/raiden_contracts/tests/utils/constants.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-
+from raiden_contracts.utils.signature import private_key_to_address
 
 MAX_UINT256 = 2 ** 256 - 1
 MAX_UINT192 = 2 ** 192 - 1
@@ -11,6 +11,9 @@ EMPTY_ADDITIONAL_HASH = b'\x00' * 32
 EMPTY_LOCKSROOT = b'\x00' * 32
 EMPTY_SIGNATURE = b'\x00' * 65
 passphrase = '0'
+FAUCET_PRIVATE_KEY = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+FAUCET_ADDRESS = private_key_to_address(FAUCET_PRIVATE_KEY)
+CONTRACT_DEPLOYER_ADDRESS = FAUCET_ADDRESS
 
 
 class TestLockIndex(IntEnum):


### PR DESCRIPTION
This only reduces the runtime by ~25%, but further speed increases can be gained by updating the scope of more fixtures.

I've also tried to reduce the number of fixtures to keep the test setup complexity down a bit. See the single commit messages for more details.