### PR TITLE
Mark slow tests

### DIFF
--- a/raiden_contracts/tests/test_channel_settle_unlock_state.py
+++ b/raiden_contracts/tests/test_channel_settle_unlock_state.py
@@ -259,6 +259,7 @@ def test_settlement_outcome(
     return f
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize('channel_test_values', channel_settle_test_values)
 @pytest.mark.parametrize('tested_range', ('one_old', 'both_old_1', 'both_old_2'))
 # This test is split in three so it does not time out on travis
@@ -371,6 +372,7 @@ def test_channel_settle_old_balance_proof_values(
                         )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize('channel_test_values', channel_settle_invalid_test_values)
 def test_channel_settle_invalid_balance_proof_values(
         web3,

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -701,6 +701,7 @@ def test_channel_unlock(
     assert balance_contract == pre_balance_contract - values_B.locked
 
 
+@pytest.mark.slow
 def test_channel_settle_and_unlock(
         web3,
         token_network,

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -26,6 +26,7 @@ from raiden_contracts.tests.utils import get_random_privkey
 from raiden_contracts.utils.type_aliases import T_Address
 
 
+@pytest.mark.slow
 def test_deploy_script_raiden(
         web3,
 ):
@@ -194,6 +195,7 @@ def test_deploy_script_token(
         )
 
 
+@pytest.mark.slow
 def test_deploy_script_register(
         web3,
         channel_participant_deposit_limit,
@@ -249,6 +251,7 @@ def test_deploy_script_register(
     assert isinstance(token_network_address, T_Address)
 
 
+@pytest.mark.slow
 def test_deploy_script_service(
         web3,
 ):


### PR DESCRIPTION
This allows skipping tests with `pytest -m 'not slow'`. Now, I can get a
run of all non-slow tests down to 90s in my machine (also using `-n 4`).