### PR TITLE
Not Changelog but CHANGELOG

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include Changelog.md
+include CHANGELOG.md
 include requirements.txt
 include raiden_contracts/constants.py
 include raiden_contracts/data*/contracts.json


### PR DESCRIPTION
Before this commit, `raiden-contracts` source package did not contain the changelog.  This commit fixes that problem.

[skip ci]