### PR TITLE
Run and enable isort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,15 @@ install:
 	pip install -r requirements.txt
 	pip install -e .
 
+ISORT_PARAMS = --ignore-whitespace --settings-path ./ --recursive raiden_contracts/
+
 lint:
 	flake8 raiden_contracts/
 	pylint -E raiden_contracts/
+	isort $(ISORT_PARAMS) --check-only
+
+isort:
+	isort $(ISORT_PARAMS)
 
 mypy:
 	mypy --ignore-missing-imports --check-untyped-defs raiden_contracts

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -4,15 +4,15 @@ import json
 from json import JSONDecodeError
 from os import chdir
 from pathlib import Path
+from typing import Dict, Optional, Union
+
 from solc import compile_files
-from typing import Dict, Union, Optional
 
 from raiden_contracts.constants import (
     CONTRACTS_VERSION,
     ID_TO_NETWORKNAME,
     PRECOMPILED_DATA_FIELDS,
 )
-
 
 _BASE = Path(__file__).parent
 

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -4,45 +4,42 @@ A simple Python script to deploy compiled contracts.
 import functools
 import json
 import logging
-import click
-
 from logging import getLogger
-from mypy_extensions import TypedDict
 from typing import Any, Dict, List, Optional
 
+import click
 from eth_utils import denoms, encode_hex, is_address, to_checksum_address
+from mypy_extensions import TypedDict
 from web3 import HTTPProvider, Web3
 from web3.contract import Contract, ContractFunction
 from web3.middleware import construct_sign_and_send_raw_middleware, geth_poa_middleware
 
-
 from raiden_contracts.constants import (
     CONTRACT_CUSTOM_TOKEN,
     CONTRACT_ENDPOINT_REGISTRY,
+    CONTRACT_MONITORING_SERVICE,
     CONTRACT_ONE_TO_N,
     CONTRACT_SECRET_REGISTRY,
+    CONTRACT_SERVICE_REGISTRY,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
-    CONTRACT_SERVICE_REGISTRY,
-    CONTRACT_MONITORING_SERVICE,
+    CONTRACTS_VERSION,
     DEPLOY_SETTLE_TIMEOUT_MAX,
     DEPLOY_SETTLE_TIMEOUT_MIN,
-    CONTRACTS_VERSION,
 )
 from raiden_contracts.contract_manager import (
     ContractManager,
     contract_version_string,
+    contracts_deployed_path,
     contracts_precompiled_path,
     contracts_source_path,
-    contracts_deployed_path,
     get_contracts_deployed,
 )
-from raiden_contracts.utils.transaction import check_succesful_tx
 from raiden_contracts.utils.bytecode import runtime_hexcode
 from raiden_contracts.utils.private_key import get_private_key
 from raiden_contracts.utils.signature import private_key_to_address
+from raiden_contracts.utils.transaction import check_succesful_tx
 from raiden_contracts.utils.type_aliases import Address
-
 
 LOG = getLogger(__name__)
 

--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -1,21 +1,21 @@
 import json
-import click
 import pprint
-import requests
 import subprocess
+from pathlib import Path
 from time import sleep
 from typing import Dict, Optional
-from pathlib import Path
 
+import click
+import requests
 from eth_abi import encode_abi
 
 from raiden_contracts.constants import (
     CONTRACT_ENDPOINT_REGISTRY,
-    CONTRACT_SECRET_REGISTRY,
-    CONTRACT_TOKEN_NETWORK_REGISTRY,
-    CONTRACT_SERVICE_REGISTRY,
     CONTRACT_MONITORING_SERVICE,
     CONTRACT_ONE_TO_N,
+    CONTRACT_SECRET_REGISTRY,
+    CONTRACT_SERVICE_REGISTRY,
+    CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
 )
 from raiden_contracts.contract_manager import (

--- a/raiden_contracts/tests/deprecation_switch_testnet.py
+++ b/raiden_contracts/tests/deprecation_switch_testnet.py
@@ -1,23 +1,23 @@
-import click
 from logging import getLogger
+
+import click
 from eth_utils import encode_hex
 
-from raiden_contracts.utils.transaction import check_succesful_tx
+from raiden_contracts.constants import (
+    CONTRACT_CUSTOM_TOKEN,
+    CONTRACT_TOKEN_NETWORK,
+    CONTRACT_TOKEN_NETWORK_REGISTRY,
+    DEPLOY_SETTLE_TIMEOUT_MIN,
+    MAX_ETH_CHANNEL_PARTICIPANT,
+    MAX_ETH_TOKEN_NETWORK,
+)
 from raiden_contracts.deploy.__main__ import (
-    setup_ctx,
     deploy_raiden_contracts,
     deploy_token_contract,
     register_token_network,
+    setup_ctx,
 )
-from raiden_contracts.constants import (
-    CONTRACT_CUSTOM_TOKEN,
-    CONTRACT_TOKEN_NETWORK_REGISTRY,
-    CONTRACT_TOKEN_NETWORK,
-    MAX_ETH_CHANNEL_PARTICIPANT,
-    MAX_ETH_TOKEN_NETWORK,
-    DEPLOY_SETTLE_TIMEOUT_MIN,
-)
-
+from raiden_contracts.utils.transaction import check_succesful_tx
 
 log = getLogger(__name__)
 

--- a/raiden_contracts/tests/fixtures/__init__.py
+++ b/raiden_contracts/tests/fixtures/__init__.py
@@ -1,15 +1,15 @@
 # flake8: noqa
 
 from .base import *
+from .channel import *
 from .contracts import *
+from .endpoint_registry import *
+from .monitoring_service import *
+from .one_to_n import *
+from .secret_registry import *
+from .service_registry_fixtures import *
 from .test_contracts import *
 from .token import *
-from .secret_registry import *
-from .endpoint_registry import *
 from .token_network_fixtures import *
 from .token_network_registry import *
-from .channel import *
-from .monitoring_service import *
-from .service_registry_fixtures import *
 from .user_deposit import *
-from .one_to_n import *

--- a/raiden_contracts/tests/fixtures/base/__init__.py
+++ b/raiden_contracts/tests/fixtures/base/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
 from .address import *
-from .web3_fixtures import *
 from .contract_manager import *
 from .utils import *
+from .web3_fixtures import *

--- a/raiden_contracts/tests/fixtures/base/contract_manager.py
+++ b/raiden_contracts/tests/fixtures/base/contract_manager.py
@@ -1,4 +1,5 @@
 import pytest
+
 from raiden_contracts.contract_manager import ContractManager, contracts_source_path
 
 

--- a/raiden_contracts/tests/fixtures/base/utils.py
+++ b/raiden_contracts/tests/fixtures/base/utils.py
@@ -1,13 +1,15 @@
 import json
-import pytest
 from typing import Dict
+
+import pytest
 from eth_tester.exceptions import TransactionFailed
+from eth_utils import denoms, is_same_address
+
 from raiden_contracts.contract_manager import contracts_gas_path
+from raiden_contracts.tests.utils import get_random_privkey
+from raiden_contracts.tests.utils.constants import passphrase
 from raiden_contracts.utils.logs import LogHandler
 from raiden_contracts.utils.signature import private_key_to_address
-from raiden_contracts.tests.utils.constants import passphrase
-from raiden_contracts.tests.utils import get_random_privkey
-from eth_utils import denoms, is_same_address
 
 
 @pytest.fixture()

--- a/raiden_contracts/tests/fixtures/base/web3_fixtures.py
+++ b/raiden_contracts/tests/fixtures/base/web3_fixtures.py
@@ -1,12 +1,12 @@
 import logging
-import pytest
 
-from eth_utils import denoms
+import pytest
 from eth_tester import EthereumTester, PyEVMBackend
+from eth_utils import denoms
 from web3 import Web3
 from web3.providers.eth_tester import EthereumTesterProvider
 
-from raiden_contracts.tests.utils.constants import FAUCET_PRIVATE_KEY, FAUCET_ADDRESS
+from raiden_contracts.tests.utils.constants import FAUCET_ADDRESS, FAUCET_PRIVATE_KEY
 
 DEFAULT_TIMEOUT = 5
 DEFAULT_RETRY_INTERVAL = 3

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -1,25 +1,23 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
-from raiden_contracts.constants import (
-    TEST_SETTLE_TIMEOUT_MIN,
-    ChannelState,
+
+from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN, ChannelState
+from raiden_contracts.tests.utils import (
+    EMPTY_LOCKSROOT,
+    ChannelValues,
+    fake_bytes,
+    get_onchain_settlement_amounts,
+    get_participants_hash,
+    get_settlement_amounts,
 )
+from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
 from raiden_contracts.utils.proofs import (
-    sign_balance_proof,
     hash_balance_data,
+    sign_balance_proof,
     sign_balance_proof_update_message,
     sign_cooperative_settle_message,
     sign_withdraw_message,
 )
-from raiden_contracts.tests.utils import (
-    get_settlement_amounts,
-    get_onchain_settlement_amounts,
-    ChannelValues,
-    get_participants_hash,
-    EMPTY_LOCKSROOT,
-    fake_bytes,
-)
-from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
 
 
 @pytest.fixture(scope='session')

--- a/raiden_contracts/tests/fixtures/channel_test_values.py
+++ b/raiden_contracts/tests/fixtures/channel_test_values.py
@@ -1,6 +1,5 @@
 from raiden_contracts.tests.utils import MAX_UINT256, ChannelValues
 
-
 # We must cover the edge cases documented in
 # https://github.com/raiden-network/raiden-contracts/issues/188
 # The scope is to make sure that if someone uses an old balance proof, this cannot be used as

--- a/raiden_contracts/tests/fixtures/contracts.py
+++ b/raiden_contracts/tests/fixtures/contracts.py
@@ -1,5 +1,6 @@
-import pytest
 import logging
+
+import pytest
 
 from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
 

--- a/raiden_contracts/tests/fixtures/monitoring_service.py
+++ b/raiden_contracts/tests/fixtures/monitoring_service.py
@@ -1,4 +1,5 @@
 import pytest
+
 from raiden_contracts.constants import CONTRACT_MONITORING_SERVICE
 from raiden_contracts.utils.proofs import sign_reward_proof
 

--- a/raiden_contracts/tests/fixtures/service_registry_fixtures.py
+++ b/raiden_contracts/tests/fixtures/service_registry_fixtures.py
@@ -1,4 +1,5 @@
 import pytest
+
 from raiden_contracts.constants import CONTRACT_SERVICE_REGISTRY
 
 

--- a/raiden_contracts/tests/fixtures/test_contracts.py
+++ b/raiden_contracts/tests/fixtures/test_contracts.py
@@ -1,9 +1,6 @@
 import pytest
 
-from raiden_contracts.constants import (
-    TEST_SETTLE_TIMEOUT_MIN,
-    TEST_SETTLE_TIMEOUT_MAX,
-)
+from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MAX, TEST_SETTLE_TIMEOUT_MIN
 
 
 @pytest.fixture()

--- a/raiden_contracts/tests/fixtures/token.py
+++ b/raiden_contracts/tests/fixtures/token.py
@@ -1,9 +1,6 @@
 import pytest
-from raiden_contracts.constants import (
-    CONTRACT_HUMAN_STANDARD_TOKEN,
-    CONTRACT_CUSTOM_TOKEN,
-)
 
+from raiden_contracts.constants import CONTRACT_CUSTOM_TOKEN, CONTRACT_HUMAN_STANDARD_TOKEN
 
 CUSTOM_TOKEN_TOTAL_SUPPLY = 10 ** 26
 

--- a/raiden_contracts/tests/fixtures/token_network_fixtures.py
+++ b/raiden_contracts/tests/fixtures/token_network_fixtures.py
@@ -2,14 +2,14 @@ import pytest
 from web3.contract import get_event_data
 
 from raiden_contracts.constants import (
+    CONTRACT_SECRET_REGISTRY,
     CONTRACT_TOKEN_NETWORK,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
-    CONTRACT_SECRET_REGISTRY,
     EVENT_TOKEN_NETWORK_CREATED,
-    TEST_SETTLE_TIMEOUT_MIN,
-    TEST_SETTLE_TIMEOUT_MAX,
     MAX_ETH_CHANNEL_PARTICIPANT,
     MAX_ETH_TOKEN_NETWORK,
+    TEST_SETTLE_TIMEOUT_MAX,
+    TEST_SETTLE_TIMEOUT_MIN,
 )
 from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
 

--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -1,16 +1,16 @@
 import pytest
-from web3.contract import get_event_data
 from eth_utils import is_address
+from web3.contract import get_event_data
 
-from raiden_contracts.utils.transaction import check_succesful_tx
 from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     EVENT_TOKEN_NETWORK_CREATED,
-    TEST_SETTLE_TIMEOUT_MIN,
     TEST_SETTLE_TIMEOUT_MAX,
+    TEST_SETTLE_TIMEOUT_MIN,
 )
 from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
+from raiden_contracts.utils.transaction import check_succesful_tx
 
 
 @pytest.fixture()

--- a/raiden_contracts/tests/property/strategies.py
+++ b/raiden_contracts/tests/property/strategies.py
@@ -1,10 +1,5 @@
 from eth_utils import keccak
-from hypothesis.strategies import (
-    binary,
-    composite,
-    integers,
-)
-
+from hypothesis.strategies import binary, composite, integers
 
 UINT64_MAX = 2 ** 64 - 1
 UINT256_MAX = 2 ** 256 - 1

--- a/raiden_contracts/tests/property/test_tokennetwork.py
+++ b/raiden_contracts/tests/property/test_tokennetwork.py
@@ -2,25 +2,15 @@
 import contextlib
 
 import eth_tester.backends.pyevm.main as pyevm_main
-
 from coincurve import PrivateKey
-from eth_utils import (
-    encode_hex,
-    to_canonical_address,
-    to_checksum_address,
-)
 from eth_tester.exceptions import TransactionFailed
+from eth_utils import encode_hex, to_canonical_address, to_checksum_address
 from hypothesis import assume
 from hypothesis.stateful import GenericStateMachine
-from hypothesis.strategies import (
-    integers,
-    just,
-    one_of,
-    sampled_from,
-    tuples,
-)
-from raiden_contracts.tests.fixtures.base.web3_fixtures import ethereum_tester
-from raiden_contracts.utils.signature import private_key_to_address
+from hypothesis.strategies import integers, just, one_of, sampled_from, tuples
+from web3 import Web3
+from web3.exceptions import ValidationError
+
 from raiden_contracts.constants import (
     CONTRACT_SECRET_REGISTRY,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
@@ -29,17 +19,17 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MAX,
     TEST_SETTLE_TIMEOUT_MIN,
 )
+from raiden_contracts.tests.fixtures.base.web3_fixtures import ethereum_tester
+from raiden_contracts.tests.property.strategies import direct_transfer
 from raiden_contracts.tests.utils import (
     EMPTY_LOCKSROOT,
     deploy_contract,
     deploy_custom_token,
-    get_web3,
     get_token_network,
+    get_web3,
     make_address,
 )
-from raiden_contracts.tests.property.strategies import direct_transfer
-from web3 import Web3
-from web3.exceptions import ValidationError
+from raiden_contracts.utils.signature import private_key_to_address
 
 DEPOSIT = 'deposit'
 CLOSE = 'close'

--- a/raiden_contracts/tests/test_channel_close.py
+++ b/raiden_contracts/tests/test_channel_close.py
@@ -1,20 +1,16 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
 
-from raiden_contracts.constants import (
-    TEST_SETTLE_TIMEOUT_MIN,
-    ChannelEvent,
-    ChannelState,
-)
-from raiden_contracts.utils.events import check_channel_closed
+from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN, ChannelEvent, ChannelState
 from raiden_contracts.tests.utils import (
+    EMPTY_ADDITIONAL_HASH,
     EMPTY_BALANCE_HASH,
     EMPTY_LOCKSROOT,
-    EMPTY_ADDITIONAL_HASH,
     EMPTY_SIGNATURE,
-    fake_bytes,
     ChannelValues,
+    fake_bytes,
 )
+from raiden_contracts.utils.events import check_channel_closed
 
 
 def test_close_nonexistent_channel(

--- a/raiden_contracts/tests/test_channel_cooperative_settle.py
+++ b/raiden_contracts/tests/test_channel_cooperative_settle.py
@@ -1,9 +1,10 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
-from raiden_contracts.utils.events import check_channel_settled
-from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS
-from raiden_contracts.constants import ChannelEvent
 from web3.exceptions import ValidationError
+
+from raiden_contracts.constants import ChannelEvent
+from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS
+from raiden_contracts.utils.events import check_channel_settled
 
 
 @pytest.mark.skip(reason='Delayed until another milestone')

--- a/raiden_contracts/tests/test_channel_deposit.py
+++ b/raiden_contracts/tests/test_channel_deposit.py
@@ -1,18 +1,19 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
 from web3.exceptions import ValidationError
-from raiden_contracts.constants import ChannelEvent, TEST_SETTLE_TIMEOUT_MIN
-from raiden_contracts.utils.events import check_new_deposit
+
+from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN, ChannelEvent
 from raiden_contracts.tests.fixtures.channel import call_settle
 from raiden_contracts.tests.utils import (
-    EMPTY_BALANCE_HASH,
     EMPTY_ADDITIONAL_HASH,
-    EMPTY_SIGNATURE,
-    MAX_UINT256,
     EMPTY_ADDRESS,
+    EMPTY_BALANCE_HASH,
+    EMPTY_SIGNATURE,
     FAKE_ADDRESS,
+    MAX_UINT256,
     ChannelValues,
 )
+from raiden_contracts.utils.events import check_new_deposit
 
 
 def test_deposit_channel_call(token_network, custom_token, create_channel, get_accounts):

--- a/raiden_contracts/tests/test_channel_open.py
+++ b/raiden_contracts/tests/test_channel_open.py
@@ -1,25 +1,28 @@
-import pytest
 from itertools import permutations
+
+import pytest
 from eth_tester.exceptions import TransactionFailed
+from web3.exceptions import ValidationError
+
 from raiden_contracts.constants import (
-    TEST_SETTLE_TIMEOUT_MIN,
     TEST_SETTLE_TIMEOUT_MAX,
+    TEST_SETTLE_TIMEOUT_MIN,
     ChannelEvent,
-    ChannelState,
     ChannelInfoIndex,
+    ChannelState,
     ParticipantInfoIndex,
 )
-from raiden_contracts.utils.events import check_channel_opened
-from web3.exceptions import ValidationError
-from .utils import get_participants_hash
 from raiden_contracts.tests.utils import (
+    EMPTY_ADDITIONAL_HASH,
+    EMPTY_ADDRESS,
     EMPTY_BALANCE_HASH,
     EMPTY_LOCKSROOT,
-    EMPTY_ADDITIONAL_HASH,
     EMPTY_SIGNATURE,
-    EMPTY_ADDRESS,
     FAKE_ADDRESS,
 )
+from raiden_contracts.utils.events import check_channel_opened
+
+from .utils import get_participants_hash
 
 
 def test_open_channel_call(token_network, get_accounts):

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -1,25 +1,23 @@
+from copy import deepcopy
+
 import pytest
 from eth_tester.exceptions import TransactionFailed
-from copy import deepcopy
-from raiden_contracts.constants import (
-    ChannelEvent,
-    ChannelState,
-    TEST_SETTLE_TIMEOUT_MIN,
-)
-from raiden_contracts.utils.events import check_channel_settled
+
+from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN, ChannelEvent, ChannelState
 from raiden_contracts.tests.fixtures.channel import call_settle
 from raiden_contracts.tests.utils import (
+    EMPTY_ADDITIONAL_HASH,
     EMPTY_BALANCE_HASH,
     EMPTY_LOCKSROOT,
-    EMPTY_ADDITIONAL_HASH,
     EMPTY_SIGNATURE,
     MAX_UINT256,
-    fake_bytes,
-    get_settlement_amounts,
-    get_onchain_settlement_amounts,
     ChannelValues,
+    fake_bytes,
+    get_onchain_settlement_amounts,
+    get_settlement_amounts,
 )
 from raiden_contracts.utils import get_pending_transfers_tree
+from raiden_contracts.utils.events import check_channel_settled
 
 
 def test_settle_no_bp_success(

--- a/raiden_contracts/tests/test_channel_settle_unlock_state.py
+++ b/raiden_contracts/tests/test_channel_settle_unlock_state.py
@@ -1,25 +1,24 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
+
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN, ParticipantInfoIndex
 from raiden_contracts.tests.fixtures.channel import call_settle
 from raiden_contracts.tests.fixtures.channel_test_values import (
-    channel_settle_test_values,
     channel_settle_invalid_test_values,
-)
-from raiden_contracts.utils import (
-    get_pending_transfers_tree,
+    channel_settle_test_values,
 )
 from raiden_contracts.tests.utils import (
     EMPTY_LOCKSROOT,
-    get_settlement_amounts,
-    get_onchain_settlement_amounts,
-    get_expected_after_settlement_unlock_amounts,
     are_balance_proofs_valid,
-    were_balance_proofs_valid,
-    is_balance_proof_old,
-    get_unlocked_amount,
+    get_expected_after_settlement_unlock_amounts,
+    get_onchain_settlement_amounts,
+    get_settlement_amounts,
     get_total_available_deposit,
+    get_unlocked_amount,
+    is_balance_proof_old,
+    were_balance_proofs_valid,
 )
+from raiden_contracts.utils import get_pending_transfers_tree
 
 
 @pytest.fixture()

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -1,25 +1,23 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
-from raiden_contracts.constants import ChannelEvent
-from raiden_contracts.utils.events import check_channel_unlocked
-from raiden_contracts.utils.merkle import get_merkle_root
-from raiden_contracts.utils import (
-    get_pending_transfers_tree,
-    get_packed_transfers,
-    get_locked_amount,
-    random_secret,
-)
-from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN
+
+from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN, ChannelEvent, ParticipantInfoIndex
+from raiden_contracts.tests.fixtures.channel import call_settle
 from raiden_contracts.tests.utils import (
     EMPTY_LOCKSROOT,
-    fake_bytes,
-    TestLockIndex,
     ChannelValues,
+    TestLockIndex,
+    fake_bytes,
     get_unlocked_amount,
 )
-from raiden_contracts.tests.fixtures.channel import call_settle
-from raiden_contracts.constants import ParticipantInfoIndex
-
+from raiden_contracts.utils import (
+    get_locked_amount,
+    get_packed_transfers,
+    get_pending_transfers_tree,
+    random_secret,
+)
+from raiden_contracts.utils.events import check_channel_unlocked
+from raiden_contracts.utils.merkle import get_merkle_root
 
 # Account names like 'A', 'B', 'C' are intuitive here.
 # pytest: disable=C0103

--- a/raiden_contracts/tests/test_channel_update_transfer.py
+++ b/raiden_contracts/tests/test_channel_update_transfer.py
@@ -3,21 +3,17 @@ from collections import namedtuple
 import pytest
 from eth_tester.exceptions import TransactionFailed
 
-from raiden_contracts.constants import (
-    ChannelEvent,
-    ChannelState,
-    TEST_SETTLE_TIMEOUT_MIN,
-)
-from raiden_contracts.utils.events import check_transfer_updated
+from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN, ChannelEvent, ChannelState
 from raiden_contracts.tests.utils import (
+    EMPTY_ADDITIONAL_HASH,
+    EMPTY_ADDRESS,
     EMPTY_BALANCE_HASH,
     EMPTY_LOCKSROOT,
-    EMPTY_ADDITIONAL_HASH,
     EMPTY_SIGNATURE,
-    EMPTY_ADDRESS,
-    fake_bytes,
     ChannelValues,
+    fake_bytes,
 )
+from raiden_contracts.utils.events import check_transfer_updated
 
 
 def test_update_call(

--- a/raiden_contracts/tests/test_channel_withdraw.py
+++ b/raiden_contracts/tests/test_channel_withdraw.py
@@ -1,20 +1,17 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
 from web3.exceptions import ValidationError
-from raiden_contracts.utils.events import check_withdraw
-from raiden_contracts.constants import (
-    ChannelEvent,
-    ChannelState,
-    TEST_SETTLE_TIMEOUT_MIN,
-)
+
+from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN, ChannelEvent, ChannelState
 from raiden_contracts.tests.utils import (
+    EMPTY_ADDITIONAL_HASH,
+    EMPTY_ADDRESS,
     EMPTY_BALANCE_HASH,
     EMPTY_LOCKSROOT,
-    EMPTY_ADDITIONAL_HASH,
     EMPTY_SIGNATURE,
-    EMPTY_ADDRESS,
     MAX_UINT256,
 )
+from raiden_contracts.utils.events import check_withdraw
 
 
 @pytest.mark.skip(reason='Delayed until another milestone')

--- a/raiden_contracts/tests/test_contract_limits.py
+++ b/raiden_contracts/tests/test_contract_limits.py
@@ -1,11 +1,12 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
+
 from raiden_contracts.constants import (
     MAX_ETH_CHANNEL_PARTICIPANT,
     MAX_ETH_TOKEN_NETWORK,
-    ParticipantInfoIndex,
-    TEST_SETTLE_TIMEOUT_MIN,
     TEST_SETTLE_TIMEOUT_MAX,
+    TEST_SETTLE_TIMEOUT_MIN,
+    ParticipantInfoIndex,
 )
 
 

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -1,19 +1,20 @@
-import pytest
 from pathlib import Path
 
+import pytest
+
+from raiden_contracts.constants import (
+    CONTRACT_TOKEN_NETWORK,
+    CONTRACTS_VERSION,
+    NETWORKNAME_TO_ID,
+    PRECOMPILED_DATA_FIELDS,
+    ChannelEvent,
+)
 from raiden_contracts.contract_manager import (
     ContractManager,
-    contracts_source_path,
-    contracts_precompiled_path,
-    contracts_deployed_path,
     ContractManagerVerificationError,
-)
-from raiden_contracts.constants import (
-    CONTRACTS_VERSION,
-    PRECOMPILED_DATA_FIELDS,
-    CONTRACT_TOKEN_NETWORK,
-    NETWORKNAME_TO_ID,
-    ChannelEvent,
+    contracts_deployed_path,
+    contracts_precompiled_path,
+    contracts_source_path,
 )
 
 

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -1,6 +1,7 @@
+from copy import deepcopy
+
 import pytest
 from eth_utils import ValidationError
-from copy import deepcopy
 
 from raiden_contracts.constants import (
     CONTRACT_ENDPOINT_REGISTRY,
@@ -21,8 +22,8 @@ from raiden_contracts.deploy.__main__ import (
     verify_deployment_data,
     verify_service_contracts_deployment_data,
 )
-from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS, FAUCET_PRIVATE_KEY
 from raiden_contracts.tests.utils import get_random_privkey
+from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS, FAUCET_PRIVATE_KEY
 from raiden_contracts.utils.type_aliases import T_Address
 
 

--- a/raiden_contracts/tests/test_deprecation_switch.py
+++ b/raiden_contracts/tests/test_deprecation_switch.py
@@ -1,16 +1,17 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
 from web3.contract import get_event_data
+
 from raiden_contracts.constants import (
-    CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_TOKEN_NETWORK,
+    CONTRACT_TOKEN_NETWORK_REGISTRY,
     EVENT_TOKEN_NETWORK_CREATED,
-    TEST_SETTLE_TIMEOUT_MIN,
     TEST_SETTLE_TIMEOUT_MAX,
+    TEST_SETTLE_TIMEOUT_MIN,
 )
-from raiden_contracts.utils.pending_transfers import get_pending_transfers_tree
-from raiden_contracts.tests.utils import ChannelValues
 from raiden_contracts.tests.fixtures.channel import call_settle
+from raiden_contracts.tests.utils import ChannelValues
+from raiden_contracts.utils.pending_transfers import get_pending_transfers_tree
 
 
 def test_deprecation_executor(

--- a/raiden_contracts/tests/test_endpointregistry.py
+++ b/raiden_contracts/tests/test_endpointregistry.py
@@ -1,5 +1,5 @@
+from raiden_contracts.constants import CONTRACTS_VERSION, EVENT_ADDRESS_REGISTERED
 from raiden_contracts.utils.events import check_address_registered
-from raiden_contracts.constants import EVENT_ADDRESS_REGISTERED, CONTRACTS_VERSION
 
 
 def test_version(endpoint_registry_contract):

--- a/raiden_contracts/tests/test_etherscan_verify.py
+++ b/raiden_contracts/tests/test_etherscan_verify.py
@@ -1,6 +1,7 @@
-from click.testing import CliRunner
-import requests_mock
 from typing import Dict, List
+
+import requests_mock
+from click.testing import CliRunner
 
 from raiden_contracts.constants import (
     CONTRACT_ENDPOINT_REGISTRY,
@@ -20,7 +21,6 @@ from raiden_contracts.deploy.etherscan_verify import (
     join_sources,
     post_data_for_etherscan_verification,
 )
-
 
 contract_name = 'DummyContract'
 

--- a/raiden_contracts/tests/test_monitoring_service.py
+++ b/raiden_contracts/tests/test_monitoring_service.py
@@ -1,11 +1,10 @@
 import pytest
 from eth_abi import encode_single
-from web3 import Web3
 from eth_tester.exceptions import TransactionFailed
+from web3 import Web3
 
 from raiden_contracts.constants import MonitoringServiceEvent
 from raiden_contracts.tests.utils.constants import EMPTY_LOCKSROOT
-
 
 REWARD_AMOUNT = 10
 

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -1,18 +1,19 @@
 import pytest
+
 from raiden_contracts.constants import (
     CONTRACT_ENDPOINT_REGISTRY,
-    CONTRACT_TOKEN_NETWORK_REGISTRY,
-    CONTRACT_TOKEN_NETWORK,
-    CONTRACT_SECRET_REGISTRY,
     CONTRACT_MONITORING_SERVICE,
     CONTRACT_ONE_TO_N,
+    CONTRACT_SECRET_REGISTRY,
+    CONTRACT_TOKEN_NETWORK,
+    CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
-    TEST_SETTLE_TIMEOUT_MIN,
     TEST_SETTLE_TIMEOUT_MAX,
+    TEST_SETTLE_TIMEOUT_MIN,
 )
-from raiden_contracts.tests.utils.constants import EMPTY_LOCKSROOT, CONTRACT_DEPLOYER_ADDRESS
-from raiden_contracts.utils.pending_transfers import get_pending_transfers_tree, get_locked_amount
+from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS, EMPTY_LOCKSROOT
 from raiden_contracts.utils.merkle import get_merkle_root
+from raiden_contracts.utils.pending_transfers import get_locked_amount, get_pending_transfers_tree
 from raiden_contracts.utils.proofs import sign_one_to_n_iou
 
 

--- a/raiden_contracts/tests/test_secret_registry.py
+++ b/raiden_contracts/tests/test_secret_registry.py
@@ -1,9 +1,10 @@
 import pytest
 from web3 import Web3
 from web3.exceptions import ValidationError
-from raiden_contracts.constants import EVENT_SECRET_REVEALED, CONTRACTS_VERSION
-from raiden_contracts.utils.events import check_secret_revealed, check_secrets_revealed
+
+from raiden_contracts.constants import CONTRACTS_VERSION, EVENT_SECRET_REVEALED
 from raiden_contracts.tests.utils.mock import fake_bytes
+from raiden_contracts.utils.events import check_secret_revealed, check_secrets_revealed
 
 
 def test_version(secret_registry_contract):

--- a/raiden_contracts/tests/test_token.py
+++ b/raiden_contracts/tests/test_token.py
@@ -1,9 +1,7 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
-from raiden_contracts.constants import (
-    CONTRACT_HUMAN_STANDARD_TOKEN,
-    CONTRACT_CUSTOM_TOKEN,
-)
+
+from raiden_contracts.constants import CONTRACT_CUSTOM_TOKEN, CONTRACT_HUMAN_STANDARD_TOKEN
 from raiden_contracts.utils.bytecode import runtime_hexcode
 
 

--- a/raiden_contracts/tests/test_token_network.py
+++ b/raiden_contracts/tests/test_token_network.py
@@ -1,16 +1,12 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
 
-from raiden_contracts.tests.utils.constants import (
-    EMPTY_ADDRESS,
-    FAKE_ADDRESS,
-    MAX_UINT256,
-)
 from raiden_contracts.constants import (
     CONTRACTS_VERSION,
-    TEST_SETTLE_TIMEOUT_MIN,
     TEST_SETTLE_TIMEOUT_MAX,
+    TEST_SETTLE_TIMEOUT_MIN,
 )
+from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS, FAKE_ADDRESS, MAX_UINT256
 
 
 def test_version(token_network):

--- a/raiden_contracts/tests/test_token_network_registry.py
+++ b/raiden_contracts/tests/test_token_network_registry.py
@@ -1,18 +1,19 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
+from web3.exceptions import ValidationError
+
 from raiden_contracts.constants import (
     CONTRACTS_VERSION,
     EVENT_TOKEN_NETWORK_CREATED,
-    TEST_SETTLE_TIMEOUT_MIN,
     TEST_SETTLE_TIMEOUT_MAX,
+    TEST_SETTLE_TIMEOUT_MIN,
 )
 from raiden_contracts.tests.utils.constants import (
+    CONTRACT_DEPLOYER_ADDRESS,
     EMPTY_ADDRESS,
     FAKE_ADDRESS,
-    CONTRACT_DEPLOYER_ADDRESS,
 )
 from raiden_contracts.utils.events import check_token_network_created
-from web3.exceptions import ValidationError
 
 
 def test_version(token_network_registry_contract):

--- a/raiden_contracts/tests/unit/test_recover_from_signature.py
+++ b/raiden_contracts/tests/unit/test_recover_from_signature.py
@@ -1,10 +1,10 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
 from web3 import Web3
-from raiden_contracts.utils.proofs import hash_balance_proof
-from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS
-from raiden_contracts.utils.signature import sign
 
+from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS
+from raiden_contracts.utils.proofs import hash_balance_proof
+from raiden_contracts.utils.signature import sign
 
 # pylint: disable=E1120
 

--- a/raiden_contracts/tests/unit/test_settle_timeout_invariant.py
+++ b/raiden_contracts/tests/unit/test_settle_timeout_invariant.py
@@ -1,7 +1,7 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
 
-from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN, TEST_SETTLE_TIMEOUT_MAX
+from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MAX, TEST_SETTLE_TIMEOUT_MIN
 from raiden_contracts.tests.utils import fake_bytes
 
 

--- a/raiden_contracts/tests/unit/test_unit_internals.py
+++ b/raiden_contracts/tests/unit/test_unit_internals.py
@@ -1,7 +1,7 @@
 from itertools import chain, product
 
 import pytest
-from eth_tester.constants import UINT256_MIN, UINT256_MAX
+from eth_tester.constants import UINT256_MAX, UINT256_MIN
 from web3.exceptions import ValidationError
 
 

--- a/raiden_contracts/tests/unit/test_unit_signatures.py
+++ b/raiden_contracts/tests/unit/test_unit_signatures.py
@@ -1,5 +1,6 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
+
 from raiden_contracts.tests.utils import fake_bytes
 
 

--- a/raiden_contracts/tests/utils/__init__.py
+++ b/raiden_contracts/tests/utils/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 
-from .constants import *
-from .mock import *
-from .contracts import *
-from .channel import *
 from .address import *
+from .channel import *
+from .constants import *
+from .contracts import *
+from .mock import *

--- a/raiden_contracts/tests/utils/channel.py
+++ b/raiden_contracts/tests/utils/channel.py
@@ -1,11 +1,12 @@
 from collections import namedtuple
+
 from eth_utils import keccak, to_canonical_address
+
 from raiden_contracts.tests.utils.constants import (
-    EMPTY_LOCKSROOT,
     EMPTY_ADDITIONAL_HASH,
+    EMPTY_LOCKSROOT,
     MAX_UINT256,
 )
-
 
 SettlementValues = namedtuple('SettlementValues', [
     'participant1_balance',

--- a/raiden_contracts/tests/utils/constants.py
+++ b/raiden_contracts/tests/utils/constants.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+
 from raiden_contracts.utils.signature import private_key_to_address
 
 MAX_UINT256 = 2 ** 256 - 1

--- a/raiden_contracts/tests/utils/contracts.py
+++ b/raiden_contracts/tests/utils/contracts.py
@@ -1,13 +1,9 @@
 from web3 import Web3
 from web3.providers.eth_tester import EthereumTesterProvider
 
-from raiden_contracts.utils.signature import private_key_to_address
-
+from raiden_contracts.constants import CONTRACT_CUSTOM_TOKEN, CONTRACT_TOKEN_NETWORK
 from raiden_contracts.tests.fixtures.base.web3_fixtures import FAUCET_ALLOWANCE
-from raiden_contracts.constants import (
-    CONTRACT_CUSTOM_TOKEN,
-    CONTRACT_TOKEN_NETWORK,
-)
+from raiden_contracts.utils.signature import private_key_to_address
 
 
 def get_web3(eth_tester, deployer_key):

--- a/raiden_contracts/utils/__init__.py
+++ b/raiden_contracts/utils/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 
+from .bytecode import *
 from .events import *
 from .logs import *
 from .merkle import *
@@ -7,4 +8,3 @@ from .pending_transfers import *
 from .proofs import *
 from .signature import *
 from .type_aliases import *
-from .bytecode import *

--- a/raiden_contracts/utils/logs.py
+++ b/raiden_contracts/utils/logs.py
@@ -1,13 +1,11 @@
-from typing import Dict, List
 import functools
 from collections import defaultdict
+from inspect import getframeinfo, stack
+from typing import Dict, List
 
 from web3.utils.events import get_event_data
 from web3.utils.filters import construct_event_filter_params
-from inspect import getframeinfo, stack
-from web3.utils.threads import (
-    Timeout,
-)
+from web3.utils.threads import Timeout
 
 
 class LogHandler:

--- a/raiden_contracts/utils/merkle.py
+++ b/raiden_contracts/utils/merkle.py
@@ -1,8 +1,8 @@
 from collections import namedtuple
-from typing import Iterable
 from itertools import zip_longest
-from eth_utils import keccak
+from typing import Iterable
 
+from eth_utils import keccak
 
 EMPTY_MERKLE_ROOT = b'\x00' * 32
 

--- a/raiden_contracts/utils/pending_transfers.py
+++ b/raiden_contracts/utils/pending_transfers.py
@@ -1,14 +1,13 @@
-from random import randint
 from collections import namedtuple
 from functools import reduce
 from os import urandom
+from random import randint
 
-from web3 import Web3
 from eth_abi import encode_abi
+from web3 import Web3
 
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN
 from raiden_contracts.utils.merkle import compute_merkle_tree, get_merkle_root
-
 
 PendingTransfersTree = namedtuple('PendingTransfersTree', [
     'transfers',

--- a/raiden_contracts/utils/private_key.py
+++ b/raiden_contracts/utils/private_key.py
@@ -1,12 +1,11 @@
 import getpass
 import json
 import logging
-
 import os
 import stat
 
-from eth_utils import is_hex, decode_hex, encode_hex
 from eth_keyfile import decode_keyfile_json
+from eth_utils import decode_hex, encode_hex, is_hex
 
 log = logging.getLogger(__name__)
 

--- a/raiden_contracts/utils/proofs.py
+++ b/raiden_contracts/utils/proofs.py
@@ -1,7 +1,9 @@
-from web3 import Web3
 from eth_abi import encode_single
-from .signature import sign
+from web3 import Web3
+
 from raiden_contracts.constants import MessageTypeId
+
+from .signature import sign
 
 
 def hash_balance_data(transferred_amount, locked_amount, locksroot):

--- a/raiden_contracts/utils/signature.py
+++ b/raiden_contracts/utils/signature.py
@@ -1,9 +1,9 @@
-from coincurve import PrivateKey, PublicKey
-from eth_utils import remove_0x_prefix, to_checksum_address, to_bytes, keccak
 from typing import Union
 
-from .type_aliases import Address
+from coincurve import PrivateKey, PublicKey
+from eth_utils import keccak, remove_0x_prefix, to_bytes, to_checksum_address
 
+from .type_aliases import Address
 
 sha3 = keccak
 

--- a/raiden_contracts/utils/transaction.py
+++ b/raiden_contracts/utils/transaction.py
@@ -1,9 +1,7 @@
 from typing import Tuple
 
 from web3 import Web3
-from web3.utils.threads import (
-    Timeout,
-)
+from web3.utils.threads import Timeout
 
 
 def check_succesful_tx(web3: Web3, txid: str, timeout=180) -> Tuple[dict, dict]:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,4 @@ requests
 mypy==0.670
 pylint
 requests_mock
+isort


### PR DESCRIPTION
This PR enables `isort` in CI runs.  Many imports had to be reordered.