### PR TITLE
Test check_successful_tx

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -38,7 +38,7 @@ from raiden_contracts.contract_manager import (
 from raiden_contracts.utils.bytecode import runtime_hexcode
 from raiden_contracts.utils.private_key import get_private_key
 from raiden_contracts.utils.signature import private_key_to_address
-from raiden_contracts.utils.transaction import check_succesful_tx
+from raiden_contracts.utils.transaction import check_successful_tx
 from raiden_contracts.utils.type_aliases import Address
 
 LOG = getLogger(__name__)
@@ -116,7 +116,7 @@ class ContractDeployer:
             f'Deploying {contract_name} txHash={encode_hex(txhash)}, '
             f'contracts version {self.contract_manager.contracts_version}',
         )
-        (receipt, tx) = check_succesful_tx(
+        (receipt, tx) = check_successful_tx(
             web3=self.web3,
             txid=txhash,
             timeout=self.wait,
@@ -140,7 +140,7 @@ class ContractDeployer:
         """ A wrapper around to_be_called.transact() that waits until the transaction succeeds. """
         txhash = contract_method.transact(self.transaction)
         LOG.debug(f'Sending txHash={encode_hex(txhash)}')
-        (receipt, _) = check_succesful_tx(
+        (receipt, _) = check_successful_tx(
             web3=self.web3,
             txid=txhash,
             timeout=self.wait,
@@ -718,7 +718,7 @@ def register_token_network(
             encode_hex(txhash),
         ),
     )
-    (receipt, _) = check_succesful_tx(web3=web3, txid=txhash, timeout=wait)
+    (receipt, _) = check_successful_tx(web3=web3, txid=txhash, timeout=wait)
 
     token_network_address = token_network_registry.functions.token_to_token_networks(
         token_address,

--- a/raiden_contracts/tests/deprecation_switch_testnet.py
+++ b/raiden_contracts/tests/deprecation_switch_testnet.py
@@ -17,7 +17,7 @@ from raiden_contracts.deploy.__main__ import (
     register_token_network,
     setup_ctx,
 )
-from raiden_contracts.utils.transaction import check_succesful_tx
+from raiden_contracts.utils.transaction import check_successful_tx
 
 log = getLogger(__name__)
 
@@ -91,7 +91,7 @@ def deprecation_test(
         deployer.transaction,
     )
     log.debug(f'Deprecation txHash={encode_hex(txhash)}')
-    check_succesful_tx(deployer.web3, txhash, deployer.wait)
+    check_successful_tx(deployer.web3, txhash, deployer.wait)
     assert token_network.functions.safety_deprecation_switch().call() is True
 
     log.info('Checking that channels cannot be opened anymore and no more deposits are allowed.')
@@ -149,7 +149,7 @@ def deprecation_test_setup(
     )
 
     log.debug(f'Minting tokens txHash={encode_hex(txhash)}')
-    check_succesful_tx(deployer.web3, txhash, deployer.wait)
+    check_successful_tx(deployer.web3, txhash, deployer.wait)
     assert token_contract.functions.balanceOf(deployer.owner).call() >= token_amount
 
     abi = deployer.contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK_REGISTRY)
@@ -178,7 +178,7 @@ def deprecation_test_setup(
         deployer.transaction,
     )
     log.debug(f'Approving tokens for the TokenNetwork contract txHash={encode_hex(txhash)}')
-    check_succesful_tx(deployer.web3, txhash, deployer.wait)
+    check_successful_tx(deployer.web3, txhash, deployer.wait)
 
     assert token_contract.functions.allowance(
         deployer.owner,
@@ -205,7 +205,7 @@ def open_and_deposit(
             deployer.transaction,
         )
         log.debug(f'Opening a channel between {A} and {B} txHash={encode_hex(txhash)}')
-        check_succesful_tx(deployer.web3, txhash, deployer.wait)
+        check_successful_tx(deployer.web3, txhash, deployer.wait)
 
         # Get the channel identifier
         channel_identifier = token_network.functions.getChannelIdentifier(A, B).call()
@@ -231,7 +231,7 @@ def open_and_deposit(
             f'Depositing {MAX_ETH_CHANNEL_PARTICIPANT} tokens for {A} in a channel with '
             f'identifier={channel_identifier} and partner= {B} txHash={encode_hex(txhash)}',
         )
-        check_succesful_tx(deployer.web3, txhash, deployer.wait)
+        check_successful_tx(deployer.web3, txhash, deployer.wait)
         success_status = True
     except ValueError as ex:
         success_status = False
@@ -253,7 +253,7 @@ def open_and_deposit(
             f'Depositing {MAX_ETH_CHANNEL_PARTICIPANT} tokens for {B} in a channel with '
             f'identifier={channel_identifier} and partner= {A} txHash={encode_hex(txhash)}',
         )
-        check_succesful_tx(deployer.web3, txhash, deployer.wait)
+        check_successful_tx(deployer.web3, txhash, deployer.wait)
         success_status = True
     except ValueError as ex:
         success_status = False

--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -10,7 +10,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MIN,
 )
 from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
-from raiden_contracts.utils.transaction import check_succesful_tx
+from raiden_contracts.utils.transaction import check_successful_tx
 
 
 @pytest.fixture()
@@ -73,7 +73,7 @@ def add_and_register_token(
             channel_participant_deposit_limit,
             token_network_deposit_limit,
         ).transact({'from': CONTRACT_DEPLOYER_ADDRESS})
-        (tx_receipt, _) = check_succesful_tx(web3, txid)
+        (tx_receipt, _) = check_successful_tx(web3, txid)
         assert len(tx_receipt['logs']) == 1
         event_abi = contracts_manager.get_event_abi(
             CONTRACT_TOKEN_NETWORK_REGISTRY,

--- a/raiden_contracts/tests/test_transaction.py
+++ b/raiden_contracts/tests/test_transaction.py
@@ -7,9 +7,7 @@ from raiden_contracts.utils.transaction import check_successful_tx
 
 def test_check_successful_tx_with_status_zero():
     web3_mock = Mock()
-    web3_mock.eth = Mock()
-    web3_mock.eth.getTransactionReceipt = Mock(return_value={'blockNumber': 300, 'status': 0})
-    web3_mock.eth.getTransaction = Mock()
+    web3_mock.eth.getTransactionReceipt.return_value = {'blockNumber': 300, 'status': 0}
     txid = 'abcdef'
     with pytest.raises(ValueError):
         check_successful_tx(web3=web3_mock, txid=txid)
@@ -19,14 +17,13 @@ def test_check_successful_tx_with_status_zero():
 
 def test_check_successful_tx_with_gas_completely_used():
     web3_mock = Mock()
-    web3_mock.eth = Mock()
     gas = 30000
-    web3_mock.eth.getTransactionReceipt = Mock(return_value={
+    web3_mock.eth.getTransactionReceipt.return_value = {
         'blockNumber': 300,
         'status': 1,
         'gasUsed': gas,
-    })
-    web3_mock.eth.getTransaction = Mock(return_value={'gas': gas})
+    }
+    web3_mock.eth.getTransaction.return_value = {'gas': gas}
     txid = 'abcdef'
     with pytest.raises(ValueError):
         check_successful_tx(web3=web3_mock, txid=txid)
@@ -36,16 +33,15 @@ def test_check_successful_tx_with_gas_completely_used():
 
 def test_check_successful_tx_successful_case():
     web3_mock = Mock()
-    web3_mock.eth = Mock()
     gas = 30000
     receipt = {
         'blockNumber': 300,
         'status': 1,
         'gasUsed': gas - 10,
     }
-    web3_mock.eth.getTransactionReceipt = Mock(return_value=receipt)
+    web3_mock.eth.getTransactionReceipt.return_value = receipt
     txinfo = {'gas': gas}
-    web3_mock.eth.getTransaction = Mock(return_value=txinfo)
+    web3_mock.eth.getTransaction.return_value = txinfo
     txid = 'abcdef'
     assert check_successful_tx(web3=web3_mock, txid=txid) == (receipt, txinfo)
     web3_mock.eth.getTransactionReceipt.assert_called_with(txid)

--- a/raiden_contracts/tests/test_transaction.py
+++ b/raiden_contracts/tests/test_transaction.py
@@ -1,0 +1,52 @@
+from unittest.mock import Mock
+
+import pytest
+
+from raiden_contracts.utils.transaction import check_successful_tx
+
+
+def test_check_successful_tx_with_status_zero():
+    web3_mock = Mock()
+    web3_mock.eth = Mock()
+    web3_mock.eth.getTransactionReceipt = Mock(return_value={'blockNumber': 300, 'status': 0})
+    web3_mock.eth.getTransaction = Mock()
+    txid = 'abcdef'
+    with pytest.raises(ValueError):
+        check_successful_tx(web3=web3_mock, txid=txid)
+    web3_mock.eth.getTransactionReceipt.assert_called_with(txid)
+    web3_mock.eth.getTransaction.assert_called_with(txid)
+
+
+def test_check_successful_tx_with_gas_completely_used():
+    web3_mock = Mock()
+    web3_mock.eth = Mock()
+    gas = 30000
+    web3_mock.eth.getTransactionReceipt = Mock(return_value={
+        'blockNumber': 300,
+        'status': 1,
+        'gasUsed': gas,
+    })
+    web3_mock.eth.getTransaction = Mock(return_value={'gas': gas})
+    txid = 'abcdef'
+    with pytest.raises(ValueError):
+        check_successful_tx(web3=web3_mock, txid=txid)
+    web3_mock.eth.getTransactionReceipt.assert_called_with(txid)
+    web3_mock.eth.getTransaction.assert_called_with(txid)
+
+
+def test_check_successful_tx_successful_case():
+    web3_mock = Mock()
+    web3_mock.eth = Mock()
+    gas = 30000
+    receipt = {
+        'blockNumber': 300,
+        'status': 1,
+        'gasUsed': gas - 10,
+    }
+    web3_mock.eth.getTransactionReceipt = Mock(return_value=receipt)
+    txinfo = {'gas': gas}
+    web3_mock.eth.getTransaction = Mock(return_value=txinfo)
+    txid = 'abcdef'
+    assert check_successful_tx(web3=web3_mock, txid=txid) == (receipt, txinfo)
+    web3_mock.eth.getTransactionReceipt.assert_called_with(txid)
+    web3_mock.eth.getTransaction.assert_called_with(txid)

--- a/raiden_contracts/utils/transaction.py
+++ b/raiden_contracts/utils/transaction.py
@@ -4,7 +4,7 @@ from web3 import Web3
 from web3.utils.threads import Timeout
 
 
-def check_succesful_tx(web3: Web3, txid: str, timeout=180) -> Tuple[dict, dict]:
+def check_successful_tx(web3: Web3, txid: str, timeout=180) -> Tuple[dict, dict]:
     '''See if transaction went through (Solidity code did not throw).
     :return: Transaction receipt and transaction info
     '''


### PR DESCRIPTION
The function `raiden_contracts.utils.check_successful_tx` had no unit tests.  I'm adding them.