### PR TITLE
Stop automatically converting version=None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Documents changes that result in:
 
 ## Unreleased
 
+- ContractManager created with version=None has contracts_version == None
 - Add a deployment-time configurable limit on the whole balance of UserDeposit
 - Deployment script's `service` command takes an additional option `--user-deposit-whole-limit`
 

--- a/README.rst
+++ b/README.rst
@@ -33,13 +33,13 @@ If you want to use the officially deployed contracts, please use the ``raiden_co
 You can find other useful constants that you can import in ``raiden_contracts/constants.py``.
 
 .. Note::
-    There are currently three versions supported in this package:
+    This package supports many contract versions, including:
 
     * Development ``0.3._`` contracts version (from ``0.3.0`` package release: https://github.com/raiden-network/raiden-contracts/releases/tag/v0.3.0). No limits on the number of tokens registered; has a limit of 100 tokens per channel). Source code: https://github.com/raiden-network/raiden-contracts/tree/fc1c79329a165c738fc55c3505cf801cc79872e4/raiden_contracts/contracts
     * Red Eyes Mainnet ``0.4.0`` contracts version (from ``0.7.0`` package release: https://github.com/raiden-network/raiden-contracts/releases/tag/v0.7.0). Source code: https://github.com/raiden-network/raiden-contracts/tree/fac73623d5b92b7c070fdde2b446648ec9117474/raiden_contracts/contracts
     * current !development version corresponding with the ``master`` branch (might not be stable).
 
-    These are temporary and will be removed in favor of only one contracts version in the Ithaca Milestone.
+    The current policy is to add all new deployment data together with the sources.
 
 If you are using the ``raiden-contracts`` package in your project, you can use::
 
@@ -50,15 +50,15 @@ If you are using the ``raiden-contracts`` package in your project, you can use::
     from raiden_contracts.constants import (
         CONTRACT_TOKEN_NETWORK_REGISTRY,
         CONTRACT_MONITORING_SERVICE,
+        CONTRACTS_VERSION,
         EVENT_TOKEN_NETWORK_CREATED,
     )
 
-    # ``raiden-contracts`` provides only three kinds of ``contracts_version``s.
-    # ``None``, ``'0.4.0'`` and ``'0.3._'``.  They are explained below.
+    # ``raiden-contracts`` provides ``contracts_version``s like
+    # ``0.9.0``, ``'0.4.0'`` and ``'0.3._'``.  They are explained below.
 
-    # Uses the newest version. Available on Kovan, Rinkeby and Ropsten.
-    # Mainnet deployments should not be accessed with contract_version == None.
-    contracts_version = None
+    # Uses the newest test net release available on Kovan, Rinkeby and Ropsten.
+    contracts_version = CONTRACTS_VERSION
 
     # Uses Red Eyes, Mainnet enabled version with deposit limits.
     # The version is also available on Kovan, Rinkeby and Ropsten.
@@ -69,10 +69,6 @@ If you are using the ``raiden-contracts`` package in your project, you can use::
     # The Solidity source of this version is unknown on Etherscan.
     # See https://github.com/raiden-network/raiden-contracts/issues/543
     contracts_version = '0.3._'
-
-    # Other contract versions like ``'0.6.0'`` do not work. Contract versions
-    # become available when anybody requests, or when there is a mainnet
-    # deployment.
 
     manager = ContractManager(contracts_precompiled_path(contracts_version))
     compiled_contract_data = manager.get_contract(CONTRACT_TOKEN_NETWORK_REGISTRY)

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -126,9 +126,7 @@ Measure Gas Costs
 Create a New Data Directory
 ---------------------------
 
-Copy ``data`` directory into ``data_x.y.z`` where ``x.y.z`` is the contract version.
-
-Also ``data_unlimited`` has to be copied into ``data_x.y.z_unlimited``.
+Copy ``data`` directory into ``data_x.y.z`` where ``x.y.z`` is the contract version.  Also, edit ``data_x.y.z/contracts.json`` to change ``contracts_version`` from ``null`` to ``x.y.z``.
 
 .. _bump-package:
 

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -46,10 +46,10 @@ class ContractManager:
         self.contracts_checksums: Optional[Dict[str, str]] = None
         if isinstance(path, dict):
             self.contracts_source_dirs = path
-            self.contracts_version = CONTRACTS_VERSION
+            self.contracts_version = None
         elif isinstance(path, Path) and path.is_dir():
             self.contracts_source_dirs = {'smart_contracts': path}
-            self.contracts_version = CONTRACTS_VERSION
+            self.contracts_version = None
         elif isinstance(path, Path):
             try:
                 with path.open() as precompiled_file:
@@ -229,7 +229,7 @@ def contract_version_string(version: Optional[str] = None):
 
 def contracts_data_path(version: Optional[str] = None):
     """Returns the deployment data directory for a flavor and a plain version."""
-    if version is None or version == CONTRACTS_VERSION:
+    if version is None:
         return _BASE.joinpath('data')
     return _BASE.joinpath(f'data_{version}')
 

--- a/raiden_contracts/data/contracts.json
+++ b/raiden_contracts/data/contracts.json
@@ -6444,6 +6444,6 @@
         "UserDeposit.sol": "263b0037646c985ea06091b031a89754cbd79e19dc06fb568dc18860ae718d11",
         "Utils.sol": "605150c14d0601504c860fe210fb88620543160501d2bac88c1dded9747f8e4e"
     },
-    "contracts_version": "0.9.0",
+    "contracts_version": null,
     "overall_checksum": "f4dd515125703fb67f4db6e5ff2fec121d3dab5f98390480b803a62f72155a06"
 }

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -96,12 +96,6 @@ def test_verification_contracts_checksums():
         manager.verify_precompiled_checksums(contracts_precompiled_path())
 
 
-def test_contracts_version():
-    """ Check the value of contracts_version """
-    manager = ContractManager(contracts_precompiled_path())
-    assert manager.contracts_version == CONTRACTS_VERSION
-
-
 def test_current_development_version():
     """ contracts_source_path() exists and contains the expected files """
     contracts_version = CONTRACTS_VERSION
@@ -232,3 +226,16 @@ def test_contract_manager_json(tmpdir):
     ContractManager(contracts_source_path()).compile_contracts(precompiled_path)
     # try to load contracts from a precompiled file
     contract_manager_meta(precompiled_path)
+
+
+def test_contract_manager_constructor_does_not_invent_version():
+    """ ContractManager should not invent a version string """
+    manager = ContractManager(contracts_precompiled_path(version=None))
+    assert manager.contracts_version is None
+
+
+@pytest.mark.parametrize('version', [CONTRACTS_VERSION, '0.3._', '0.4.0'])
+def test_contract_manager_constructor_keeps_existing_versions(version):
+    """ ContractManager should keep an existing version string """
+    manager = ContractManager(contracts_precompiled_path(version=version))
+    assert manager.contracts_version == version

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -234,7 +234,7 @@ def test_contract_manager_constructor_does_not_invent_version():
     assert manager.contracts_version is None
 
 
-@pytest.mark.parametrize('version', [CONTRACTS_VERSION, '0.3._', '0.4.0'])
+@pytest.mark.parametrize('version', [CONTRACTS_VERSION, '0.9.0', '0.3._', '0.4.0'])
 def test_contract_manager_constructor_keeps_existing_versions(version):
     """ ContractManager should keep an existing version string """
     manager = ContractManager(contracts_precompiled_path(version=version))


### PR DESCRIPTION
into the current contracts version.

During the release process, the version number in contracts.json will be changed by hand.