### PR TITLE
Split ContractSourceManager from ContractManager

### DIFF
--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -31,9 +31,9 @@ class ContractManagerVerificationError(RuntimeError):
 
 
 class ContractManager:
-    """ContractManager knows how to interact with already compiled contracts:
+    """ ContractManager holds compiled contracts of the same version
 
-    using the ABI and checking the bytecode against the source.
+    Provides access to the ABI and the bytecode.
     """
     def __init__(self, path: Path) -> None:
         """Params:
@@ -84,7 +84,7 @@ class ContractManager:
 
 
 class ContractSourceManager():
-    """ ContractSourceManager knows how to compile contracts. """
+    """ ContractSourceManager knows how to compile contracts """
 
     def __init__(self, path: Union[Path, Dict[str, Path]]) -> None:
         """ Parmas: a dictionary of directories which contain solidity files to compile """

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -17,7 +17,7 @@ from raiden_contracts.constants import (
 _BASE = Path(__file__).parent
 
 
-class ContractManagerCompilationError(RuntimeError):
+class ContractSourceManagerCompilationError(RuntimeError):
     """Compilation failed for infrastructural reasons (lack of the compiler,
     failure to take checksums)."""
 
@@ -26,7 +26,7 @@ class ContractManagerLoadError(RuntimeError):
     """Failure in loading contracts.json."""
 
 
-class ContractManagerVerificationError(RuntimeError):
+class ContractSourceManagerVerificationError(RuntimeError):
     """Failure in comparing contracts.json contents against sources."""
 
 
@@ -135,7 +135,7 @@ class ContractSourceManager():
                 }
                 ret.update(_fix_contract_key_names(res))
         except FileNotFoundError as ex:
-            raise ContractManagerCompilationError(
+            raise ContractSourceManagerCompilationError(
                 'Could not compile the contract. Check that solc is available.',
             ) from ex
         finally:
@@ -150,7 +150,7 @@ class ContractSourceManager():
         self.checksum_contracts()
 
         if self.overall_checksum is None:
-            raise ContractManagerCompilationError('Checksumming failed.')
+            raise ContractSourceManagerCompilationError('Checksumming failed.')
 
         contracts_compiled = self._compile_all_contracts()
 
@@ -187,17 +187,17 @@ class ContractSourceManager():
                 assert contracts_precompiled.contracts_checksums is not None
                 precompiled_checksum = contracts_precompiled.contracts_checksums[contract]
             except KeyError:
-                raise ContractManagerVerificationError(
+                raise ContractSourceManagerVerificationError(
                     f'No checksum for {contract}',
                 )
             if precompiled_checksum != checksum:
-                raise ContractManagerVerificationError(
+                raise ContractSourceManagerVerificationError(
                     f'checksum of {contract} does not match {precompiled_checksum} != {checksum}',
                 )
 
         # Compare the overall source code checksum with the one from the precompiled file
         if self.overall_checksum != contracts_precompiled.overall_checksum:
-            raise ContractManagerVerificationError(
+            raise ContractSourceManagerVerificationError(
                 f'overall checksum does not match '
                 f'{self.overall_checksum} != {contracts_precompiled.overall_checksum}',
             )

--- a/raiden_contracts/contract_source_manager.py
+++ b/raiden_contracts/contract_source_manager.py
@@ -1,0 +1,182 @@
+"""ContractSourceManager knows the sources and how to compile them."""
+import hashlib
+import json
+from os import chdir
+from pathlib import Path
+from typing import Dict, Union
+
+from solc import compile_files
+
+from raiden_contracts.constants import PRECOMPILED_DATA_FIELDS
+from raiden_contracts.contract_manager import ContractManager
+
+_BASE = Path(__file__).parent
+
+
+class ContractSourceManagerCompilationError(RuntimeError):
+    """Compilation failed for infrastructural reasons (lack of the compiler,
+    failure to take checksums)."""
+
+
+class ContractSourceManagerVerificationError(RuntimeError):
+    """Failure in comparing contracts.json contents against sources."""
+
+
+class ContractSourceManager():
+    """ ContractSourceManager knows how to compile contracts """
+
+    def __init__(self, path: Union[Path, Dict[str, Path]]) -> None:
+        """ Parmas: a dictionary of directories which contain solidity files to compile """
+        if isinstance(path, dict):
+            self.contracts_source_dirs = path
+        elif isinstance(path, Path) and path.is_dir():
+            self.contracts_source_dirs = {'smart_contracts': path}
+        else:
+            raise TypeError('Wrong type of argument given for ContractSourceManager()')
+
+    def _compile_all_contracts(self) -> Dict:
+        """
+        Compile solidity contracts into ABI and BIN. This requires solc somewhere in the $PATH
+        and also the :ref:`ethereum.tools` python library.  The return value is a dict that
+        should be written into contracts.json.
+        """
+        if self.contracts_source_dirs is None:
+            raise TypeError("Missing contracts source path, can't compile contracts.")
+
+        ret = {}
+        old_working_dir = Path.cwd()
+        chdir(_BASE)
+
+        def relativise(path):
+            return path.relative_to(_BASE)
+        import_dir_map = [
+            '%s=%s' % (k, relativise(v))
+            for k, v in self.contracts_source_dirs.items()
+        ]
+        import_dir_map.insert(0, '.=.')  # allow solc to compile contracts in all subdirs
+        try:
+            for contracts_dir in self.contracts_source_dirs.values():
+                res = compile_files(
+                    [str(relativise(file)) for file in contracts_dir.glob('*.sol')],
+                    output_values=PRECOMPILED_DATA_FIELDS + ['ast'],
+                    import_remappings=import_dir_map,
+                    optimize=False,
+                )
+
+                # Strip `ast` part from result
+                # TODO: Remove after https://github.com/ethereum/py-solc/issues/56 is fixed
+                res = {
+                    contract_name: {
+                        content_key: content_value
+                        for content_key, content_value in contract_content.items()
+                        if content_key != 'ast'
+                    } for contract_name, contract_content in res.items()
+                }
+                ret.update(_fix_contract_key_names(res))
+        except FileNotFoundError as ex:
+            raise ContractSourceManagerCompilationError(
+                'Could not compile the contract. Check that solc is available.',
+            ) from ex
+        finally:
+            chdir(old_working_dir)
+        return ret
+
+    def compile_contracts(self, target_path: Path) -> ContractManager:
+        """ Store compiled contracts JSON at `target_path`. """
+        if self.contracts_source_dirs is None:
+            raise TypeError('Already using stored contracts.')
+
+        self.checksum_contracts()
+
+        if self.overall_checksum is None:
+            raise ContractSourceManagerCompilationError('Checksumming failed.')
+
+        contracts_compiled = self._compile_all_contracts()
+
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        with target_path.open(mode='w') as target_file:
+            target_file.write(
+                json.dumps(
+                    dict(
+                        contracts=contracts_compiled,
+                        contracts_checksums=self.contracts_checksums,
+                        overall_checksum=self.overall_checksum,
+                        contracts_version=None,
+                    ),
+                    sort_keys=True,
+                    indent=4,
+                ),
+            )
+
+        return ContractManager(target_path)
+
+    def verify_precompiled_checksums(self, precompiled_path: Path) -> None:
+        """ Compare source code checksums with those from a precompiled file. """
+
+        # We get the precompiled file data
+        contracts_precompiled = ContractManager(precompiled_path)
+
+        # Silence mypy
+        assert self.contracts_checksums is not None
+
+        # Compare each contract source code checksum with the one from the precompiled file
+        for contract, checksum in self.contracts_checksums.items():
+            try:
+                # Silence mypy
+                assert contracts_precompiled.contracts_checksums is not None
+                precompiled_checksum = contracts_precompiled.contracts_checksums[contract]
+            except KeyError:
+                raise ContractSourceManagerVerificationError(
+                    f'No checksum for {contract}',
+                )
+            if precompiled_checksum != checksum:
+                raise ContractSourceManagerVerificationError(
+                    f'checksum of {contract} does not match {precompiled_checksum} != {checksum}',
+                )
+
+        # Compare the overall source code checksum with the one from the precompiled file
+        if self.overall_checksum != contracts_precompiled.overall_checksum:
+            raise ContractSourceManagerVerificationError(
+                f'overall checksum does not match '
+                f'{self.overall_checksum} != {contracts_precompiled.overall_checksum}',
+            )
+
+    def checksum_contracts(self) -> None:
+        """Remember the checksum of each source, and the overall checksum."""
+        if self.contracts_source_dirs is None:
+            raise TypeError("Missing contracts source path, can't checksum contracts.")
+
+        checksums: Dict[str, str] = {}
+        for contracts_dir in self.contracts_source_dirs.values():
+            file: Path
+            for file in contracts_dir.glob('*.sol'):
+                checksums[file.name] = hashlib.sha256(file.read_bytes()).hexdigest()
+
+        self.overall_checksum = hashlib.sha256(
+            ':'.join(checksums[key] for key in sorted(checksums)).encode(),
+        ).hexdigest()
+        self.contracts_checksums = checksums
+
+
+def contracts_source_path():
+    return contracts_source_path_with_stem('contracts')
+
+
+def contracts_source_path_with_stem(stem):
+    """The directory remapping given to the Solidity compiler."""
+    return {
+        'lib': _BASE.joinpath(stem, 'lib'),
+        'raiden': _BASE.joinpath(stem, 'raiden'),
+        'test': _BASE.joinpath(stem, 'test'),
+        'services': _BASE.joinpath(stem, 'services'),
+    }
+
+
+def _fix_contract_key_names(d: Dict) -> Dict:
+    result = {}
+
+    for k, v in d.items():
+        name = k.split(':')[1]
+        result[name] = v
+
+    return result

--- a/raiden_contracts/contract_source_manager.py
+++ b/raiden_contracts/contract_source_manager.py
@@ -3,7 +3,7 @@ import hashlib
 import json
 from os import chdir
 from pathlib import Path
-from typing import Dict, Union
+from typing import Dict
 
 from solc import compile_files
 
@@ -25,14 +25,11 @@ class ContractSourceManagerVerificationError(RuntimeError):
 class ContractSourceManager():
     """ ContractSourceManager knows how to compile contracts """
 
-    def __init__(self, path: Union[Path, Dict[str, Path]]) -> None:
+    def __init__(self, path: Dict[str, Path]) -> None:
         """ Parmas: a dictionary of directories which contain solidity files to compile """
-        if isinstance(path, dict):
-            self.contracts_source_dirs = path
-        elif isinstance(path, Path) and path.is_dir():
-            self.contracts_source_dirs = {'smart_contracts': path}
-        else:
+        if not isinstance(path, dict):
             raise TypeError('Wrong type of argument given for ContractSourceManager()')
+        self.contracts_source_dirs = path
 
     def _compile_all_contracts(self) -> Dict:
         """
@@ -40,9 +37,6 @@ class ContractSourceManager():
         and also the :ref:`ethereum.tools` python library.  The return value is a dict that
         should be written into contracts.json.
         """
-        if self.contracts_source_dirs is None:
-            raise TypeError("Missing contracts source path, can't compile contracts.")
-
         ret = {}
         old_working_dir = Path.cwd()
         chdir(_BASE)
@@ -83,9 +77,6 @@ class ContractSourceManager():
 
     def compile_contracts(self, target_path: Path) -> ContractManager:
         """ Store compiled contracts JSON at `target_path`. """
-        if self.contracts_source_dirs is None:
-            raise TypeError('Already using stored contracts.')
-
         self.checksum_contracts()
 
         if self.overall_checksum is None:
@@ -143,9 +134,6 @@ class ContractSourceManager():
 
     def checksum_contracts(self) -> None:
         """Remember the checksum of each source, and the overall checksum."""
-        if self.contracts_source_dirs is None:
-            raise TypeError("Missing contracts source path, can't checksum contracts.")
-
         checksums: Dict[str, str] = {}
         for contracts_dir in self.contracts_source_dirs.values():
             file: Path

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -29,6 +29,7 @@ from raiden_contracts.constants import (
 )
 from raiden_contracts.contract_manager import (
     ContractManager,
+    ContractSourceManager,
     contract_version_string,
     contracts_deployed_path,
     contracts_precompiled_path,
@@ -82,7 +83,7 @@ class ContractDeployer:
         # Check that the precompiled data matches the source code
         # Only for current version, because this is the only one with source code
         if self.contracts_version in [None, CONTRACTS_VERSION]:
-            contract_manager_source = ContractManager(contracts_source_path())
+            contract_manager_source = ContractSourceManager(contracts_source_path())
             contract_manager_source.checksum_contracts()
             contract_manager_source.verify_precompiled_checksums(self.precompiled_path)
         else:
@@ -979,8 +980,7 @@ def verify_deployed_contract(
     # Check the contract version
     version = contract_instance.functions.contract_version().call()
     assert version == deployment_data['contracts_version'], \
-        f'got {version} expected {deployment_data["contracts_version"]},' \
-        f'contract_manager has source {contract_manager.contracts_source_dirs} and' \
+        f'got {version} expected {deployment_data["contracts_version"]}.' \
         f'contract_manager has contracts_version {contract_manager.contracts_version}'
 
     return contract_instance, contracts[contract_name]['constructor_arguments']

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -29,13 +29,12 @@ from raiden_contracts.constants import (
 )
 from raiden_contracts.contract_manager import (
     ContractManager,
-    ContractSourceManager,
     contract_version_string,
     contracts_deployed_path,
     contracts_precompiled_path,
-    contracts_source_path,
     get_contracts_deployed,
 )
+from raiden_contracts.contract_source_manager import ContractSourceManager, contracts_source_path
 from raiden_contracts.utils.bytecode import runtime_hexcode
 from raiden_contracts.utils.private_key import get_private_key
 from raiden_contracts.utils.signature import private_key_to_address

--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -21,9 +21,9 @@ from raiden_contracts.constants import (
 from raiden_contracts.contract_manager import (
     ContractManager,
     contracts_precompiled_path,
-    contracts_source_path,
     get_contracts_deployed,
 )
+from raiden_contracts.contract_source_manager import contracts_source_path
 
 
 @click.command()

--- a/raiden_contracts/tests/fixtures/base/contract_manager.py
+++ b/raiden_contracts/tests/fixtures/base/contract_manager.py
@@ -1,8 +1,17 @@
 import pytest
 
-from raiden_contracts.contract_manager import ContractManager, contracts_source_path
+from raiden_contracts.contract_manager import (
+    ContractSourceManager,
+    contracts_precompiled_path,
+    contracts_source_path,
+)
 
 
 @pytest.fixture(scope='session')
-def contracts_manager():
-    return ContractManager(contracts_source_path())
+def contract_source_manager():
+    return ContractSourceManager(contracts_source_path())
+
+
+@pytest.fixture(scope='session')
+def contracts_manager(contract_source_manager):
+    return contract_source_manager.compile_contracts(contracts_precompiled_path())

--- a/raiden_contracts/tests/fixtures/base/contract_manager.py
+++ b/raiden_contracts/tests/fixtures/base/contract_manager.py
@@ -1,10 +1,7 @@
 import pytest
 
-from raiden_contracts.contract_manager import (
-    ContractSourceManager,
-    contracts_precompiled_path,
-    contracts_source_path,
-)
+from raiden_contracts.contract_manager import contracts_precompiled_path
+from raiden_contracts.contract_source_manager import ContractSourceManager, contracts_source_path
 
 
 @pytest.fixture(scope='session')

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -248,32 +248,9 @@ def test_contract_manager_constructor_keeps_existing_versions(version):
     assert manager.contracts_version == version
 
 
-def test_contract_manager_missing_source_path():
-    """ ContractManager._compile_all_contracts() raises TypeError when source_dirs is not set """
-    manager = ContractSourceManager(contracts_precompiled_path())
-    with pytest.raises(TypeError):
-        manager._compile_all_contracts()
-
-
 def test_contract_manager_precompiled_load_error():
     """ ContractManager's constructor raises ContractManagerLoadError when precompiled
     contracts cannot be loaded """
     with NamedTemporaryFile() as empty_file:
         with pytest.raises(ContractManagerLoadError):
             ContractManager(Path(empty_file.name))
-
-
-def test_contract_manager_already_using_stored():
-    """ ContractManager.compile_contracts() should raise TypeError when source directories
-    are not set """
-    manager = ContractSourceManager(contracts_precompiled_path())
-    with pytest.raises(TypeError):
-        manager.compile_contracts(Path('/'))
-
-
-def test_contract_manager_checksum_on_no_source():
-    """ ContractManager.checksum_contracts() should raise TypeError when source directories
-    are not set """
-    manager = ContractSourceManager(contracts_precompiled_path())
-    with pytest.raises(TypeError):
-        manager.checksum_contracts()

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -13,8 +13,8 @@ from raiden_contracts.constants import (
 from raiden_contracts.contract_manager import (
     ContractManager,
     ContractManagerLoadError,
-    ContractManagerVerificationError,
     ContractSourceManager,
+    ContractSourceManagerVerificationError,
     contracts_deployed_path,
     contracts_precompiled_path,
     contracts_source_path,
@@ -46,22 +46,22 @@ def test_verification_overall_checksum():
     # We change the source code overall checksum
     manager.overall_checksum += '2'
     # Now the verification should fail
-    with pytest.raises(ContractManagerVerificationError):
+    with pytest.raises(ContractSourceManagerVerificationError):
         manager.verify_precompiled_checksums(contracts_precompiled_path())
 
     manager.overall_checksum = None  # type: ignore
-    with pytest.raises(ContractManagerVerificationError):
+    with pytest.raises(ContractSourceManagerVerificationError):
         manager.verify_precompiled_checksums(contracts_precompiled_path())
 
     manager.overall_checksum = ''
-    with pytest.raises(ContractManagerVerificationError):
+    with pytest.raises(ContractSourceManagerVerificationError):
         manager.verify_precompiled_checksums(contracts_precompiled_path())
 
     checksum_fail = list(original_checksum)
     # Replace the first char with a different one
     checksum_fail[0] = 'a' if checksum_fail[0] == '2' else '2'
     manager.overall_checksum = ''.join(checksum_fail)
-    with pytest.raises(ContractManagerVerificationError):
+    with pytest.raises(ContractSourceManagerVerificationError):
         manager.verify_precompiled_checksums(contracts_precompiled_path())
 
     manager.overall_checksum = original_checksum
@@ -77,22 +77,22 @@ def test_verification_contracts_checksums():
     assert manager.contracts_checksums
     for contract, checksum in manager.contracts_checksums.items():
         manager.contracts_checksums[contract] += '2'
-        with pytest.raises(ContractManagerVerificationError):
+        with pytest.raises(ContractSourceManagerVerificationError):
             manager.verify_precompiled_checksums(contracts_precompiled_path())
 
         manager.contracts_checksums[contract] = None  # type: ignore
-        with pytest.raises(ContractManagerVerificationError):
+        with pytest.raises(ContractSourceManagerVerificationError):
             manager.verify_precompiled_checksums(contracts_precompiled_path())
 
         manager.contracts_checksums[contract] = ''
-        with pytest.raises(ContractManagerVerificationError):
+        with pytest.raises(ContractSourceManagerVerificationError):
             manager.verify_precompiled_checksums(contracts_precompiled_path())
 
         checksum_fail = list(checksum)
         # Replace the first char with a different one
         checksum_fail[0] = 'a' if checksum_fail[0] == '2' else '2'
         manager.contracts_checksums[contract] = ''.join(checksum_fail)
-        with pytest.raises(ContractManagerVerificationError):
+        with pytest.raises(ContractSourceManagerVerificationError):
             manager.verify_precompiled_checksums(contracts_precompiled_path())
 
         manager.contracts_checksums[contract] = checksum

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -13,10 +13,12 @@ from raiden_contracts.constants import (
 from raiden_contracts.contract_manager import (
     ContractManager,
     ContractManagerLoadError,
-    ContractSourceManager,
-    ContractSourceManagerVerificationError,
     contracts_deployed_path,
     contracts_precompiled_path,
+)
+from raiden_contracts.contract_source_manager import (
+    ContractSourceManager,
+    ContractSourceManagerVerificationError,
     contracts_source_path,
 )
 

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -256,3 +256,9 @@ def test_contract_manager_precompiled_load_error():
     with NamedTemporaryFile() as empty_file:
         with pytest.raises(ContractManagerLoadError):
             ContractManager(Path(empty_file.name))
+
+
+def test_contract_source_manager_constructor_with_wrong_type():
+    """ ConstructSourceManager's constructor raises TypeError on a wrong kind of argument """
+    with pytest.raises(TypeError):
+        ContractSourceManager(None)  # type: ignore

--- a/raiden_contracts/tests/test_deploy_data.py
+++ b/raiden_contracts/tests/test_deploy_data.py
@@ -10,10 +10,10 @@ from raiden_contracts.contract_manager import (
 )
 
 
-@pytest.mark.parametrize("version", [None, CONTRACTS_VERSION])
+@pytest.mark.parametrize('version', [None, CONTRACTS_VERSION])
 def test_deploy_data_dir_exists(version: Optional[str]):
     """ Make sure directories exist for deployment data """
-    assert contracts_data_path(version).exists(), "deployment data do not exist"
+    assert contracts_data_path(version).exists(), 'deployment data do not exist'
     assert contracts_data_path(version).is_dir()
 
 
@@ -23,9 +23,9 @@ def test_deploy_data_dir_is_not_nested(version: Optional[str]):
     assert list(contracts_data_path(version).glob('./data*')) == []
 
 
-@pytest.mark.parametrize("version", [None, CONTRACTS_VERSION])
-@pytest.mark.parametrize("chain_id", [3, 4, 42])
-@pytest.mark.parametrize("services", [False, True])
+@pytest.mark.parametrize('version', [None, CONTRACTS_VERSION])
+@pytest.mark.parametrize('chain_id', [3, 4, 42])
+@pytest.mark.parametrize('services', [False, True])
 def test_deploy_data_file_exists(
         version: Optional[str],
         chain_id: int,
@@ -37,42 +37,42 @@ def test_deploy_data_file_exists(
 
 def reasonable_deployment_of_a_contract(deployed):
     """ Checks an entry under deployment_*.json under a contract name """
-    assert isinstance(deployed["address"], str)
-    assert len(deployed["address"]) == 42
-    assert isinstance(deployed["transaction_hash"], str)
-    assert len(deployed["transaction_hash"]) == 66
-    assert isinstance(deployed["block_number"], int)
-    assert deployed["block_number"] > 0
-    assert isinstance(deployed["gas_cost"], int)
-    assert deployed["gas_cost"] > 0
-    assert isinstance(deployed["constructor_arguments"], list)
+    assert isinstance(deployed['address'], str)
+    assert len(deployed['address']) == 42
+    assert isinstance(deployed['transaction_hash'], str)
+    assert len(deployed['transaction_hash']) == 66
+    assert isinstance(deployed['block_number'], int)
+    assert deployed['block_number'] > 0
+    assert isinstance(deployed['gas_cost'], int)
+    assert deployed['gas_cost'] > 0
+    assert isinstance(deployed['constructor_arguments'], list)
 
 
-@pytest.mark.parametrize("version", [None])
-@pytest.mark.parametrize("chain_id", [3, 4, 42])
+@pytest.mark.parametrize('version', [None])
+@pytest.mark.parametrize('chain_id', [3, 4, 42])
 def test_deploy_data_has_fields_raiden(
         version: Optional[str],
         chain_id: int,
 ):
     data = get_contracts_deployed(chain_id, version, services=False)
-    assert data["contracts_version"] == version if version else CONTRACTS_VERSION
-    assert data["chain_id"] == chain_id
-    contracts = data["contracts"]
-    for name in {"EndpointRegistry", "TokenNetworkRegistry", "SecretRegistry"}:
+    assert data['contracts_version'] == version if version else CONTRACTS_VERSION
+    assert data['chain_id'] == chain_id
+    contracts = data['contracts']
+    for name in {'EndpointRegistry', 'TokenNetworkRegistry', 'SecretRegistry'}:
         deployed = contracts[name]
         reasonable_deployment_of_a_contract(deployed)
 
 
-@pytest.mark.parametrize("version", [None])
-@pytest.mark.parametrize("chain_id", [3, 4, 42])
+@pytest.mark.parametrize('version', [None])
+@pytest.mark.parametrize('chain_id', [3, 4, 42])
 def test_deploy_data_has_fields_services(
         version: Optional[str],
         chain_id: int,
 ):
     data = get_contracts_deployed(chain_id, version, services=True)
-    assert data["contracts_version"] == version if version else CONTRACTS_VERSION
-    assert data["chain_id"] == chain_id
-    contracts = data["contracts"]
-    for name in {"ServiceRegistry", "MonitoringService", "OneToN", "UserDeposit"}:
+    assert data['contracts_version'] == version if version else CONTRACTS_VERSION
+    assert data['chain_id'] == chain_id
+    contracts = data['contracts']
+    for name in {'ServiceRegistry', 'MonitoringService', 'OneToN', 'UserDeposit'}:
         deployed = contracts[name]
         reasonable_deployment_of_a_contract(deployed)

--- a/raiden_contracts/tests/test_etherscan_verify.py
+++ b/raiden_contracts/tests/test_etherscan_verify.py
@@ -12,7 +12,7 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
 )
-from raiden_contracts.contract_manager import ContractManager, contracts_source_path
+from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
 from raiden_contracts.deploy.etherscan_verify import (
     api_of_chain_id,
     etherscan_verify,
@@ -27,7 +27,7 @@ contract_name = 'DummyContract'
 
 def test_get_constructor_args_no_args():
     """ Test get_constructor_args() on no arguments """
-    contract_manager = ContractManager(contracts_source_path())
+    contract_manager = ContractManager(contracts_precompiled_path())
     deploy_info: Dict = {
         'contracts': {
             contract_name: {
@@ -47,7 +47,7 @@ def abi_with_constructor_input_types(types: List[str]):
 
 def test_get_constructor_args_one_arg():
     """ Test get_constructor_args() on one argument """
-    contract_manager = ContractManager(contracts_source_path())
+    contract_manager = ContractManager(contracts_precompiled_path())
     contract_manager.contracts[contract_name] = {
         'abi': abi_with_constructor_input_types(['uint256']),
     }
@@ -64,7 +64,7 @@ def test_get_constructor_args_one_arg():
 
 def test_get_constructor_args_two_args():
     """ Test get_constructor_args() on two arguments """
-    contract_manager = ContractManager(contracts_source_path())
+    contract_manager = ContractManager(contracts_precompiled_path())
     contract_manager.contracts[contract_name] = {
         'abi': abi_with_constructor_input_types(['uint256', 'bool']),
     }

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 
 from raiden_contracts.constants import (

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,10 @@ class VerifyContracts(Command):
 
     def run(self):
         from raiden_contracts.contract_manager import (
-            ContractSourceManager,
             contracts_precompiled_path,
+        )
+        from raiden_contracts.contract_source_manager import (
+            ContractSourceManager,
             contracts_source_path,
         )
         manager = ContractSourceManager(contracts_source_path())
@@ -66,9 +68,9 @@ class CompileContracts(Command):
         pass
 
     def run(self):
-        from raiden_contracts.contract_manager import (
+        from raiden_contracts.contract_manager import contracts_precompiled_path
+        from raiden_contracts.contract_source_manager import (
             ContractSourceManager,
-            contracts_precompiled_path,
             contracts_source_path,
         )
 

--- a/setup.py
+++ b/setup.py
@@ -46,11 +46,11 @@ class VerifyContracts(Command):
 
     def run(self):
         from raiden_contracts.contract_manager import (
-            ContractManager,
+            ContractSourceManager,
             contracts_precompiled_path,
             contracts_source_path,
         )
-        manager = ContractManager(contracts_source_path())
+        manager = ContractSourceManager(contracts_source_path())
         manager.checksum_contracts()
         manager.verify_precompiled_checksums(contracts_precompiled_path())
 
@@ -67,12 +67,12 @@ class CompileContracts(Command):
 
     def run(self):
         from raiden_contracts.contract_manager import (
-            ContractManager,
+            ContractSourceManager,
             contracts_precompiled_path,
             contracts_source_path,
         )
 
-        contract_manager = ContractManager(contracts_source_path())
+        contract_manager = ContractSourceManager(contracts_source_path())
         contract_manager.compile_contracts(contracts_precompiled_path())
 
 


### PR DESCRIPTION
Before this PR, there were two ways to create a ContractManager object, with sources and with precompiled json file.  This PR splits the two uses into two different classes.

This closes #695.