### PR TITLE
MS should be able to claim reward after settle period ends

### DIFF
--- a/raiden_contracts/data/source/services/MonitoringService.sol
+++ b/raiden_contracts/data/source/services/MonitoringService.sol
@@ -232,7 +232,7 @@ contract MonitoringService is Utils {
         ));
 
         // Only allowed to claim, if channel is out of the settlement period
-        TokenNetwork.ChannelState channel_state;
+        uint256 settle_block_number;
         (settle_block_number,) = token_network.getChannelInfo(
             channel_identifier,
             closing_participant,

--- a/raiden_contracts/data/source/services/MonitoringService.sol
+++ b/raiden_contracts/data/source/services/MonitoringService.sol
@@ -231,15 +231,14 @@ contract MonitoringService is Utils {
             token_network_address
         ));
 
-        // Only allowed to claim, if channel is settled
-        // Channel is settled if it's data has been deleted
+        // Only allowed to claim, if channel is out of the settlement period
         TokenNetwork.ChannelState channel_state;
-        (, channel_state) = token_network.getChannelInfo(
+        (settle_block_number,) = token_network.getChannelInfo(
             channel_identifier,
             closing_participant,
             non_closing_participant
         );
-        require(channel_state == TokenNetwork.ChannelState.Removed);
+        require(settle_block_number < block.number);
 
         Reward storage reward = rewards[reward_identifier];
 

--- a/raiden_contracts/tests/test_monitoring_service.py
+++ b/raiden_contracts/tests/test_monitoring_service.py
@@ -75,7 +75,7 @@ def monitor_data(
     }
 
 
-def test_claimReward(
+def test_claimReward_with_settle_call(
         token_network,
         monitoring_service_external,
         user_deposit_contract,
@@ -96,7 +96,7 @@ def test_claimReward(
         monitor_data['reward_proof_signature'],
     ).transact({'from': ms_address})
 
-    # claiming before settlement must fail
+    # claiming before settlement timeout must fail
     with pytest.raises(TransactionFailed):
         monitoring_service_external.functions.claimReward(
             channel_identifier,
@@ -117,6 +117,66 @@ def test_claimReward(
         0,                   # participant_A_locked_amount
         EMPTY_LOCKSROOT,     # participant_A_locksroot
     ).transact()
+
+    # Claim reward for MS
+    monitoring_service_external.functions.claimReward(
+        channel_identifier,
+        token_network.address,
+        A, B,
+    ).transact({'from': ms_address})
+
+    # Check REWARD_CLAIMED event
+    reward_identifier = Web3.sha3(
+        encode_single('uint256', channel_identifier) +
+        Web3.toBytes(hexstr=token_network.address),
+    )
+    ms_ev_handler = event_handler(monitoring_service_external)
+    ms_ev_handler.assert_event(
+        txn_hash,
+        MonitoringServiceEvent.REWARD_CLAIMED,
+        dict(
+            ms_address=ms_address,
+            amount=REWARD_AMOUNT,
+            reward_identifier=reward_identifier,
+        ),
+    )
+
+    # Check that MS balance has increased by claiming the reward
+    ms_balance_after_reward = user_deposit_contract.functions.balances(ms_address).call()
+    assert ms_balance_after_reward == REWARD_AMOUNT
+
+
+def test_claimReward_without_settle_call(
+        token_network,
+        monitoring_service_external,
+        user_deposit_contract,
+        event_handler,
+        monitor_data,
+        ms_address,
+):
+    A, B = monitor_data['participants']
+    channel_identifier = monitor_data['channel_identifier']
+
+    # MS updates closed channel on behalf of B
+    txn_hash = monitoring_service_external.functions.monitor(
+        A, B,
+        *monitor_data['balance_proof_B'],
+        monitor_data['non_closing_signature'],
+        REWARD_AMOUNT,
+        token_network.address,
+        monitor_data['reward_proof_signature'],
+    ).transact({'from': ms_address})
+
+    # claiming before settlement timeout must fail
+    with pytest.raises(TransactionFailed):
+        monitoring_service_external.functions.claimReward(
+            channel_identifier,
+            token_network.address,
+            A, B,
+        ).transact({'from': ms_address})
+
+    # Wait for settle_timeout to elapse
+    token_network.web3.testing.mine(8)
 
     # Claim reward for MS
     monitoring_service_external.functions.claimReward(


### PR DESCRIPTION
As per our conversation with @palango and @Dominik1999 in the chat.

It makes no sense to claim a reward after the channel data has been removed. Instead we should only wait until the end of the settlement period.

@pirapira : My system only has solc v0.5.5 and as such I can't run `make compile contracts`. Got no time to compile solidity by hand for v0.5.4 now so I would like to see if someone else can do it. If not I will just have to bite the bullet at some point.

Also is this the file you are supposed to change to introduce changes?