### PR TITLE
Move test constants from `web3_fixtures.py`

### DIFF
--- a/raiden_contracts/tests/fixtures/base/web3_fixtures.py
+++ b/raiden_contracts/tests/fixtures/base/web3_fixtures.py
@@ -2,16 +2,14 @@ import logging
 
 import pytest
 from eth_tester import EthereumTester, PyEVMBackend
-from eth_utils import denoms
 from web3 import Web3
 from web3.providers.eth_tester import EthereumTesterProvider
 
-from raiden_contracts.tests.utils.constants import FAUCET_ADDRESS, FAUCET_PRIVATE_KEY
-
-DEFAULT_TIMEOUT = 5
-DEFAULT_RETRY_INTERVAL = 3
-FAUCET_ALLOWANCE = 100 * denoms.ether  # pylint: disable=E1101
-INITIAL_TOKEN_SUPPLY = 200000000000
+from raiden_contracts.tests.utils.constants import (
+    FAUCET_ADDRESS,
+    FAUCET_ALLOWANCE,
+    FAUCET_PRIVATE_KEY,
+)
 
 log = logging.getLogger(__name__)
 

--- a/raiden_contracts/tests/utils/constants.py
+++ b/raiden_contracts/tests/utils/constants.py
@@ -1,5 +1,7 @@
 from enum import IntEnum
 
+from eth_utils import denoms
+
 from raiden_contracts.utils.signature import private_key_to_address
 
 MAX_UINT256 = 2 ** 256 - 1
@@ -14,6 +16,7 @@ EMPTY_SIGNATURE = b'\x00' * 65
 passphrase = '0'
 FAUCET_PRIVATE_KEY = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 FAUCET_ADDRESS = private_key_to_address(FAUCET_PRIVATE_KEY)
+FAUCET_ALLOWANCE = 100 * denoms.ether  # pylint: disable=E1101
 CONTRACT_DEPLOYER_ADDRESS = FAUCET_ADDRESS
 
 

--- a/raiden_contracts/tests/utils/contracts.py
+++ b/raiden_contracts/tests/utils/contracts.py
@@ -2,7 +2,7 @@ from web3 import Web3
 from web3.providers.eth_tester import EthereumTesterProvider
 
 from raiden_contracts.constants import CONTRACT_CUSTOM_TOKEN, CONTRACT_TOKEN_NETWORK
-from raiden_contracts.tests.fixtures.base.web3_fixtures import FAUCET_ALLOWANCE
+from raiden_contracts.tests.utils.constants import FAUCET_ALLOWANCE
 from raiden_contracts.utils.signature import private_key_to_address
 
 


### PR DESCRIPTION
* `tests.utils.constants` is a better place from them
* some could be deleted
* avoids a circular import