### PR TITLE
Split verifyer away from deployer

### DIFF
--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -7,19 +7,16 @@ from web3.contract import ContractFunction
 from web3.middleware import construct_sign_and_send_raw_middleware
 
 from raiden_contracts.constants import CONTRACTS_VERSION
-from raiden_contracts.contract_manager import (
-    ContractManager,
-    contract_version_string,
-    contracts_precompiled_path,
-)
+from raiden_contracts.contract_manager import contract_version_string
 from raiden_contracts.contract_source_manager import ContractSourceManager, contracts_source_path
+from raiden_contracts.deploy.contract_verifyer import ContractVerifyer
 from raiden_contracts.utils.signature import private_key_to_address
 from raiden_contracts.utils.transaction import check_successful_tx
 
 LOG = getLogger(__name__)
 
 
-class ContractDeployer:
+class ContractDeployer(ContractVerifyer):
     def __init__(
             self,
             web3: Web3,
@@ -30,16 +27,13 @@ class ContractDeployer:
             contracts_version: Optional[str]=None,
     ):
         # pylint: disable=E1101
-        self.web3 = web3
+        super(ContractDeployer, self).__init__(web3=web3, contracts_version=contracts_version)
         self.wait = wait
         self.owner = private_key_to_address(private_key)
         self.transaction = {'from': self.owner, 'gas': gas_limit}
         if gas_price != 0:
             self.transaction['gasPrice'] = gas_price * denoms.gwei
 
-        self.contracts_version = contracts_version
-        self.precompiled_path = contracts_precompiled_path(self.contracts_version)
-        self.contract_manager = ContractManager(self.precompiled_path)
         self.web3.middleware_stack.add(
             construct_sign_and_send_raw_middleware(private_key),
         )

--- a/raiden_contracts/deploy/contract_verifyer.py
+++ b/raiden_contracts/deploy/contract_verifyer.py
@@ -1,0 +1,320 @@
+import json
+from typing import Any, Dict, Optional
+
+from eth_utils import to_checksum_address
+from mypy_extensions import TypedDict
+from web3 import Web3
+from web3.contract import Contract
+
+from raiden_contracts.constants import (
+    CONTRACT_ENDPOINT_REGISTRY,
+    CONTRACT_MONITORING_SERVICE,
+    CONTRACT_ONE_TO_N,
+    CONTRACT_SECRET_REGISTRY,
+    CONTRACT_SERVICE_REGISTRY,
+    CONTRACT_TOKEN_NETWORK_REGISTRY,
+    CONTRACT_USER_DEPOSIT,
+)
+from raiden_contracts.contract_manager import (
+    ContractManager,
+    contracts_deployed_path,
+    contracts_precompiled_path,
+    get_contracts_deployed,
+)
+from raiden_contracts.utils.bytecode import runtime_hexcode
+from raiden_contracts.utils.type_aliases import Address
+
+# Classes for static type checking of deployed_contracts dictionary.
+
+
+class DeployedContract(TypedDict):
+    address: Address
+    transaction_hash: str
+    block_number: int
+    gas_cost: int
+    constructor_arguments: Any
+
+
+class DeployedContracts(TypedDict):
+    chain_id: int
+    contracts: Dict[str, DeployedContract]
+    contracts_version: str
+
+
+class ContractVerifyer:
+    def __init__(
+            self,
+            web3: Web3,
+            contracts_version: Optional[str]=None,
+    ):
+        self.web3 = web3
+        self.contracts_version = contracts_version
+        self.precompiled_path = contracts_precompiled_path(self.contracts_version)
+        self.contract_manager = ContractManager(self.precompiled_path)
+
+    def verify_deployed_contracts_in_filesystem(self):
+        chain_id = int(self.web3.version.network)
+
+        deployment_data = get_contracts_deployed(
+            chain_id=chain_id,
+            version=self.contract_manager.contracts_version,
+        )
+        deployment_file_path = contracts_deployed_path(
+            chain_id=chain_id,
+            version=self.contract_manager.contracts_version,
+        )
+        assert deployment_data is not None
+
+        if self._verify_deployment_data(deployment_data):
+            print(f'Deployment info from {deployment_file_path} has been verified'
+                  'and it is CORRECT.')
+
+    def verify_deployed_service_contracts_in_filesystem(
+            self,
+            token_address: str,
+            user_deposit_whole_balance_limit: int,
+    ):
+        chain_id = int(self.web3.version.network)
+
+        deployment_data = get_contracts_deployed(
+            chain_id=chain_id,
+            version=self.contract_manager.contracts_version,
+            services=True,
+        )
+        deployment_file_path = contracts_deployed_path(
+            chain_id=chain_id,
+            version=self.contract_manager.contracts_version,
+            services=True,
+        )
+        assert deployment_data is not None
+
+        if self._verify_service_contracts_deployment_data(
+                token_address=token_address,
+                user_deposit_whole_balance_limit=user_deposit_whole_balance_limit,
+                deployment_data=deployment_data,
+        ):
+            print(f'Deployment info from {deployment_file_path} has been verified '
+                  'and it is CORRECT.')
+
+    def store_and_verify_deployment_info_raiden(
+            self,
+            deployed_contracts_info: DeployedContracts,
+            save_info: bool,
+    ):
+        if save_info:
+            self._store_deployment_info(
+                deployment_info=deployed_contracts_info,
+                services=False,
+            )
+            self.verify_deployed_contracts_in_filesystem()
+        else:
+            self._verify_deployment_data(deployed_contracts_info)
+
+    def store_and_verify_deployment_info_services(
+            self,
+            deployed_contracts_info: DeployedContracts,
+            save_info: bool,
+            token_address: str,
+            user_deposit_whole_limit: int,
+    ):
+        if save_info:
+            self._store_deployment_info(
+                services=True,
+                deployment_info=deployed_contracts_info,
+            )
+            self.verify_deployed_service_contracts_in_filesystem(
+                token_address=token_address,
+                user_deposit_whole_balance_limit=user_deposit_whole_limit,
+            )
+        else:
+            self._verify_service_contracts_deployment_data(
+                token_address=token_address,
+                user_deposit_whole_balance_limit=user_deposit_whole_limit,
+                deployment_data=deployed_contracts_info,
+            )
+
+    def _store_deployment_info(
+            self,
+            services: bool,
+            deployment_info: DeployedContracts,
+    ):
+        deployment_file_path = contracts_deployed_path(
+            chain_id=int(self.web3.version.network),
+            version=self.contracts_version,
+            services=services,
+        )
+        with deployment_file_path.open(mode='w') as target_file:
+            target_file.write(json.dumps(deployment_info))
+
+        print(
+            f'Deployment information for chain id = {deployment_info["chain_id"]} '
+            f' has been updated at {deployment_file_path}.',
+        )
+
+    def _verify_deployment_data(
+            self,
+            deployment_data: DeployedContracts,
+    ):
+        chain_id = int(self.web3.version.network)
+        assert deployment_data is not None
+
+        assert self.contract_manager.version_string() == deployment_data['contracts_version']
+        assert chain_id == deployment_data['chain_id']
+
+        self._verify_deployed_contract(
+            deployment_data=deployment_data,
+            contract_name=CONTRACT_ENDPOINT_REGISTRY,
+        )
+
+        secret_registry, _ = self._verify_deployed_contract(
+            deployment_data=deployment_data,
+            contract_name=CONTRACT_SECRET_REGISTRY,
+        )
+
+        token_network_registry, constructor_arguments = self._verify_deployed_contract(
+            deployment_data=deployment_data,
+            contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
+        )
+
+        # We need to also check the constructor parameters against the chain
+        assert to_checksum_address(
+            token_network_registry.functions.secret_registry_address().call(),
+        ) == secret_registry.address
+        assert secret_registry.address == constructor_arguments[0]
+        assert token_network_registry.functions.chain_id().call() == constructor_arguments[1]
+        assert token_network_registry.functions.settlement_timeout_min().call() == \
+            constructor_arguments[2]
+        assert token_network_registry.functions.settlement_timeout_max().call() == \
+            constructor_arguments[3]
+
+        return True
+
+    def _verify_deployed_contract(
+            self,
+            deployment_data: DeployedContracts,
+            contract_name: str,
+    ) -> Contract:
+        """ Verify deployment info against the chain
+
+        Verifies:
+        - the runtime bytecode - precompiled data against the chain
+        - information stored in deployment_*.json against the chain,
+        except for the constructor arguments, which have to be checked
+        separately.
+
+        Returns: (onchain_instance, constructor_arguments)
+        """
+        contracts = deployment_data['contracts']
+
+        contract_address = contracts[contract_name]['address']
+        contract_instance = self.web3.eth.contract(
+            abi=self.contract_manager.get_contract_abi(contract_name),
+            address=contract_address,
+        )
+
+        # Check that the deployed bytecode matches the precompiled data
+        blockchain_bytecode = self.web3.eth.getCode(contract_address).hex()
+        compiled_bytecode = runtime_hexcode(
+            contracts_manager=self.contract_manager,
+            name=contract_name,
+        )
+        assert blockchain_bytecode == compiled_bytecode
+
+        print(
+            f'{contract_name} at {contract_address} '
+            f'matches the compiled data from contracts.json',
+        )
+
+        # Check blockchain transaction hash & block information
+        receipt = self.web3.eth.getTransactionReceipt(
+            contracts[contract_name]['transaction_hash'],
+        )
+        assert receipt['blockNumber'] == contracts[contract_name]['block_number'], (
+            f'We have block_number {contracts[contract_name]["block_number"]} '
+            f'instead of {receipt["blockNumber"]}'
+        )
+        assert receipt['gasUsed'] == contracts[contract_name]['gas_cost'], (
+            f'We have gasUsed {contracts[contract_name]["gas_cost"]} '
+            f'instead of {receipt["gasUsed"]}'
+        )
+        assert receipt['contractAddress'] == contracts[contract_name]['address'], (
+            f'We have contractAddress {contracts[contract_name]["address"]} '
+            f'instead of {receipt["contractAddress"]}'
+        )
+
+        # Check the contract version
+        version = contract_instance.functions.contract_version().call()
+        assert version == deployment_data['contracts_version'], \
+            f'got {version} expected {deployment_data["contracts_version"]}.' \
+            f'contract_manager has contracts_version {self.contract_manager.contracts_version}'
+
+        return contract_instance, contracts[contract_name]['constructor_arguments']
+
+    def _verify_service_contracts_deployment_data(
+            self,
+            token_address: str,
+            user_deposit_whole_balance_limit: int,
+            deployment_data: DeployedContracts,
+    ):
+        chain_id = int(self.web3.version.network)
+        assert deployment_data is not None
+
+        assert self.contract_manager.version_string() == deployment_data['contracts_version']
+        assert chain_id == deployment_data['chain_id']
+
+        service_bundle, constructor_arguments = self._verify_deployed_contract(
+            deployment_data=deployment_data,
+            contract_name=CONTRACT_SERVICE_REGISTRY,
+        )
+        assert to_checksum_address(service_bundle.functions.token().call()) == token_address
+        assert token_address == constructor_arguments[0]
+
+        user_deposit, constructor_arguments = self._verify_deployed_contract(
+            deployment_data=deployment_data,
+            contract_name=CONTRACT_USER_DEPOSIT,
+        )
+        assert len(constructor_arguments) == 2
+        assert to_checksum_address(user_deposit.functions.token().call()) == token_address
+        assert token_address == constructor_arguments[0]
+        assert user_deposit.functions.whole_balance_limit().call() == \
+            user_deposit_whole_balance_limit
+        assert user_deposit_whole_balance_limit == constructor_arguments[1]
+
+        monitoring_service, constructor_arguments = self._verify_deployed_contract(
+            deployment_data,
+            CONTRACT_MONITORING_SERVICE,
+        )
+        assert len(constructor_arguments) == 3
+        assert to_checksum_address(monitoring_service.functions.token().call()) == token_address
+        assert token_address == constructor_arguments[0]
+
+        assert to_checksum_address(
+            monitoring_service.functions.service_registry().call(),
+        ) == service_bundle.address
+        assert service_bundle.address == constructor_arguments[1]
+
+        assert to_checksum_address(
+            monitoring_service.functions.user_deposit().call(),
+        ) == user_deposit.address
+        assert user_deposit.address == constructor_arguments[2]
+
+        one_to_n, constructor_arguments = self._verify_deployed_contract(
+            deployment_data=deployment_data,
+            contract_name=CONTRACT_ONE_TO_N,
+        )
+        assert to_checksum_address(
+            one_to_n.functions.deposit_contract().call(),
+        ) == user_deposit.address
+        assert user_deposit.address == constructor_arguments[0]
+        assert len(constructor_arguments) == 1
+
+        # Check that UserDeposit.init() had the right effect
+        onchain_msc_address = to_checksum_address(user_deposit.functions.msc_address().call())
+        assert onchain_msc_address == monitoring_service.address, \
+            f'MSC address found onchain: {onchain_msc_address}, ' \
+            f'expected: {monitoring_service.address}'
+        assert to_checksum_address(
+            user_deposit.functions.one_to_n_address().call(),
+        ) == one_to_n.address
+
+        return True

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -26,11 +26,7 @@ from raiden_contracts.deploy.__main__ import (
     deploy_token_contract,
     error_removed_option,
     register_token_network,
-    store_and_verify_deployment_info_raiden,
-    store_and_verify_deployment_info_services,
     validate_address,
-    verify_deployment_data,
-    verify_service_contracts_deployment_data,
 )
 from raiden_contracts.tests.utils import get_random_privkey
 from raiden_contracts.tests.utils.constants import (
@@ -125,27 +121,21 @@ def test_deploy_script_raiden(
     """
     deployed_contracts_info = deployed_raiden_info
 
-    verify_deployment_data(
-        web3=deployer.web3,
-        contract_manager=deployer.contract_manager,
+    deployer._verify_deployment_data(
         deployment_data=deployed_contracts_info,
     )
 
     deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
     deployed_contracts_info_fail['contracts_version'] = '0.0.0'
     with pytest.raises(AssertionError):
-        verify_deployment_data(
-            web3=deployer.web3,
-            contract_manager=deployer.contract_manager,
+        deployer._verify_deployment_data(
             deployment_data=deployed_contracts_info_fail,
         )
 
     deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
     deployed_contracts_info_fail['chain_id'] = 0
     with pytest.raises(AssertionError):
-        verify_deployment_data(
-            web3=deployer.web3,
-            contract_manager=deployer.contract_manager,
+        deployer._verify_deployment_data(
             deployment_data=deployed_contracts_info_fail,
         )
 
@@ -154,18 +144,14 @@ def test_deploy_script_raiden(
         CONTRACT_ENDPOINT_REGISTRY
     ]['address'] = EMPTY_ADDRESS
     with pytest.raises(AssertionError):
-        verify_deployment_data(
-            deployer.web3,
-            deployer.contract_manager,
+        deployer._verify_deployment_data(
             deployed_contracts_info_fail,
         )
 
     deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
     deployed_contracts_info_fail['contracts'][CONTRACT_SECRET_REGISTRY]['address'] = EMPTY_ADDRESS
     with pytest.raises(AssertionError):
-        verify_deployment_data(
-            deployer.web3,
-            deployer.contract_manager,
+        deployer._verify_deployment_data(
             deployed_contracts_info_fail,
         )
 
@@ -174,36 +160,28 @@ def test_deploy_script_raiden(
         CONTRACT_TOKEN_NETWORK_REGISTRY
     ]['address'] = EMPTY_ADDRESS
     with pytest.raises(AssertionError):
-        verify_deployment_data(
-            deployer.web3,
-            deployer.contract_manager,
+        deployer._verify_deployment_data(
             deployed_contracts_info_fail,
         )
 
     deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
     deployed_contracts_info_fail['contracts'][CONTRACT_ENDPOINT_REGISTRY]['block_number'] = 0
     with pytest.raises(AssertionError):
-        verify_deployment_data(
-            deployer.web3,
-            deployer.contract_manager,
+        deployer._verify_deployment_data(
             deployed_contracts_info_fail,
         )
 
     deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
     deployed_contracts_info_fail['contracts'][CONTRACT_SECRET_REGISTRY]['block_number'] = 0
     with pytest.raises(AssertionError):
-        verify_deployment_data(
-            deployer.web3,
-            deployer.contract_manager,
+        deployer._verify_deployment_data(
             deployed_contracts_info_fail,
         )
 
     deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
     deployed_contracts_info_fail['contracts'][CONTRACT_TOKEN_NETWORK_REGISTRY]['block_number'] = 0
     with pytest.raises(AssertionError):
-        verify_deployment_data(
-            deployer.web3,
-            deployer.contract_manager,
+        deployer._verify_deployment_data(
             deployed_contracts_info_fail,
         )
 
@@ -339,9 +317,7 @@ def test_deploy_script_service(
     deposit_limit = token_supply // 2
 
     deployed_service_contracts = deployed_service_info
-    verify_service_contracts_deployment_data(
-        web3=deployer.web3,
-        contract_manager=deployer.contract_manager,
+    deployer._verify_service_contracts_deployment_data(
         token_address=token_address,
         user_deposit_whole_balance_limit=deposit_limit,
         deployment_data=deployed_service_contracts,
@@ -350,9 +326,7 @@ def test_deploy_script_service(
     deployed_info_fail = deepcopy(deployed_service_contracts)
     deployed_info_fail['contracts_version'] = '0.0.0'
     with pytest.raises(AssertionError):
-        verify_service_contracts_deployment_data(
-            web3=deployer.web3,
-            contract_manager=deployer.contract_manager,
+        deployer._verify_service_contracts_deployment_data(
             token_address=token_address,
             user_deposit_whole_balance_limit=deposit_limit,
             deployment_data=deployed_info_fail,
@@ -364,9 +338,7 @@ def test_deploy_script_service(
             contract_name
         ]['address'] = EMPTY_ADDRESS
         with pytest.raises(AssertionError):
-            verify_service_contracts_deployment_data(
-                web3=deployer.web3,
-                contract_manager=deployer.contract_manager,
+            deployer._verify_service_contracts_deployment_data(
                 token_address=token_address,
                 user_deposit_whole_balance_limit=deposit_limit,
                 deployment_data=deployed_info_fail,
@@ -421,15 +393,11 @@ def test_store_and_verify_raiden(fs_reload_deployer, web3, deployed_raiden_info,
         version=None,
     ).parent)
     deployed_contracts_info = deployed_raiden_info
-    store_and_verify_deployment_info_raiden(
-        contracts_version=None,
-        deployer=deployer,
+    deployer.store_and_verify_deployment_info_raiden(
         deployed_contracts_info=deployed_contracts_info,
         save_info=False,
     )
-    store_and_verify_deployment_info_raiden(
-        contracts_version=None,
-        deployer=deployer,
+    deployer.store_and_verify_deployment_info_raiden(
         deployed_contracts_info=deployed_contracts_info,
         save_info=True,
     )
@@ -448,18 +416,14 @@ def test_store_and_verify_services(
         version=None,
     ).parent)
     deployed_contracts_info = deployed_service_info
-    store_and_verify_deployment_info_services(
+    deployer.store_and_verify_deployment_info_services(
         token_address=token_address,
-        contracts_version=None,
-        deployer=deployer,
         deployed_contracts_info=deployed_contracts_info,
         save_info=False,
         user_deposit_whole_limit=DEPOSIT_LIMIT,
     )
-    store_and_verify_deployment_info_services(
+    deployer.store_and_verify_deployment_info_services(
         token_address=token_address,
-        contracts_version=None,
-        deployer=deployer,
         deployed_contracts_info=deployed_contracts_info,
         save_info=True,
         user_deposit_whole_limit=DEPOSIT_LIMIT,

--- a/raiden_contracts/utils/logs.py
+++ b/raiden_contracts/utils/logs.py
@@ -7,7 +7,6 @@ from web3.utils.events import get_event_data
 from web3.utils.filters import construct_event_filter_params
 from web3.utils.threads import Timeout
 
-
 # A concrete event added in a transaction.
 LogRecorded = namedtuple('LogRecorded', 'message callback count')
 


### PR DESCRIPTION
This PR purely shuffles code around.

The original motivation was to reduce the number of lines in `raiden_contracts/deployer/_main_.py` 
https://github.com/raiden-network/raiden-contracts/issues/714 .

* I moved some code from `_main_.py` into `contract_deployer.py`.
* Then I had to separate `contract_verifyer.py` away because sometimes we don't have enough information to deploy but just want to verify the existing deployement data.