### PR TITLE
Split a complicated function `join()`

### DIFF
--- a/raiden_contracts/utils/join-contracts.py
+++ b/raiden_contracts/utils/join-contracts.py
@@ -3,7 +3,7 @@ import json
 import os
 import re
 import sys
-from typing import Set
+from typing import List, Set
 
 import click
 from click.types import File
@@ -29,7 +29,7 @@ class ContractJoiner:
         self.import_map = import_map if import_map else {}
 
     def join(self, contract_file):
-        out = []
+        out: List[str] = []
         if contract_file.name in self.seen:
             print('Skipping duplicate {}'.format(contract_file.name), file=sys.stderr)
             return []
@@ -41,23 +41,43 @@ class ContractJoiner:
             line = line.strip('\r\n')
             stripped_line = line.strip()
             if stripped_line.startswith('pragma'):
-                if not self.have_pragma:
-                    self.have_pragma = True
-                    out.append(line)
+                self._on_pragma_line(
+                    line=line,
+                    out=out,
+                )
             elif stripped_line.startswith('import'):
-                match = IMPORT_RE.match(stripped_line)
-                if match:
-                    next_file = match.groupdict().get('contract')
-                    assert next_file
-                    for prefix, path in self.import_map.items():
-                        if next_file.startswith(prefix):
-                            next_file = next_file.replace(prefix, path)
-                    if next_file and os.path.exists(next_file):
-                        with open(next_file) as next_contract:
-                            out.extend(self.join(next_contract))
+                self._on_import_line(
+                    stripped_line=stripped_line,
+                    out=out,
+                )
             else:
                 out.append(line)
         return out
+
+    def _on_pragma_line(
+            self,
+            line: str,
+            out: List[str],
+    ):
+        if not self.have_pragma:
+            self.have_pragma = True
+            out.append(line)
+
+    def _on_import_line(
+            self,
+            stripped_line: str,
+            out: List[str],
+    ):
+        match = IMPORT_RE.match(stripped_line)
+        if match:
+            next_file = match.groupdict().get('contract')
+            assert next_file
+            for prefix, path in self.import_map.items():
+                if next_file.startswith(prefix):
+                    next_file = next_file.replace(prefix, path)
+            if next_file and os.path.exists(next_file):
+                with open(next_file) as next_contract:
+                    out.extend(self.join(next_contract))
 
 
 @click.command()


### PR DESCRIPTION
because CodeClimate says it is too complicated:
https://github.com/raiden-network/raiden-contracts/issues/763