### PR TITLE
Make deploy register runnable

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -56,7 +56,8 @@ def validate_address(_, _param, value):
 
 
 def error_removed_option(_, param, value):
-    raise click.NoSuchOption(f'--{param.name.replace("_", "-")} is no longer a valid option')
+    if value is not None:
+        raise click.NoSuchOption(f'--{param.name.replace("_", "-")} is no longer a valid option')
 
 
 def common_options(func):
@@ -473,7 +474,9 @@ def register(
         token_network_registry_address,
         channel_participant_deposit_limit,
         token_network_deposit_limit,
+        registry_address,
 ):
+    assert registry_address is None  # No longer used option
     setup_ctx(
         ctx,
         private_key,

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -486,4 +486,4 @@ def test_red_eyes_deployer(web3):
 def test_error_removed_option_raises():
     with pytest.raises(NoSuchOption):
         mock = MagicMock()
-        error_removed_option(None, mock, None)
+        error_removed_option(None, mock, '0xaabbcc')


### PR DESCRIPTION
Before this PR, `deploy register` command always failed.
There was a check against an obsolete option `--registry-address` and the check
was always called and failed.

Fixes #766