### PR TITLE
Make 0.4.0 deployable again

### DIFF
--- a/raiden_contracts/tests/deprecation_switch_testnet.py
+++ b/raiden_contracts/tests/deprecation_switch_testnet.py
@@ -163,6 +163,7 @@ def deprecation_test_setup(
         token_network_deposit_limit=token_network_deposit_limit,
         token_registry_version=deployer.contract_manager.version_string(),
         wait=deployer.wait,
+        contracts_version=deployer.contracts_version,
     )
 
     token_network_abi = deployer.contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK)

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -288,6 +288,7 @@ def test_deploy_script_register(
         token_address=token_address,
         channel_participant_deposit_limit=channel_participant_deposit_limit,
         token_network_deposit_limit=token_network_deposit_limit,
+        contracts_version=deployer.contracts_version,
     )
     assert token_network_address is not None
     assert isinstance(token_network_address, T_Address)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ rlp>=1.0.0
 coincurve>=8.0.0
 web3>=4.4.1
 py-solc>=3.0.0
+semver


### PR DESCRIPTION
`deploy register` failed on contracts version 0.4.0.  This commit fixes
#769