### PR TITLE
Make a suggestion when failing for obsolete option

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -51,9 +51,17 @@ def validate_address(_, _param, value):
         raise click.BadParameter('must be a valid ethereum address')
 
 
-def error_removed_option(_, param, value):
-    if value is not None:
-        raise click.NoSuchOption(f'--{param.name.replace("_", "-")} is no longer a valid option')
+def error_removed_option(message: str):
+    """ Takes a message and returns a callback that raises NoSuchOption
+
+    if the value is not None. The message is used as an argument to NoSuchOption. """
+    def f(_, param, value):
+        if value is not None:
+            raise click.NoSuchOption(
+                f'--{param.name.replace("_", "-")} is no longer a valid option. ' +
+                message,
+            )
+    return f
 
 
 def common_options(func):
@@ -373,7 +381,7 @@ def token(
 @click.option(
     '--registry-address',
     default=None,
-    callback=error_removed_option,
+    callback=error_removed_option('Use --token-network-registry-address'),
     hidden=True,
     help='Renamed into --token-network-registry-address',
 )

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -451,4 +451,4 @@ def test_red_eyes_deployer(web3):
 def test_error_removed_option_raises():
     with pytest.raises(NoSuchOption):
         mock = MagicMock()
-        error_removed_option(None, mock, '0xaabbcc')
+        error_removed_option('msg')(None, mock, '0xaabbcc')


### PR DESCRIPTION
When `deploy register` fails for the obsolete option `--registry-option`
the script should make a suggestion to use `--token-network-registry`.

This fixes #765.