### PR TITLE
get_contract_deployment_info that returns both service and raiden deployment info by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Documents changes that result in:
 
 ## Unreleased
 
+- Deprecated get_contracts_deployed() whose name sounded wrong and that had to be called twice.
 - deploy script does not take --registry option anymore.  Use --token-network-registry instead.
 
 ## [0.15.0](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.15.0) - 2019-03-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Documents changes that result in:
 
 ## Unreleased
 
-- Added contract_manager.get_contracts_deployed_info() that takes a module (`services`, `raiden` or `all`) instead of `services:bool`
+- Added contract_manager.get_contracts_deployed_info() that takes a module (`SERVICES`, `RAIDEN` or `ALL`) instead of `services:bool`
 - Deprecated get_contracts_deployed() whose name sounded wrong and that had to be called twice.
 - deploy script does not take --registry option anymore.  Use --token-network-registry instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Documents changes that result in:
 
 ## Unreleased
 
+- Added contract_manager.get_contracts_deployed_info() that takes a module (`services`, `raiden` or `all`) instead of `services:bool`
 - Deprecated get_contracts_deployed() whose name sounded wrong and that had to be called twice.
 - deploy script does not take --registry option anymore.  Use --token-network-registry instead.
 

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ If you want to use the officially deployed contracts, please use the ``raiden_co
     manager = ContractManager(contracts_precompiled_path(contracts_version))
     compiled_contract_data = manager.get_contract(CONTRACT_TOKEN_NETWORK_REGISTRY)
 
-    deployment_data = get_contracts_deployed(int(web3.version.network))
+    deployment_data = get_contracts_deployment_info(int(web3.version.network))
     TOKEN_NETWORK_REGISTRY_ADDRESS = deployment_data['contracts'][CONTRACT_TOKEN_NETWORK_REGISTRY].address
 
     # And then use:
@@ -83,7 +83,7 @@ If you want to use the officially deployed contracts, please use the ``raiden_co
     # To use one of the 3rd party services contracts:
     compiled_ms_contract = manager.get_contract(CONTRACT_MONITORING_SERVICE)
     deployed_services = get_contracts_deployed(int(web3.version.network), services=True)
-    MONITORING_SERVICE_ADDRESS = deployed_services['contracts'][CONTRACT_MONITORING_SERVICE].address
+    MONITORING_SERVICE_ADDRESS = deployment_data['contracts'][CONTRACT_MONITORING_SERVICE].address
 
 Test-only Contracts
 -------------------

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -1,6 +1,7 @@
 """ContractManager knows binaries and ABI of contracts."""
 import json
 from copy import deepcopy
+from enum import Enum
 from json import JSONDecodeError
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -125,6 +126,12 @@ def contracts_deployed_path(
     return data_path.joinpath(f'deployment_{"services_" if services else ""}{chain_name}.json')
 
 
+class DeploymentModule(Enum):
+    RAIDEN = 'raiden'
+    SERVICES = 'services'
+    ALL = 'all'
+
+
 @deprecated(reason='Use get_contract_deployment_info()')
 def get_contracts_deployed(
         chain_id: int,
@@ -135,7 +142,7 @@ def get_contracts_deployed(
     return get_contracts_deployment_info(
         chain_id=chain_id,
         version=version,
-        module='services' if services else 'raiden',
+        module=DeploymentModule.SERVICES if services else DeploymentModule.RAIDEN,
     )
 
 
@@ -167,26 +174,26 @@ def merge_deployment_data(dict1: Dict, dict2: Dict) -> Dict:
 def get_contracts_deployment_info(
         chain_id: int,
         version: Optional[str] = None,
-        module: str = 'all',
+        module: DeploymentModule = DeploymentModule.ALL,
 ) -> Dict:
     """Reads the deployment data.
 
     Parameter:
-        module The name of the module: currently, 'raiden' 'services' or 'all'.
+        module The name of the module. ALL means deployed contracts from all modules.
     """
-    if module not in {'all', 'services', 'raiden'}:
+    if module not in DeploymentModule:
         raise ValueError(f'Unknown module {module} given to get_contracts_deployment_info()')
 
     files: List[Path] = []
 
-    if module == 'raiden' or module == 'all':
+    if module == DeploymentModule.RAIDEN or module == DeploymentModule.ALL:
         files.append(contracts_deployed_path(
             chain_id=chain_id,
             version=version,
             services=False,
         ))
 
-    if module == 'services' or module == 'all':
+    if module == DeploymentModule.SERVICES or module == DeploymentModule.ALL:
         files.append(contracts_deployed_path(
             chain_id=chain_id,
             version=version,

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -4,6 +4,8 @@ from json import JSONDecodeError
 from pathlib import Path
 from typing import Dict, Optional
 
+from deprecated import deprecated
+
 from raiden_contracts.constants import CONTRACTS_VERSION, ID_TO_NETWORKNAME
 
 _BASE = Path(__file__).parent
@@ -103,6 +105,7 @@ def contracts_deployed_path(
     return data_path.joinpath(f'deployment_{"services_" if services else ""}{chain_name}.json')
 
 
+@deprecated(reason='Use get_contract_deployment_info()')
 def get_contracts_deployed(
         chain_id: int,
         version: Optional[str] = None,

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -1,6 +1,6 @@
 """ContractManager knows binaries and ABI of contracts."""
-from copy import deepcopy
 import json
+from copy import deepcopy
 from json import JSONDecodeError
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -171,7 +171,10 @@ def get_contracts_deployment_info(
     for f in files:
         try:
             with f.open() as deployment_file:
-                deployment_data = merge_deployment_data(deployment_data, json.load(deployment_file))
+                deployment_data = merge_deployment_data(
+                    deployment_data,
+                    json.load(deployment_file),
+                )
         except (JSONDecodeError, UnicodeDecodeError, FileNotFoundError) as ex:
             raise ValueError(f'Cannot load deployment data file: {ex}') from ex
     return deployment_data

--- a/raiden_contracts/deploy/contract_verifyer.py
+++ b/raiden_contracts/deploy/contract_verifyer.py
@@ -1,8 +1,7 @@
 import json
-from typing import Any, Dict, Optional
+from typing import Optional
 
 from eth_utils import to_checksum_address
-from mypy_extensions import TypedDict
 from web3 import Web3
 from web3.contract import Contract
 
@@ -17,28 +16,12 @@ from raiden_contracts.constants import (
 )
 from raiden_contracts.contract_manager import (
     ContractManager,
+    DeployedContracts,
     contracts_deployed_path,
     contracts_precompiled_path,
     get_contracts_deployed,
 )
 from raiden_contracts.utils.bytecode import runtime_hexcode
-from raiden_contracts.utils.type_aliases import Address
-
-# Classes for static type checking of deployed_contracts dictionary.
-
-
-class DeployedContract(TypedDict):
-    address: Address
-    transaction_hash: str
-    block_number: int
-    gas_cost: int
-    constructor_arguments: Any
-
-
-class DeployedContracts(TypedDict):
-    chain_id: int
-    contracts: Dict[str, DeployedContract]
-    contracts_version: str
 
 
 class ContractVerifyer:

--- a/raiden_contracts/tests/test_deploy_data.py
+++ b/raiden_contracts/tests/test_deploy_data.py
@@ -4,6 +4,7 @@ import pytest
 
 from raiden_contracts.constants import CONTRACTS_VERSION
 from raiden_contracts.contract_manager import (
+    DeploymentModule,
     contracts_data_path,
     contracts_deployed_path,
     get_contracts_deployed,
@@ -60,7 +61,7 @@ def test_deploy_data_has_fields_raiden(
         chain_id: int,
 ):
     data = get_contracts_deployed(chain_id, version, services=False)
-    data2 = get_contracts_deployment_info(chain_id, version, module='raiden')
+    data2 = get_contracts_deployment_info(chain_id, version, module=DeploymentModule.RAIDEN)
     assert data2 == data
     assert data['contracts_version'] == version if version else CONTRACTS_VERSION
     assert data['chain_id'] == chain_id
@@ -80,7 +81,7 @@ def test_deploy_data_has_fields_services(
         chain_id: int,
 ):
     data = get_contracts_deployed(chain_id, version, services=True)
-    data2 = get_contracts_deployment_info(chain_id, version, module='services')
+    data2 = get_contracts_deployment_info(chain_id, version, module=DeploymentModule.SERVICES)
     assert data2 == data
     assert data['contracts_version'] == version if version else CONTRACTS_VERSION
     assert data['chain_id'] == chain_id
@@ -99,8 +100,8 @@ def test_deploy_data_all(
     data_services = get_contracts_deployed(chain_id, version, services=True)
     data_raiden = get_contracts_deployed(chain_id, version, services=False)
     data_all_computed = merge_deployment_data(data_services, data_raiden)
-    data_all = get_contracts_deployment_info(chain_id, version, module='all')
-    data_default = get_contracts_deployment_info(chain_id, version, module='all')
+    data_all = get_contracts_deployment_info(chain_id, version, module=DeploymentModule.ALL)
+    data_default = get_contracts_deployment_info(chain_id, version, module=DeploymentModule.ALL)
     assert data_all == data_all_computed
     assert data_all == data_default
 
@@ -111,4 +112,4 @@ def test_deploy_data_all(
 
 def test_deploy_data_unknown_module():
     with pytest.raises(ValueError):
-        get_contracts_deployment_info(3, None, module='unknown')
+        get_contracts_deployment_info(3, None, module=None)  # type: ignore

--- a/raiden_contracts/tests/test_deploy_data.py
+++ b/raiden_contracts/tests/test_deploy_data.py
@@ -50,7 +50,7 @@ def reasonable_deployment_of_a_contract(deployed):
     assert isinstance(deployed['constructor_arguments'], list)
 
 
-RAIDEN_CONTRACT_NAMES = {'EndpointRegistry', 'TokenNetworkRegistry', 'SecretRegistry'}
+RAIDEN_CONTRACT_NAMES = ('EndpointRegistry', 'TokenNetworkRegistry', 'SecretRegistry')
 
 
 @pytest.mark.parametrize('version', [None])
@@ -70,7 +70,7 @@ def test_deploy_data_has_fields_raiden(
         reasonable_deployment_of_a_contract(deployed)
 
 
-SERVICE_CONTRACT_NAMES = {'ServiceRegistry', 'MonitoringService', 'OneToN', 'UserDeposit'}
+SERVICE_CONTRACT_NAMES = ('ServiceRegistry', 'MonitoringService', 'OneToN', 'UserDeposit')
 
 
 @pytest.mark.parametrize('version', [None])
@@ -104,7 +104,7 @@ def test_deploy_data_all(
     assert data_all == data_all_computed
     assert data_all == data_default
 
-    for name in RAIDEN_CONTRACT_NAMES.union(SERVICE_CONTRACT_NAMES):
+    for name in RAIDEN_CONTRACT_NAMES + SERVICE_CONTRACT_NAMES:
         deployed = data_all['contracts'][name]
         reasonable_deployment_of_a_contract(deployed)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ coincurve>=8.0.0
 web3>=4.4.1
 py-solc>=3.0.0
 semver
+Deprecated


### PR DESCRIPTION
`get_contracts_deployed()` had two problems
* you had to call it twice to get all deployment data #774 
* the name sounded like the function deploys contracts, but it doesn't #671 

This PR fixes both by introducing a new interface function `get_contracts_deployment_info()` that takes `module: str` instead of `services: bool`.  Moreover, `module` defaults to `all`, meaning "give me deployment info for all modules".

Also `get_contracts_deployed()` is deprecated.