### PR TITLE
The deployment script requires mypy_extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ web3>=4.4.1
 py-solc>=3.0.0
 semver
 Deprecated
+mypy-extensions


### PR DESCRIPTION
because the script contains
```
from mypy_extensions import TypedDict
```

This fixes #778.  This should be trigger a release.