### PR TITLE
click must be at least 7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click
+click>=7.0
 rlp>=1.0.0
 coincurve>=8.0.0
 web3>=4.4.1


### PR DESCRIPTION
because we use `hidden` options.

This commit fixes https://github.com/raiden-network/raiden-contracts/issues/784