### PR TITLE
Enable 0.3._ TokenNetwork creation

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -616,6 +616,14 @@ def deploy_token_contract(
     return {token_type: token_address}
 
 
+def contracts_version_expects_deposit_limits(contracts_version: Optional[str]) -> bool:
+    if contracts_version is None:
+        return True
+    if contracts_version == '0.3._':
+        return False
+    return compare(contracts_version, '0.9.0') > -1
+
+
 def register_token_network(
         web3: Web3,
         caller: str,
@@ -631,8 +639,7 @@ def register_token_network(
         gas_price=10,
 ):
     """Register token with a TokenNetworkRegistry contract."""
-    print(contracts_version)
-    with_limits = contracts_version is None or compare(contracts_version, '0.9.0') > -1
+    with_limits = contracts_version_expects_deposit_limits(contracts_version)
     if with_limits:
         assert channel_participant_deposit_limit is not None, \
             'contracts_version 0.9.0 and afterwards expect channel_participant_deposit_limit'

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -21,6 +21,7 @@ from raiden_contracts.contract_manager import contract_version_string, contracts
 from raiden_contracts.deploy.__main__ import (
     ContractDeployer,
     contract_version_with_max_token_networks,
+    contracts_version_expects_deposit_limits,
     deploy_raiden_contracts,
     deploy_service_contracts,
     deploy_token_contract,
@@ -452,3 +453,12 @@ def test_error_removed_option_raises():
     with pytest.raises(NoSuchOption):
         mock = MagicMock()
         error_removed_option('msg')(None, mock, '0xaabbcc')
+
+
+def test_contracts_version_expects_deposit_limits():
+    assert not contracts_version_expects_deposit_limits('0.3._')
+    assert not contracts_version_expects_deposit_limits('0.4.0')
+    assert contracts_version_expects_deposit_limits('0.9.0')
+    assert contracts_version_expects_deposit_limits('0.10.0')
+    assert contracts_version_expects_deposit_limits('0.10.1')
+    assert contracts_version_expects_deposit_limits(None)

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -462,3 +462,5 @@ def test_contracts_version_expects_deposit_limits():
     assert contracts_version_expects_deposit_limits('0.10.0')
     assert contracts_version_expects_deposit_limits('0.10.1')
     assert contracts_version_expects_deposit_limits(None)
+    with pytest.raises(ValueError):
+        contracts_version_expects_deposit_limits('not a semver string')


### PR DESCRIPTION
There was a bug when the deployment script tried to see whether
0.3._ requires deposit limits, the script tried to interpret
'0.3._' as a semver but failed becaue '0.3._' is not a semver string.

This fixes https://github.com/raiden-network/raiden-contracts/issues/787