### PR TITLE
Skip gas estimation to speed up tests

### DIFF
--- a/raiden_contracts/tests/fixtures/base/web3_fixtures.py
+++ b/raiden_contracts/tests/fixtures/base/web3_fixtures.py
@@ -40,6 +40,10 @@ def web3(
     """Returns an initialized Web3 instance"""
     provider = EthereumTesterProvider(ethereum_tester)
     web3 = Web3(provider)
+    # Improve test speed by skipping the gas cost estimation.
+    # Currently commented out because setting cast costs in single cases
+    # already causes enough problems.
+    # web3.eth.estimateGas = lambda txn: int(5.7e6)
 
     # add faucet account to tester
     ethereum_tester.add_account(FAUCET_PRIVATE_KEY)

--- a/raiden_contracts/tests/test_channel_close.py
+++ b/raiden_contracts/tests/test_channel_close.py
@@ -37,7 +37,7 @@ def test_close_nonexistent_channel(
             nonce=0,
             additional_hash=EMPTY_ADDITIONAL_HASH,
             signature=EMPTY_SIGNATURE,
-        ).transact({'from': A, 'gas': 81000})
+        ).call({'from': A, 'gas': 81000})
 
 
 def test_close_settled_channel_fail(

--- a/raiden_contracts/tests/test_channel_close.py
+++ b/raiden_contracts/tests/test_channel_close.py
@@ -37,7 +37,7 @@ def test_close_nonexistent_channel(
             nonce=0,
             additional_hash=EMPTY_ADDITIONAL_HASH,
             signature=EMPTY_SIGNATURE,
-        ).transact({'from': A})
+        ).transact({'from': A, 'gas': 81000})
 
 
 def test_close_settled_channel_fail(


### PR DESCRIPTION
This currently causes weird side-effects like transactions that used to
fail with gas cost estimation suddenly succeeding (or at least not
throwing `TransactionFailed`).

@pirapira This a the problem I talked to you about. I have no idea why this happens. Maybe you can give this PR a try.