### PR TITLE
Move DeployedModule enum to constants.py

### DIFF
--- a/raiden_contracts/constants.py
+++ b/raiden_contracts/constants.py
@@ -122,6 +122,13 @@ class OneToNEvent(str, Enum):
     CLAIMED = 'Claimed'
 
 
+class DeploymentModule(Enum):
+    """Groups of contracts that are deployed together"""
+    RAIDEN = 'raiden'
+    SERVICES = 'services'
+    ALL = 'all'
+
+
 # Network configurations
 START_QUERY_BLOCK_KEY = 'DefaultStartBlock'
 

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -1,7 +1,6 @@
 """ContractManager knows binaries and ABI of contracts."""
 import json
 from copy import deepcopy
-from enum import Enum
 from json import JSONDecodeError
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -9,7 +8,7 @@ from typing import Any, Dict, List, Optional
 from deprecated import deprecated
 from mypy_extensions import TypedDict
 
-from raiden_contracts.constants import CONTRACTS_VERSION, ID_TO_NETWORKNAME
+from raiden_contracts.constants import CONTRACTS_VERSION, ID_TO_NETWORKNAME, DeploymentModule
 from raiden_contracts.utils.type_aliases import Address
 
 _BASE = Path(__file__).parent
@@ -124,12 +123,6 @@ def contracts_deployed_path(
     chain_name = ID_TO_NETWORKNAME[chain_id] if chain_id in ID_TO_NETWORKNAME else 'private_net'
 
     return data_path.joinpath(f'deployment_{"services_" if services else ""}{chain_name}.json')
-
-
-class DeploymentModule(Enum):
-    RAIDEN = 'raiden'
-    SERVICES = 'services'
-    ALL = 'all'
 
 
 @deprecated(reason='Use get_contract_deployment_info()')

--- a/raiden_contracts/tests/test_deploy_data.py
+++ b/raiden_contracts/tests/test_deploy_data.py
@@ -2,9 +2,8 @@ from typing import Optional
 
 import pytest
 
-from raiden_contracts.constants import CONTRACTS_VERSION
+from raiden_contracts.constants import CONTRACTS_VERSION, DeploymentModule
 from raiden_contracts.contract_manager import (
-    DeploymentModule,
     contracts_data_path,
     contracts_deployed_path,
     get_contracts_deployed,


### PR DESCRIPTION
Without doing this, I was unable to call `get_contracts_deployment_info()` from `contract_verifyer.py`.

I saw an error:
```
        if module not in DeploymentModule:
>           raise ValueError(f'Unknown module {module} given to get_contracts_deployment_info()')
E           ValueError: Unknown module DeploymentModule.RAIDEN given to get_contracts_deployment_info()
```
from `get_contracts_deployment_info()`.

It seemed like the Enum visible locally in contract_manager.py was different from the Enum imported into contract_verifyer.py .

I guess that's why many enums are defined in `constants.py`.`