### PR TITLE
Introduce transact_for_success()

### DIFF
--- a/raiden_contracts/tests/test_channel_deposit.py
+++ b/raiden_contracts/tests/test_channel_deposit.py
@@ -350,7 +350,7 @@ def test_deposit_wrong_state_fail(
         ).transact({'from': B})
 
     web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN)
-    call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
+    call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B)
     with pytest.raises(TransactionFailed):
         token_network.functions.setTotalDeposit(
             channel_identifier,

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -123,7 +123,7 @@ def test_settle_channel_state(
     pre_balance_B = custom_token.functions.balanceOf(B).call()
     pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
-    call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
+    call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B)
 
     # Balance & state tests
     settle_state_tests(
@@ -363,7 +363,7 @@ def test_settlement_with_unauthorized_token_transfer(
     settlement = get_settlement_amounts(vals_A, vals_B)
 
     # Channel is settled
-    call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
+    call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B)
 
     # Fetch onchain balances after settlement
     post_balance_A = custom_token.functions.balanceOf(A).call()
@@ -411,7 +411,7 @@ def test_settle_wrong_state_fail(
     assert settle_timeout == TEST_SETTLE_TIMEOUT_MIN
 
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
+        call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B)
 
     txn_hash = token_network.functions.closeChannel(
         channel_identifier,
@@ -432,13 +432,13 @@ def test_settle_wrong_state_fail(
     assert web3.eth.blockNumber < settle_block_number
 
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
+        call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B)
 
     web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN)
     assert web3.eth.blockNumber >= settle_block_number
 
     # Channel is settled
-    call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
+    call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B)
 
     (settle_block_number, state) = token_network.functions.getChannelInfo(
         channel_identifier,
@@ -507,80 +507,80 @@ def test_settle_wrong_balance_hash(
     web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN)
 
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, B, vals_A, A, vals_B)
+        call_settle(web3, token_network, channel_identifier, B, vals_A, A, vals_B)
 
     vals_A_fail = deepcopy(vals_A)
     vals_A_fail.transferred += 1
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, A, vals_A_fail, B, vals_B)
+        call_settle(web3, token_network, channel_identifier, A, vals_A_fail, B, vals_B)
 
     vals_A_fail.transferred = 0
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, A, vals_A_fail, B, vals_B)
+        call_settle(web3, token_network, channel_identifier, A, vals_A_fail, B, vals_B)
 
     vals_A_fail.transferred = MAX_UINT256
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, B, vals_B, A, vals_A_fail)
+        call_settle(web3, token_network, channel_identifier, B, vals_B, A, vals_A_fail)
 
     vals_A_fail = deepcopy(vals_A)
     vals_A_fail.locked += 1
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, A, vals_A_fail, B, vals_B)
+        call_settle(web3, token_network, channel_identifier, A, vals_A_fail, B, vals_B)
 
     vals_A_fail.locked = 0
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, A, vals_A_fail, B, vals_B)
+        call_settle(web3, token_network, channel_identifier, A, vals_A_fail, B, vals_B)
 
     vals_A_fail.locked = MAX_UINT256
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, B, vals_B, A, vals_A_fail)
+        call_settle(web3, token_network, channel_identifier, B, vals_B, A, vals_A_fail)
 
     vals_A_fail = deepcopy(vals_A)
     vals_A_fail.locksroot = EMPTY_LOCKSROOT
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, A, vals_A_fail, B, vals_B)
+        call_settle(web3, token_network, channel_identifier, A, vals_A_fail, B, vals_B)
 
     vals_A_fail.locksroot = fake_bytes(32, '01')
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, A, vals_A_fail, B, vals_B)
+        call_settle(web3, token_network, channel_identifier, A, vals_A_fail, B, vals_B)
 
     vals_B_fail = deepcopy(vals_B)
     vals_B_fail.transferred += 1
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, A, vals_A, B, vals_B_fail)
+        call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B_fail)
 
     vals_B_fail.transferred = 0
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, B, vals_B_fail, A, vals_A)
+        call_settle(web3, token_network, channel_identifier, B, vals_B_fail, A, vals_A)
 
     vals_B_fail.transferred = MAX_UINT256
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, A, vals_A, B, vals_B_fail)
+        call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B_fail)
 
     vals_B_fail = deepcopy(vals_B)
     vals_B_fail.locked += 1
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, A, vals_A, B, vals_B_fail)
+        call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B_fail)
 
     vals_B_fail.locked = 0
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, B, vals_B_fail, A, vals_A)
+        call_settle(web3, token_network, channel_identifier, B, vals_B_fail, A, vals_A)
 
     vals_B_fail.locked = MAX_UINT256
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, A, vals_A, B, vals_B_fail)
+        call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B_fail)
 
     vals_B_fail = deepcopy(vals_B)
     vals_B_fail.locksroot = EMPTY_LOCKSROOT
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, A, vals_A, B, vals_B_fail)
+        call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B_fail)
 
     vals_B_fail.locksroot = fake_bytes(32, '01')
     with pytest.raises(TransactionFailed):
-        call_settle(token_network, channel_identifier, A, vals_A, B, vals_B_fail)
+        call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B_fail)
 
     # Channel is settled
-    call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
+    call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B)
 
 
 def test_settle_channel_event(

--- a/raiden_contracts/tests/test_channel_settle_unlock_state.py
+++ b/raiden_contracts/tests/test_channel_settle_unlock_state.py
@@ -89,7 +89,7 @@ def test_settlement_outcome(
         pre_balance_B = custom_token.functions.balanceOf(B).call()
         pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
-        call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
+        call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B)
 
         # We do the balance & state tests here for each channel and also compare with
         # the expected settlement amounts
@@ -440,7 +440,7 @@ def test_channel_settle_invalid_balance_proof_values(
     pre_balance_B = custom_token.functions.balanceOf(B).call()
     pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
-    call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
+    call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B)
 
     # We do the balance & state tests here for each channel and also compare with
     # the expected settlement amounts

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -661,7 +661,7 @@ def test_channel_unlock(
     # Settlement window must be over before settling the channel
     web3.testing.mine(settle_timeout)
 
-    call_settle(token_network, channel_identifier, A, values_A, B, values_B)
+    call_settle(web3, token_network, channel_identifier, A, values_A, B, values_B)
 
     pre_balance_A = custom_token.functions.balanceOf(A).call()
     pre_balance_B = custom_token.functions.balanceOf(B).call()
@@ -865,7 +865,7 @@ def test_channel_unlock_registered_expired_lock_refunds(
     web3.testing.mine(settle_timeout)
 
     # settle channel
-    call_settle(token_network, channel_identifier, A, values_A, B, values_B)
+    call_settle(web3, token_network, channel_identifier, A, values_A, B, values_B)
 
     pre_balance_A = custom_token.functions.balanceOf(A).call()
     pre_balance_B = custom_token.functions.balanceOf(B).call()
@@ -925,7 +925,7 @@ def test_channel_unlock_unregistered_locks(
 
     # Secret hasn't been registered before settlement timeout
     web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN)
-    call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
+    call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B)
 
     # Someone unlocks A's pending transfers - all tokens should be refunded
     token_network.functions.unlock(
@@ -1030,7 +1030,7 @@ def test_channel_unlock_before_settlement_fails(
         ).transact()
 
     # settle channel
-    call_settle(token_network, channel_identifier, A, values_A, B, values_B)
+    call_settle(web3, token_network, channel_identifier, A, values_A, B, values_B)
 
     pre_balance_A = custom_token.functions.balanceOf(A).call()
     pre_balance_B = custom_token.functions.balanceOf(B).call()
@@ -1206,7 +1206,7 @@ def test_channel_unlock_both_participants(
     # Settle channel
     web3.testing.mine(settle_timeout)
 
-    call_settle(token_network, channel_identifier, A, values_A, B, values_B)
+    call_settle(web3, token_network, channel_identifier, A, values_A, B, values_B)
 
     pre_balance_A = custom_token.functions.balanceOf(A).call()
     pre_balance_B = custom_token.functions.balanceOf(B).call()
@@ -1353,7 +1353,7 @@ def test_channel_unlock_with_a_large_expiration(
     # Settle channel after a "long" time
     web3.testing.mine(settle_timeout + 50)
 
-    call_settle(token_network, channel_identifier, A, values_A, B, values_B)
+    call_settle(web3, token_network, channel_identifier, A, values_A, B, values_B)
 
     pre_balance_A = custom_token.functions.balanceOf(A).call()
     pre_balance_B = custom_token.functions.balanceOf(B).call()
@@ -1596,7 +1596,7 @@ def test_unlock_channel_event(
     # Settlement window must be over before settling the channel
     web3.testing.mine(settle_timeout)
 
-    call_settle(token_network, channel_identifier, A, values_A, B, values_B)
+    call_settle(web3, token_network, channel_identifier, A, values_A, B, values_B)
 
     ev_handler = event_handler(token_network)
 

--- a/raiden_contracts/tests/test_deprecation_switch.py
+++ b/raiden_contracts/tests/test_deprecation_switch.py
@@ -225,7 +225,7 @@ def test_deprecation_switch_settle(
     )
     web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN)
 
-    call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
+    call_settle(web3, token_network, channel_identifier, A, vals_A, B, vals_B)
 
     # Unlock B's pending transfers that were sent to A
     token_network.functions.unlock(


### PR DESCRIPTION
which is similar to transact() but checks the receipt's status field.

Currently, we rely on the behavior that `transact()` raises `TransactionFailed` exception, but this is true only when we don't specify the amount of gas.  We'll be specifying the amount of gas (so that tests run faster) https://github.com/raiden-network/raiden-contracts/pull/794.