### PR TITLE
Declare raiden-contracts to be typed via PEP561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ config = {
         'build_py': BuildPyCommand,
     },
     'zip_safe': False,
+    'package_data': {"raiden_contracts": ["py.typed"]},
 }
 
 setup(**config)


### PR DESCRIPTION
When other packages import raiden-contracts, the type signatures will
not be used by mypy unless the package declares itself as properly
types.  This can be done via PEP561:
https://mypy.readthedocs.io/en/latest/installed_packages.html#using-pep-561-compatible-packages-with-mypy

Adding this will improve type checking quality in raiden-services (and
potential other packages) whenever imports from raiden-contracts are
used.