### PR TITLE
0.17.2 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.1
+current_version = 0.17.2
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Documents changes that result in:
 
 ## Unreleased
 
+## [0.17.2](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.17.2) - 2019-04-06
+
+- [#813](https://github.com/raiden-network/raiden-contracts/pull/813) expose mypy type checking results to the other packages.
+
 ## [0.17.1](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.17.1) - 2019-04-02
 
 - [#809](https://github.com/raiden-network/raiden-contracts/pull/809) fix a bug in `get_contracts_deployment_info()`.

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools.command.build_py import build_py
 
 
 DESCRIPTION = 'Raiden contracts library and utilities'
-VERSION = '0.17.1'
+VERSION = '0.17.2'
 
 
 def read_requirements(path: str) -> List[str]:


### PR DESCRIPTION
because #813 exposes the type-checking information to `raiden` and `raiden-services`, the CI in `raiden` and `raiden-services` might get additional mypy errors.  This release is for finding them sooner.