### PR TITLE
Remove get_contracts_deployed()

### DIFF
--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -5,7 +5,6 @@ from json import JSONDecodeError
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from deprecated import deprecated
 from mypy_extensions import TypedDict
 from semver import compare
 
@@ -124,20 +123,6 @@ def contracts_deployed_path(
     chain_name = ID_TO_NETWORKNAME[chain_id] if chain_id in ID_TO_NETWORKNAME else 'private_net'
 
     return data_path.joinpath(f'deployment_{"services_" if services else ""}{chain_name}.json')
-
-
-@deprecated(reason='Use get_contract_deployment_info()')
-def get_contracts_deployed(
-        chain_id: int,
-        version: Optional[str] = None,
-        services: bool = False,
-) -> DeployedContracts:
-    """Reads the deployment data."""
-    return get_contracts_deployment_info(
-        chain_id=chain_id,
-        version=version,
-        module=DeploymentModule.SERVICES if services else DeploymentModule.RAIDEN,
-    )
 
 
 def merge_deployment_data(dict1: DeployedContracts, dict2: DeployedContracts) -> DeployedContracts:

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -3,11 +3,11 @@ import json
 from copy import deepcopy
 from json import JSONDecodeError
 from pathlib import Path
-from semver import compare
 from typing import Any, Dict, List, Optional
 
 from deprecated import deprecated
 from mypy_extensions import TypedDict
+from semver import compare
 
 from raiden_contracts.constants import CONTRACTS_VERSION, ID_TO_NETWORKNAME, DeploymentModule
 from raiden_contracts.utils.type_aliases import Address

--- a/raiden_contracts/contract_source_manager.py
+++ b/raiden_contracts/contract_source_manager.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 from solc import compile_files
 
-from raiden_contracts.constants import PRECOMPILED_DATA_FIELDS
+from raiden_contracts.constants import PRECOMPILED_DATA_FIELDS, DeploymentModule
 from raiden_contracts.contract_manager import ContractManager
 
 _BASE = Path(__file__).parent
@@ -148,6 +148,15 @@ class ContractSourceManager():
 
 def contracts_source_path():
     return contracts_source_path_with_stem('data/source')
+
+
+def contracts_source_path_of_deployment_module(module: DeploymentModule):
+    if module == DeploymentModule.RAIDEN:
+        return contracts_source_path()['raiden']
+    elif module == DeploymentModule.SERVICES:
+        return contracts_source_path()['services']
+    else:
+        raise ValueError(f'No source known for module {module}')
 
 
 def contracts_source_path_with_stem(stem):

--- a/raiden_contracts/deploy/contract_verifyer.py
+++ b/raiden_contracts/deploy/contract_verifyer.py
@@ -13,13 +13,14 @@ from raiden_contracts.constants import (
     CONTRACT_SERVICE_REGISTRY,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
+    DeploymentModule,
 )
 from raiden_contracts.contract_manager import (
     ContractManager,
     DeployedContracts,
     contracts_deployed_path,
     contracts_precompiled_path,
-    get_contracts_deployed,
+    get_contracts_deployment_info,
 )
 from raiden_contracts.utils.bytecode import runtime_hexcode
 
@@ -38,9 +39,10 @@ class ContractVerifyer:
     def verify_deployed_contracts_in_filesystem(self):
         chain_id = int(self.web3.version.network)
 
-        deployment_data = get_contracts_deployed(
+        deployment_data = get_contracts_deployment_info(
             chain_id=chain_id,
             version=self.contract_manager.contracts_version,
+            module=DeploymentModule.RAIDEN,
         )
         deployment_file_path = contracts_deployed_path(
             chain_id=chain_id,
@@ -59,10 +61,10 @@ class ContractVerifyer:
     ):
         chain_id = int(self.web3.version.network)
 
-        deployment_data = get_contracts_deployed(
+        deployment_data = get_contracts_deployment_info(
             chain_id=chain_id,
             version=self.contract_manager.contracts_version,
-            services=True,
+            module=DeploymentModule.SERVICES,
         )
         deployment_file_path = contracts_deployed_path(
             chain_id=chain_id,

--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -18,24 +18,27 @@ from raiden_contracts.constants import (
     CONTRACT_SERVICE_REGISTRY,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
+    DeploymentModule,
 )
 from raiden_contracts.contract_manager import (
     ContractManager,
+    DeployedContract,
+    DeployedContracts,
     contracts_precompiled_path,
-    get_contracts_deployed,
+    get_contracts_deployment_info,
 )
 from raiden_contracts.contract_source_manager import contracts_source_path
 
 ContractListEntry = namedtuple('ContractListEntry', 'module name')
 
 CONTRACT_LIST = [
-    ContractListEntry(module='raiden', name=CONTRACT_ENDPOINT_REGISTRY),
-    ContractListEntry(module='raiden', name=CONTRACT_SECRET_REGISTRY),
-    ContractListEntry(module='raiden', name=CONTRACT_TOKEN_NETWORK_REGISTRY),
-    ContractListEntry(module='services', name=CONTRACT_SERVICE_REGISTRY),
-    ContractListEntry(module='services', name=CONTRACT_MONITORING_SERVICE),
-    ContractListEntry(module='services', name=CONTRACT_ONE_TO_N),
-    ContractListEntry(module='services', name=CONTRACT_USER_DEPOSIT),
+    ContractListEntry(module=DeploymentModule.RAIDEN, name=CONTRACT_ENDPOINT_REGISTRY),
+    ContractListEntry(module=DeploymentModule.RAIDEN, name=CONTRACT_SECRET_REGISTRY),
+    ContractListEntry(module=DeploymentModule.RAIDEN, name=CONTRACT_TOKEN_NETWORK_REGISTRY),
+    ContractListEntry(module=DeploymentModule.SERVICES, name=CONTRACT_SERVICE_REGISTRY),
+    ContractListEntry(module=DeploymentModule.SERVICES, name=CONTRACT_MONITORING_SERVICE),
+    ContractListEntry(module=DeploymentModule.SERVICES, name=CONTRACT_ONE_TO_N),
+    ContractListEntry(module=DeploymentModule.SERVICES, name=CONTRACT_USER_DEPOSIT),
 ]
 
 
@@ -87,7 +90,7 @@ api_of_chain_id = {
 }
 
 
-def join_sources(source_module: str, contract_name: str):
+def join_sources(source_module: DeploymentModule, contract_name: str):
     """ Use join-contracts.py to concatenate all imported Solidity files.
 
     Args:
@@ -114,7 +117,7 @@ def join_sources(source_module: str, contract_name: str):
 
 
 def get_constructor_args(
-        deployment_info: Dict,
+        deployment_info: DeployedContracts,
         contract_name: str,
         contract_manager: ContractManager,
 ):
@@ -136,7 +139,7 @@ def get_constructor_args(
 
 def post_data_for_etherscan_verification(
         apikey: str,
-        deployment_info: Dict,
+        deployment_info: DeployedContract,
         source: str,
         contract_name: str,
         metadata: Dict,
@@ -166,7 +169,7 @@ def post_data_for_etherscan_verification(
 def etherscan_verify_contract(
         chain_id: int,
         apikey: str,
-        source_module: str,
+        source_module: DeploymentModule,
         contract_name: str,
 ):
     """ Calls Etherscan API for verifying the Solidity source of a contract.
@@ -178,9 +181,9 @@ def etherscan_verify_contract(
         contract_name: 'TokenNetworkRegistry', 'SecretRegistry' etc.
     """
     etherscan_api = api_of_chain_id[chain_id]
-    deployment_info = get_contracts_deployed(
+    deployment_info = get_contracts_deployment_info(
         chain_id=chain_id,
-        services=(source_module == 'services'),
+        module=source_module,
     )
     contract_manager = ContractManager(contracts_precompiled_path())
 

--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -27,7 +27,10 @@ from raiden_contracts.contract_manager import (
     contracts_precompiled_path,
     get_contracts_deployment_info,
 )
-from raiden_contracts.contract_source_manager import contracts_source_path
+from raiden_contracts.contract_source_manager import (
+    contracts_source_path,
+    contracts_source_path_of_deployment_module,
+)
 
 ContractListEntry = namedtuple('ContractListEntry', 'module name')
 
@@ -103,7 +106,9 @@ def join_sources(source_module: DeploymentModule, contract_name: str):
         './utils/join-contracts.py',
         '--import-map',
         json.dumps(remapping),
-        str(contracts_source_path()[source_module].joinpath(contract_name + '.sol')),
+        str(contracts_source_path_of_deployment_module(
+            source_module,
+        ).joinpath(contract_name + '.sol')),
         str(joined_file),
     ]
     working_dir = Path(__file__).parent.parent

--- a/raiden_contracts/tests/test_deploy_data.py
+++ b/raiden_contracts/tests/test_deploy_data.py
@@ -6,9 +6,7 @@ from raiden_contracts.constants import CONTRACTS_VERSION, DeploymentModule
 from raiden_contracts.contract_manager import (
     contracts_data_path,
     contracts_deployed_path,
-    get_contracts_deployed,
     get_contracts_deployment_info,
-    merge_deployment_data,
     version_provides_services,
 )
 
@@ -60,9 +58,7 @@ def test_deploy_data_has_fields_raiden(
         version: Optional[str],
         chain_id: int,
 ):
-    data = get_contracts_deployed(chain_id, version, services=False)
-    data2 = get_contracts_deployment_info(chain_id, version, module=DeploymentModule.RAIDEN)
-    assert data2 == data
+    data = get_contracts_deployment_info(chain_id, version, module=DeploymentModule.RAIDEN)
     assert data['contracts_version'] == version if version else CONTRACTS_VERSION
     assert data['chain_id'] == chain_id
     contracts = data['contracts']
@@ -80,9 +76,7 @@ def test_deploy_data_has_fields_services(
         version: Optional[str],
         chain_id: int,
 ):
-    data = get_contracts_deployed(chain_id, version, services=True)
-    data2 = get_contracts_deployment_info(chain_id, version, module=DeploymentModule.SERVICES)
-    assert data2 == data
+    data = get_contracts_deployment_info(chain_id, version, module=DeploymentModule.SERVICES)
     assert data['contracts_version'] == version if version else CONTRACTS_VERSION
     assert data['chain_id'] == chain_id
     contracts = data['contracts']
@@ -97,12 +91,8 @@ def test_deploy_data_all(
         version: Optional[str],
         chain_id: int,
 ):
-    data_services = get_contracts_deployed(chain_id, version, services=True)
-    data_raiden = get_contracts_deployed(chain_id, version, services=False)
-    data_all_computed = merge_deployment_data(data_services, data_raiden)
     data_all = get_contracts_deployment_info(chain_id, version, module=DeploymentModule.ALL)
-    data_default = get_contracts_deployment_info(chain_id, version, module=DeploymentModule.ALL)
-    assert data_all == data_all_computed
+    data_default = get_contracts_deployment_info(chain_id, version)
     assert data_all == data_default
 
     for name in RAIDEN_CONTRACT_NAMES + SERVICE_CONTRACT_NAMES:

--- a/raiden_contracts/tests/test_etherscan_verify.py
+++ b/raiden_contracts/tests/test_etherscan_verify.py
@@ -11,8 +11,13 @@ from raiden_contracts.constants import (
     CONTRACT_SERVICE_REGISTRY,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
+    DeploymentModule,
 )
-from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
+from raiden_contracts.contract_manager import (
+    ContractManager,
+    DeployedContracts,
+    contracts_precompiled_path,
+)
 from raiden_contracts.deploy.etherscan_verify import (
     api_of_chain_id,
     etherscan_verify,
@@ -35,7 +40,7 @@ def test_get_constructor_args_no_args():
             },
         },
     }
-    assert get_constructor_args(deploy_info, contract_name, contract_manager) == ''
+    assert get_constructor_args(deploy_info, contract_name, contract_manager) == ''  # type: ignore
 
 
 def abi_with_constructor_input_types(types: List[str]):
@@ -51,7 +56,7 @@ def test_get_constructor_args_one_arg():
     contract_manager.contracts[contract_name] = {
         'abi': abi_with_constructor_input_types(['uint256']),
     }
-    deploy_info = {
+    deploy_info: DeployedContracts = {  # type: ignore
         'contracts': {
             contract_name: {
                 'constructor_arguments': [16],
@@ -68,7 +73,7 @@ def test_get_constructor_args_two_args():
     contract_manager.contracts[contract_name] = {
         'abi': abi_with_constructor_input_types(['uint256', 'bool']),
     }
-    deploy_info = {
+    deploy_info: DeployedContracts = {  # type: ignore
         'contracts': {
             contract_name: {
                 'constructor_arguments': [16, True],
@@ -83,7 +88,7 @@ def test_get_constructor_args_two_args():
 def test_post_data_for_etherscan_verification():
     output = post_data_for_etherscan_verification(
         apikey='jkl;jkl;jkl;',
-        deployment_info={'address': 'dummy_address'},
+        deployment_info={'address': 'dummy_address'},  # type: ignore
         source='dummy_source',
         contract_name=contract_name,
         metadata={
@@ -113,13 +118,13 @@ def test_post_data_for_etherscan_verification():
 
 def test_run_join_contracts():
     """ Just running join_sources() """
-    join_sources('raiden', CONTRACT_TOKEN_NETWORK_REGISTRY)
-    join_sources('raiden', CONTRACT_SECRET_REGISTRY)
-    join_sources('raiden', CONTRACT_ENDPOINT_REGISTRY)
-    join_sources('services', CONTRACT_MONITORING_SERVICE)
-    join_sources('services', CONTRACT_SERVICE_REGISTRY)
-    join_sources('services', CONTRACT_ONE_TO_N)
-    join_sources('services', CONTRACT_USER_DEPOSIT)
+    join_sources(DeploymentModule.RAIDEN, CONTRACT_TOKEN_NETWORK_REGISTRY)
+    join_sources(DeploymentModule.RAIDEN, CONTRACT_SECRET_REGISTRY)
+    join_sources(DeploymentModule.RAIDEN, CONTRACT_ENDPOINT_REGISTRY)
+    join_sources(DeploymentModule.SERVICES, CONTRACT_MONITORING_SERVICE)
+    join_sources(DeploymentModule.SERVICES, CONTRACT_SERVICE_REGISTRY)
+    join_sources(DeploymentModule.SERVICES, CONTRACT_ONE_TO_N)
+    join_sources(DeploymentModule.SERVICES, CONTRACT_USER_DEPOSIT)
 
 
 def test_guid_status():

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ coincurve>=8.0.0
 web3>=4.4.1
 py-solc>=3.0.0
 semver
-Deprecated
 mypy-extensions


### PR DESCRIPTION
As far as I know, neither `raiden` or `raiden-services` uses `get_contracts_deployed()` interface anymore.  This PR removes the function from `raiden-contracts` codebase.