### PR TITLE
Show a better error message before Byzantium

### DIFF
--- a/raiden_contracts/tests/test_transaction.py
+++ b/raiden_contracts/tests/test_transaction.py
@@ -15,6 +15,17 @@ def test_check_successful_tx_with_status_zero():
     web3_mock.eth.getTransaction.assert_called_with(txid)
 
 
+def test_check_successful_tx_with_nonexistent_status():
+    """ check_successful_tx() with a receipt without status field should raise a KeyError """
+    web3_mock = Mock()
+    web3_mock.eth.getTransactionReceipt.return_value = {'blockNumber': 300}
+    txid = 'abcdef'
+    with pytest.raises(KeyError):
+        check_successful_tx(web3=web3_mock, txid=txid)
+    web3_mock.eth.getTransactionReceipt.assert_called_with(txid)
+    web3_mock.eth.getTransaction.assert_called_with(txid)
+
+
 def test_check_successful_tx_with_gas_completely_used():
     web3_mock = Mock()
     gas = 30000

--- a/raiden_contracts/utils/transaction.py
+++ b/raiden_contracts/utils/transaction.py
@@ -10,6 +10,11 @@ def check_successful_tx(web3: Web3, txid: str, timeout=180) -> Tuple[dict, dict]
     """
     receipt = wait_for_transaction_receipt(web3, txid, timeout=timeout)
     txinfo = web3.eth.getTransaction(txid)
+    if 'status' not in receipt:
+        raise KeyError(
+            'A transaction receipt does not contain the "status" field. '
+            'Does your chain have Byzantium rules enabled?',
+        )
     if receipt['status'] == 0:
         raise ValueError(f'Status 0 indicates failure')
     if txinfo['gas'] == receipt['gasUsed']:


### PR DESCRIPTION
and when a transaction receipt does not contain 'status' field.

It's sometimes hard to connect a missing 'status' and the Byzantium hard fork.