### PR TITLE
Refactor register_token_network()

### DIFF
--- a/raiden_contracts/tests/deprecation_switch_testnet.py
+++ b/raiden_contracts/tests/deprecation_switch_testnet.py
@@ -147,16 +147,12 @@ def deprecation_test_setup(
 
     abi = deployer.contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK_REGISTRY)
     token_network_address = register_token_network(
-        web3=deployer.web3,
-        caller=deployer.owner,
+        deployer=deployer,
         token_registry_abi=abi,
         token_registry_address=deployed_contracts[CONTRACT_TOKEN_NETWORK_REGISTRY]['address'],
         token_address=token_address,
         channel_participant_deposit_limit=channel_participant_deposit_limit,
         token_network_deposit_limit=token_network_deposit_limit,
-        token_registry_version=deployer.contract_manager.version_string(),
-        wait=deployer.wait,
-        contracts_version=deployer.contracts_version,
     )
 
     token_network_abi = deployer.contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK)

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -17,7 +17,7 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
 )
-from raiden_contracts.contract_manager import contract_version_string, contracts_precompiled_path
+from raiden_contracts.contract_manager import contracts_precompiled_path
 from raiden_contracts.deploy.__main__ import (
     ContractDeployer,
     contract_version_with_max_token_networks,
@@ -273,15 +273,12 @@ def test_deploy_script_register(
         CONTRACT_TOKEN_NETWORK_REGISTRY
     ]['address']
     token_network_address = register_token_network(
-        web3=web3,
-        caller=deployer.owner,
+        deployer=deployer,
         token_registry_abi=token_registry_abi,
         token_registry_address=token_registry_address,
-        token_registry_version=contract_version_string(version=None),
         token_address=token_address,
         channel_participant_deposit_limit=channel_participant_deposit_limit,
         token_network_deposit_limit=token_network_deposit_limit,
-        contracts_version=deployer.contracts_version,
     )
     assert token_network_address is not None
     assert isinstance(token_network_address, T_Address)


### PR DESCRIPTION
because most of the parameter-passing and error-checking was
already implemented in CotnractDeployer.transact().

This implements the idea and closes https://github.com/raiden-network/raiden-contracts/issues/515