### PR TITLE
Move register_token_network into ContractDeployer

### DIFF
--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -223,15 +223,26 @@ class ContractDeployer(ContractVerifyer):
         """Register token with a TokenNetworkRegistry contract."""
         with_limits = contracts_version_expects_deposit_limits(self.contracts_version)
         if with_limits:
-            assert channel_participant_deposit_limit is not None, \
-                'contracts_version 0.9.0 and afterwards expect channel_participant_deposit_limit'
-            assert token_network_deposit_limit is not None, \
-                'contracts_version 0.9.0 and afterwards expect token_network_deposit_limit'
+            if channel_participant_deposit_limit is None:
+                raise ValueError(
+                    'contracts_version 0.9.0 and afterwards expect '
+                    'channel_participant_deposit_limit',
+                )
+            if token_network_deposit_limit is None:
+                raise ValueError(
+                    'contracts_version 0.9.0 and afterwards expect '
+                    'token_network_deposit_limit',
+                )
         else:
-            assert channel_participant_deposit_limit is None, \
-                'contracts_version below 0.9.0 does not expect channel_participant_deposit_limit'
-            assert token_network_deposit_limit is None, \
-                'contracts_version below 0.9.0 does not expect token_network_deposit_limit'
+            if channel_participant_deposit_limit:
+                raise ValueError(
+                    'contracts_version below 0.9.0 does not expect '
+                    'channel_participant_deposit_limit',
+                )
+            if token_network_deposit_limit:
+                raise ValueError(
+                    'contracts_version below 0.9.0 does not expect token_network_deposit_limit',
+                )
         token_network_registry = self.web3.eth.contract(
             abi=token_registry_abi,
             address=token_registry_address,

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -268,7 +268,7 @@ class ContractDeployer(ContractVerifyer):
             token_address,
         ).call()
         token_network_address = to_checksum_address(token_network_address)
-        print(f'TokenNetwork address: {token_network_address}')
+        LOG.debug(f'TokenNetwork address: {token_network_address}')
         return token_network_address
 
     def deploy_service_contracts(

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -249,8 +249,11 @@ class ContractDeployer(ContractVerifyer):
         )
 
         version_from_onchain = token_network_registry.functions.contract_version().call()
-        assert version_from_onchain == self.contract_manager.version_string(), \
-            f'got {version_from_onchain}, expected {self.contract_manager.version_string()}'
+        if version_from_onchain != self.contract_manager.version_string():
+            raise RuntimeError(
+                f'got {version_from_onchain} from the chain, expected '
+                f'{self.contract_manager.version_string()} in the deployment data',
+            )
 
         if with_limits:
             command = token_network_registry.functions.createERC20TokenNetwork(

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -241,13 +241,16 @@ class ContractDeployer(ContractVerifyer):
         assert version_from_onchain == self.contract_manager.version_string(), \
             f'got {version_from_onchain}, expected {self.contract_manager.version_string()}'
 
-        command = token_network_registry.functions.createERC20TokenNetwork(
-            token_address,
-            channel_participant_deposit_limit,
-            token_network_deposit_limit,
-        ) if with_limits else token_network_registry.functions.createERC20TokenNetwork(
-            token_address,
-        )
+        if with_limits:
+            command = token_network_registry.functions.createERC20TokenNetwork(
+                _token_address=token_address,
+                _channel_participant_deposit_limit=channel_participant_deposit_limit,
+                _token_network_deposit_limit=token_network_deposit_limit,
+            )
+        else:
+            command = token_network_registry.functions.createERC20TokenNetwork(
+                token_address,
+            )
         self.transact(command)
 
         token_network_address = token_network_registry.functions.token_to_token_networks(

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -257,12 +257,7 @@ class ContractDeployer(ContractVerifyer):
             token_address,
         ).call()
         token_network_address = to_checksum_address(token_network_address)
-
-        print(
-            'TokenNetwork address: {0}'.format(
-                token_network_address,
-            ),
-        )
+        print(f'TokenNetwork address: {token_network_address}')
         return token_network_address
 
     def deploy_service_contracts(

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -1,7 +1,8 @@
 from logging import getLogger
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from eth_utils import denoms, encode_hex, is_address, to_checksum_address
+from semver import compare
 from web3 import Web3
 from web3.contract import Contract, ContractFunction
 from web3.middleware import construct_sign_and_send_raw_middleware
@@ -211,6 +212,56 @@ class ContractDeployer(ContractVerifyer):
             address=deployed_contracts['contracts'][contract_name]['address'],
         )
 
+    def register_token_network(
+            self,
+            token_registry_abi: Dict,
+            token_registry_address: str,
+            token_address: str,
+            channel_participant_deposit_limit: Optional[int],
+            token_network_deposit_limit: Optional[int],
+    ):
+        """Register token with a TokenNetworkRegistry contract."""
+        with_limits = contracts_version_expects_deposit_limits(self.contracts_version)
+        if with_limits:
+            assert channel_participant_deposit_limit is not None, \
+                'contracts_version 0.9.0 and afterwards expect channel_participant_deposit_limit'
+            assert token_network_deposit_limit is not None, \
+                'contracts_version 0.9.0 and afterwards expect token_network_deposit_limit'
+        else:
+            assert channel_participant_deposit_limit is None, \
+                'contracts_version below 0.9.0 does not expect channel_participant_deposit_limit'
+            assert token_network_deposit_limit is None, \
+                'contracts_version below 0.9.0 does not expect token_network_deposit_limit'
+        token_network_registry = self.web3.eth.contract(
+            abi=token_registry_abi,
+            address=token_registry_address,
+        )
+
+        version_from_onchain = token_network_registry.functions.contract_version().call()
+        assert version_from_onchain == self.contract_manager.version_string(), \
+            f'got {version_from_onchain}, expected {self.contract_manager.version_string()}'
+
+        command = token_network_registry.functions.createERC20TokenNetwork(
+            token_address,
+            channel_participant_deposit_limit,
+            token_network_deposit_limit,
+        ) if with_limits else token_network_registry.functions.createERC20TokenNetwork(
+            token_address,
+        )
+        self.transact(command)
+
+        token_network_address = token_network_registry.functions.token_to_token_networks(
+            token_address,
+        ).call()
+        token_network_address = to_checksum_address(token_network_address)
+
+        print(
+            'TokenNetwork address: {0}'.format(
+                token_network_address,
+            ),
+        )
+        return token_network_address
+
     def deploy_service_contracts(
             self,
             token_address: str,
@@ -256,6 +307,14 @@ class ContractDeployer(ContractVerifyer):
         self.transact(user_deposit.functions.init(msc.address, one_to_n.address))
 
         return deployed_contracts
+
+
+def contracts_version_expects_deposit_limits(contracts_version: Optional[str]) -> bool:
+    if contracts_version is None:
+        return True
+    if contracts_version == '0.3._':
+        return False
+    return compare(contracts_version, '0.9.0') > -1
 
 
 def _deployed_data_from_receipt(receipt, constructor_arguments):

--- a/raiden_contracts/tests/deprecation_switch_testnet.py
+++ b/raiden_contracts/tests/deprecation_switch_testnet.py
@@ -11,7 +11,7 @@ from raiden_contracts.constants import (
     MAX_ETH_CHANNEL_PARTICIPANT,
     MAX_ETH_TOKEN_NETWORK,
 )
-from raiden_contracts.deploy.__main__ import register_token_network, setup_ctx
+from raiden_contracts.deploy.__main__ import setup_ctx
 from raiden_contracts.utils.transaction import check_successful_tx
 
 log = getLogger(__name__)
@@ -146,8 +146,7 @@ def deprecation_test_setup(
     assert token_contract.functions.balanceOf(deployer.owner).call() >= token_amount
 
     abi = deployer.contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK_REGISTRY)
-    token_network_address = register_token_network(
-        deployer=deployer,
+    token_network_address = deployer.register_token_network(
         token_registry_abi=abi,
         token_registry_address=deployed_contracts[CONTRACT_TOKEN_NETWORK_REGISTRY]['address'],
         token_address=token_address,

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -283,6 +283,102 @@ def test_deploy_script_register(
     assert isinstance(token_network_address, T_Address)
 
 
+def test_deploy_script_register_missing_limits(
+        web3,
+        token_network_deposit_limit,
+        channel_participant_deposit_limit,
+        deployed_raiden_info,
+        token_address,
+        deployer,
+):
+    """ Run token register function used in the deployment script
+
+    without the expected channel participant deposit limit.
+    """
+    token_registry_abi = deployer.contract_manager.get_contract_abi(
+        CONTRACT_TOKEN_NETWORK_REGISTRY,
+    )
+    token_registry_address = deployed_raiden_info['contracts'][
+        CONTRACT_TOKEN_NETWORK_REGISTRY
+    ]['address']
+    with pytest.raises(ValueError):
+        deployer.register_token_network(
+            token_registry_abi=token_registry_abi,
+            token_registry_address=token_registry_address,
+            token_address=token_address,
+            channel_participant_deposit_limit=None,
+            token_network_deposit_limit=token_network_deposit_limit,
+        )
+    with pytest.raises(ValueError):
+        deployer.register_token_network(
+            token_registry_abi=token_registry_abi,
+            token_registry_address=token_registry_address,
+            token_address=token_address,
+            channel_participant_deposit_limit=channel_participant_deposit_limit,
+            token_network_deposit_limit=None,
+        )
+    with pytest.raises(ValueError):
+        deployer.register_token_network(
+            token_registry_abi=token_registry_abi,
+            token_registry_address=token_registry_address,
+            token_address=token_address,
+            channel_participant_deposit_limit=None,
+            token_network_deposit_limit=None,
+        )
+
+
+def test_deploy_script_register_unexpected_limits(
+        web3,
+        token_network_deposit_limit,
+        channel_participant_deposit_limit,
+        token_address,
+        deployed_raiden_info,
+):
+    """ Run token register function used in the deployment script
+
+    without the expected channel participant deposit limit.
+    """
+    deployer = ContractDeployer(
+        web3=web3,
+        private_key=FAUCET_PRIVATE_KEY,
+        gas_limit=GAS_LIMIT,
+        gas_price=1,
+        wait=10,
+        contracts_version='0.4.0',
+    )
+
+    token_registry_abi = deployer.contract_manager.get_contract_abi(
+        CONTRACT_TOKEN_NETWORK_REGISTRY,
+    )
+    token_registry_address = deployed_raiden_info['contracts'][
+        CONTRACT_TOKEN_NETWORK_REGISTRY
+    ]['address']
+    with pytest.raises(ValueError):
+        deployer.register_token_network(
+            token_registry_abi=token_registry_abi,
+            token_registry_address=token_registry_address,
+            token_address=token_address,
+            channel_participant_deposit_limit=None,
+            token_network_deposit_limit=token_network_deposit_limit,
+        )
+    with pytest.raises(ValueError):
+        deployer.register_token_network(
+            token_registry_abi=token_registry_abi,
+            token_registry_address=token_registry_address,
+            token_address=token_address,
+            channel_participant_deposit_limit=channel_participant_deposit_limit,
+            token_network_deposit_limit=None,
+        )
+    with pytest.raises(ValueError):
+        deployer.register_token_network(
+            token_registry_abi=token_registry_abi,
+            token_registry_address=token_registry_address,
+            token_address=token_address,
+            channel_participant_deposit_limit=channel_participant_deposit_limit,
+            token_network_deposit_limit=token_network_deposit_limit,
+        )
+
+
 @pytest.mark.slow
 def test_deploy_script_service(
         web3,

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -21,11 +21,11 @@ from raiden_contracts.contract_manager import contracts_precompiled_path
 from raiden_contracts.deploy.__main__ import (
     ContractDeployer,
     contract_version_with_max_token_networks,
-    contracts_version_expects_deposit_limits,
     error_removed_option,
-    register_token_network,
     validate_address,
 )
+from raiden_contracts.deploy.contract_deployer import contracts_version_expects_deposit_limits
+
 from raiden_contracts.tests.utils import get_random_privkey
 from raiden_contracts.tests.utils.constants import (
     CONTRACT_DEPLOYER_ADDRESS,
@@ -272,8 +272,7 @@ def test_deploy_script_register(
     token_registry_address = deployed_contracts_raiden['contracts'][
         CONTRACT_TOKEN_NETWORK_REGISTRY
     ]['address']
-    token_network_address = register_token_network(
-        deployer=deployer,
+    token_network_address = deployer.register_token_network(
         token_registry_abi=token_registry_abi,
         token_registry_address=token_registry_address,
         token_address=token_address,


### PR DESCRIPTION
talking to a TokenNetworkRegistor contract is quite similar to
deploying a contract. ContractDeployer is the natural place for
register_token_network() for now.