### PR TITLE
Do not change gas.json unless explicitly told

### DIFF
--- a/raiden_contracts/tests/fixtures/base/utils.py
+++ b/raiden_contracts/tests/fixtures/base/utils.py
@@ -1,4 +1,5 @@
 import json
+from sys import argv
 from typing import Dict
 
 import pytest
@@ -111,9 +112,21 @@ def gas_measurement_results():
     return results
 
 
+def sys_args_contain(searched: str) -> bool:
+    """ Returns True if 'searched' appears in any of the command line arguments. """
+    for arg in argv:
+        if arg.find(searched) != -1:
+            return True
+    return False
+
+
 @pytest.fixture
 def print_gas(web3, txn_gas, gas_measurement_results):
     def get(txn_hash, message=None, additional_gas=0):
+        if not sys_args_contain('test_print_gas'):
+            # If the command line arguments don't contain 'test_print_gas', do nothing
+            return
+
         gas_used = txn_gas(txn_hash)
         if not message:
             message = txn_hash


### PR DESCRIPTION
in the command line argument 'test_print_gas'.

For historical reasons one test case prints the gas consumption in
gas.json.  There is another test that checks the integrity of gas.json
but it fails when the two tests run in parallel.

This fixes https://github.com/raiden-network/raiden-contracts/issues/839

As a solution, this commit disables the writing unless the
command line argument contains 'test_print_gas'.