### PR TITLE
"Which version takes which options" into a module

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -14,11 +14,11 @@ from web3 import HTTPProvider, Web3
 from web3.middleware import geth_poa_middleware
 
 from raiden_contracts.constants import CONTRACT_CUSTOM_TOKEN, CONTRACT_TOKEN_NETWORK_REGISTRY
-from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
 from raiden_contracts.deploy.contract_deployer import ContractDeployer
 from raiden_contracts.deploy.contract_verifyer import ContractVerifyer
 from raiden_contracts.utils.private_key import get_private_key
 from raiden_contracts.utils.signature import private_key_to_address
+from raiden_contracts.utils.versions import contract_version_with_max_token_networks
 
 LOG = getLogger(__name__)
 
@@ -130,25 +130,6 @@ def setup_ctx(
 @click.group(chain=True)
 def main():
     pass
-
-
-def contract_version_with_max_token_networks(version: Optional[str]) -> bool:
-    manager = ContractManager(contracts_precompiled_path(version))
-    abi = manager.get_contract_abi(CONTRACT_TOKEN_NETWORK_REGISTRY)
-    constructors = list(filter(lambda x: x['type'] == 'constructor', abi))
-    assert len(constructors) == 1
-    inputs = constructors[0]['inputs']
-    max_token_networks_args = list(filter(lambda x: x['name'] == '_max_token_networks', inputs))
-    found_args = len(max_token_networks_args)
-    if found_args == 0:
-        return False
-    elif found_args == 1:
-        return True
-    else:
-        raise ValueError(
-            "TokenNetworkRegistry's constructor has more than one arguments that are "
-            'called "_max_token_networks".',
-        )
 
 
 def check_version_dependent_parameters(

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -2,7 +2,6 @@ from logging import getLogger
 from typing import Dict, List, Optional
 
 from eth_utils import denoms, encode_hex, is_address, to_checksum_address
-from semver import compare
 from web3 import Web3
 from web3.contract import Contract, ContractFunction
 from web3.middleware import construct_sign_and_send_raw_middleware
@@ -24,6 +23,7 @@ from raiden_contracts.contract_source_manager import ContractSourceManager, cont
 from raiden_contracts.deploy.contract_verifyer import ContractVerifyer, DeployedContracts
 from raiden_contracts.utils.signature import private_key_to_address
 from raiden_contracts.utils.transaction import check_successful_tx
+from raiden_contracts.utils.versions import contracts_version_expects_deposit_limits
 
 LOG = getLogger(__name__)
 
@@ -319,14 +319,6 @@ class ContractDeployer(ContractVerifyer):
         self.transact(user_deposit.functions.init(msc.address, one_to_n.address))
 
         return deployed_contracts
-
-
-def contracts_version_expects_deposit_limits(contracts_version: Optional[str]) -> bool:
-    if contracts_version is None:
-        return True
-    if contracts_version == '0.3._':
-        return False
-    return compare(contracts_version, '0.9.0') > -1
 
 
 def _deployed_data_from_receipt(receipt, constructor_arguments):

--- a/raiden_contracts/utils/versions.py
+++ b/raiden_contracts/utils/versions.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+from semver import compare
+
+from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY
+from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
+
+
+def contracts_version_expects_deposit_limits(contracts_version: Optional[str]) -> bool:
+    """ Answers whether TokenNetworkRegistry of the contracts_vesion needs deposit limits """
+    if contracts_version is None:
+        return True
+    if contracts_version == '0.3._':
+        return False
+    return compare(contracts_version, '0.9.0') > -1
+
+
+def contract_version_with_max_token_networks(version: Optional[str]) -> bool:
+    manager = ContractManager(contracts_precompiled_path(version))
+    abi = manager.get_contract_abi(CONTRACT_TOKEN_NETWORK_REGISTRY)
+    constructors = list(filter(lambda x: x['type'] == 'constructor', abi))
+    assert len(constructors) == 1
+    inputs = constructors[0]['inputs']
+    max_token_networks_args = list(filter(lambda x: x['name'] == '_max_token_networks', inputs))
+    found_args = len(max_token_networks_args)
+    if found_args == 0:
+        return False
+    elif found_args == 1:
+        return True
+    else:
+        raise ValueError(
+            "TokenNetworkRegistry's constructor has more than one arguments that are "
+            'called "_max_token_networks".',
+        )


### PR DESCRIPTION
Here and there I saw ad-hoc functions for deciding which
contracts_version expects which options.

This commit gathers these functions into a new module.

This makes CodeClimate happier https://github.com/raiden-network/raiden-contracts/issues/704