### PR TITLE
Remove render_contracts that no longer exists

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,6 @@ If you want to write tests, check `/raiden_contracts/tests/README.md` first.
 ::
 
     # tests
-    make render_contracts
     pytest
     pytest raiden_contracts/tests/test_token_network.py
 


### PR DESCRIPTION
README contained a line `make render_contracts`. This does not
work anymore.  The line is a leftover from the time we tried
Mustache.