### PR TITLE
get_contracts_deployment_info() returns None instead of raising a ValueError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Documents changes that result in:
 
 ## Unreleased
 
+- get_contracts_deployment_info() returns None instead of raising a ValueError when no deployment file is found.
 - Deploy 0.4.0 version on Goerli
 - [#853](https://github.com/raiden-network/raiden-contracts/pull/853) add chain_id in the IOU claims
 

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -202,15 +202,20 @@ def get_contracts_deployment_info(
     deployment_data: DeployedContracts = {}  # type: ignore
 
     for f in files:
-        try:
-            with f.open() as deployment_file:
-                deployment_data = merge_deployment_data(
-                    deployment_data,
-                    json.load(deployment_file),
-                )
-        except (FileNotFoundError) as ex:
-            return None
-        except (JSONDecodeError, UnicodeDecodeError) as ex:
-            raise ValueError(f'Deployment data file is corrupted: {ex}') from ex
+        deployment_data = merge_deployment_data(
+            deployment_data,
+            _load_json_from_path(f),
+        )
+
     assert deployment_data  # If it's empty, it's not DeployedContracts
     return deployment_data  # type: ignore
+
+
+def _load_json_from_path(f: Path):
+    try:
+        with f.open() as deployment_file:
+            return json.load(deployment_file)
+    except (FileNotFoundError) as ex:
+        return None
+    except (JSONDecodeError, UnicodeDecodeError) as ex:
+        raise ValueError(f'Deployment data file is corrupted: {ex}') from ex

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -207,8 +207,9 @@ def get_contracts_deployment_info(
             _load_json_from_path(f),
         )
 
-    assert deployment_data  # If it's empty, it's not DeployedContracts
-    return deployment_data  # type: ignore
+    if not deployment_data:
+        deployment_data = None
+    return deployment_data
 
 
 def _load_json_from_path(f: Path):

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -165,7 +165,7 @@ def get_contracts_deployment_info(
         version: Optional[str] = None,
         module: DeploymentModule = DeploymentModule.ALL,
 ) -> Optional[DeployedContracts]:
-    """Reads the deployment data.
+    """Reads the deployment data. Returns None if the file is not found.
 
     Parameter:
         module The name of the module. ALL means deployed contracts from all modules that are

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -164,7 +164,7 @@ def get_contracts_deployment_info(
         chain_id: int,
         version: Optional[str] = None,
         module: DeploymentModule = DeploymentModule.ALL,
-) -> DeployedContracts:
+) -> Optional[DeployedContracts]:
     """Reads the deployment data.
 
     Parameter:
@@ -208,7 +208,9 @@ def get_contracts_deployment_info(
                     deployment_data,
                     json.load(deployment_file),
                 )
-        except (JSONDecodeError, UnicodeDecodeError, FileNotFoundError) as ex:
-            raise ValueError(f'Cannot load deployment data file: {ex}') from ex
+        except (FileNotFoundError) as ex:
+            return None
+        except (JSONDecodeError, UnicodeDecodeError) as ex:
+            raise ValueError(f'Deployment data file is corrupted: {ex}') from ex
     assert deployment_data  # If it's empty, it's not DeployedContracts
     return deployment_data  # type: ignore

--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -191,6 +191,10 @@ def etherscan_verify_contract(
         chain_id=chain_id,
         module=source_module,
     )
+    if deployment_info is None:
+        raise FileNotFoundError(
+            f'Deployment file not found for chain_id={chain_id} and module={source_module}',
+        )
     contract_manager = ContractManager(contracts_precompiled_path())
 
     data = post_data_for_etherscan_verification(

--- a/raiden_contracts/tests/test_deploy_data.py
+++ b/raiden_contracts/tests/test_deploy_data.py
@@ -105,6 +105,10 @@ def test_deploy_data_unknown_module():
         get_contracts_deployment_info(3, None, module=None)  # type: ignore
 
 
+def test_deploy_data_not_deployed():
+    assert get_contracts_deployment_info(1, '0.8.0', module=DeploymentModule.RAIDEN) is None
+
+
 @pytest.mark.parametrize('chain_id', [3, 4, 42])
 def test_deploy_data_for_redeyes_succeed(chain_id):
     """ get_contracts_deployment_info() on RedEyes version should return a non-empty dictionary """

--- a/raiden_contracts/tests/test_deploy_data.py
+++ b/raiden_contracts/tests/test_deploy_data.py
@@ -59,6 +59,7 @@ def test_deploy_data_has_fields_raiden(
         chain_id: int,
 ):
     data = get_contracts_deployment_info(chain_id, version, module=DeploymentModule.RAIDEN)
+    assert data
     assert data['contracts_version'] == version if version else CONTRACTS_VERSION
     assert data['chain_id'] == chain_id
     contracts = data['contracts']
@@ -77,6 +78,7 @@ def test_deploy_data_has_fields_services(
         chain_id: int,
 ):
     data = get_contracts_deployment_info(chain_id, version, module=DeploymentModule.SERVICES)
+    assert data
     assert data['contracts_version'] == version if version else CONTRACTS_VERSION
     assert data['chain_id'] == chain_id
     contracts = data['contracts']
@@ -93,6 +95,7 @@ def test_deploy_data_all(
 ):
     data_all = get_contracts_deployment_info(chain_id, version, module=DeploymentModule.ALL)
     data_default = get_contracts_deployment_info(chain_id, version)
+    assert data_all
     assert data_all == data_default
 
     for name in RAIDEN_CONTRACT_NAMES + SERVICE_CONTRACT_NAMES:

--- a/raiden_contracts/tests/unit/test_files.py
+++ b/raiden_contracts/tests/unit/test_files.py
@@ -1,0 +1,12 @@
+import tempfile
+from pathlib import Path
+import pytest
+
+from raiden_contracts.contract_manager import _load_json_from_path
+
+
+def test_load_json_from_corrupt_file():
+    with tempfile.NamedTemporaryFile() as f:
+        f.write(b'not a JSON')
+        with pytest.raises(ValueError):
+            _load_json_from_path(Path(f.name))


### PR DESCRIPTION
when the deployment file is not found.  This closes https://github.com/raiden-network/raiden-contracts/issues/860