### PR TITLE
A new method get_constructor_argument_types()

### DIFF
--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -85,6 +85,14 @@ class ContractManager:
             event_name=event_name,
         )
 
+    def get_constructor_argument_types(self, contract_name: str) -> List:
+        abi = self.get_contract_abi(contract_name=contract_name)
+        return [
+            arg['type'] for arg in list(
+                filter(lambda x: x['type'] == 'constructor', abi),
+            )[0]['inputs']
+        ]
+
     @property
     def version_string(self):
         """Return a flavored version string."""

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -87,11 +87,8 @@ class ContractManager:
 
     def get_constructor_argument_types(self, contract_name: str) -> List:
         abi = self.get_contract_abi(contract_name=contract_name)
-        return [
-            arg['type'] for arg in list(
-                filter(lambda x: x['type'] == 'constructor', abi),
-            )[0]['inputs']
-        ]
+        constructor = [f for f in abi if f['type'] == 'constructor'][0]
+        return [arg['type'] for arg in constructor['inputs']]
 
     @property
     def version_string(self):

--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -129,12 +129,7 @@ def get_constructor_args(
 ):
     constructor_arguments = deployment_info['contracts'][contract_name]['constructor_arguments']
     if constructor_arguments != []:
-        abi = contract_manager.contracts[contract_name]['abi']
-        constructor_types = [
-            arg['type'] for arg in list(
-                filter(lambda x: x['type'] == 'constructor', abi),
-            )[0]['inputs']
-        ]
+        constructor_types = contract_manager.get_constructor_argument_types(contract_name)
         constructor_args = encode_abi(types=constructor_types, args=constructor_arguments).hex()
     else:
         constructor_types = []


### PR DESCRIPTION
These three lines were in etherscan_verify.py but they belong to
ContractManager in terms of functionality.

This commit closes #871.