### PR TITLE
Remove a wrong 'is' usage

### DIFF
--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -168,7 +168,7 @@ def post_data_for_etherscan_verification(
         # Typo is intentional. Etherscan does not like the correct spelling.
         'constructorArguements': constructor_args,
     }
-    pprint.pprint({k: v for k, v in data.items() if k is not 'sourceCode'})
+    pprint.pprint({k: v for k, v in data.items() if k != 'sourceCode'})
     return data
 
 


### PR DESCRIPTION
Comparing a string against a string literal with 'is' looks wrong,
said pylint.