### PR TITLE
Use pipdeptree to detect inconsistent dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
   - pip install pytest-travis-fold
   - pip install -r requirements-dev.txt
   - pip install pytest-xdist pytest-sugar codecov
+  - pipdeptree --warn fail
   - make verify_contracts
 
 before_script:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-eth-tester[py-evm]==0.1.0-beta.32,<1.0
+eth-tester[py-evm]<=0.1.0b33
 pytest
 pytest-cov
 pyfakefs
@@ -16,3 +16,4 @@ pylint-quotes
 requests_mock
 isort
 pipdeptree
+eth-typing<2.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ pylint
 pylint-quotes
 requests_mock
 isort
+pipdeptree

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 click>=7.0
 rlp>=1.0.0
 coincurve>=8.0.0
-web3>=4.4.1
 py-solc>=3.0.0
 semver
 mypy-extensions
+web3
+py_ecc<=1.5.0
+eth-abi<=1.2.2


### PR DESCRIPTION
So that when pip installs incompatible packages, the CI builds fail.

Closes #882.