### PR TITLE
Upgrade eth-tester

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - pip install pytest-travis-fold
   - pip install -r requirements-dev.txt
   - pip install pytest-xdist pytest-sugar codecov
-  - pipdeptree --warn fail
+  - pip check
   - make verify_contracts
 
 before_script:

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -76,7 +76,7 @@ class ContractManager:
     def get_event_abi(self, contract_name: str, event_name: str) -> Dict:
         """ Returns the ABI for a given event. """
         # Import locally to avoid web3 dependency during installation via `compile_contracts`
-        from web3.utils.contracts import find_matching_event_abi
+        from web3._utils.contracts import find_matching_event_abi
 
         assert self.contracts, 'ContractManager should have contracts compiled'
         contract_abi = self.get_contract_abi(contract_name)

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -105,8 +105,8 @@ def setup_ctx(
     logging.getLogger('urllib3').setLevel(logging.INFO)
 
     web3 = Web3(HTTPProvider(rpc_provider, request_kwargs={'timeout': 60}))
-    web3.middleware_stack.inject(geth_poa_middleware, layer=0)
-    print('Web3 provider is', web3.providers[0])
+    web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+    print('Web3 provider is', web3.provider)
     private_key = get_private_key(private_key)
     assert private_key is not None
     owner = private_key_to_address(private_key)
@@ -420,8 +420,8 @@ def register(
 @click.pass_context
 def verify(_, rpc_provider, contracts_version):
     web3 = Web3(HTTPProvider(rpc_provider, request_kwargs={'timeout': 60}))
-    web3.middleware_stack.inject(geth_poa_middleware, layer=0)
-    print('Web3 provider is', web3.providers[0])
+    web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+    print('Web3 provider is', web3.provider)
 
     verifyer = ContractVerifyer(web3=web3, contracts_version=contracts_version)
     verifyer.verify_deployed_contracts_in_filesystem()

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -47,7 +47,7 @@ class ContractDeployer(ContractVerifyer):
         if gas_price != 0:
             self.transaction['gasPrice'] = gas_price * int(units['gwei'])
 
-        self.web3.middleware_stack.add(
+        self.web3.middleware_onion.add(
             construct_sign_and_send_raw_middleware(private_key),
         )
 
@@ -170,7 +170,7 @@ class ContractDeployer(ContractVerifyer):
 
         deployed_contracts: DeployedContracts = {
             'contracts_version': self.contract_version_string(),
-            'chain_id': int(self.web3.version.network),
+            'chain_id': int(self.web3.eth.protocolVersion),
             'contracts': {},
         }
 
@@ -341,7 +341,7 @@ class ContractDeployer(ContractVerifyer):
             user_deposit_whole_balance_limit: int,
     ):
         """Deploy 3rd party service contracts"""
-        chain_id = int(self.web3.version.network)
+        chain_id = int(self.web3.eth.protocolVersion)
         deployed_contracts: DeployedContracts = {
             'contracts_version': self.contract_version_string(),
             'chain_id': chain_id,

--- a/raiden_contracts/deploy/contract_verifyer.py
+++ b/raiden_contracts/deploy/contract_verifyer.py
@@ -36,7 +36,7 @@ class ContractVerifyer:
         self.contract_manager = ContractManager(self.precompiled_path)
 
     def verify_deployed_contracts_in_filesystem(self):
-        chain_id = int(self.web3.version.network)
+        chain_id = int(self.web3.eth.protocolVersion)
 
         deployment_data = get_contracts_deployment_info(
             chain_id=chain_id,
@@ -61,7 +61,7 @@ class ContractVerifyer:
             token_address: str,
             user_deposit_whole_balance_limit: int,
     ):
-        chain_id = int(self.web3.version.network)
+        chain_id = int(self.web3.eth.protocolVersion)
 
         deployment_data = get_contracts_deployment_info(
             chain_id=chain_id,
@@ -129,7 +129,7 @@ class ContractVerifyer:
             deployment_info: DeployedContracts,
     ):
         deployment_file_path = contracts_deployed_path(
-            chain_id=int(self.web3.version.network),
+            chain_id=int(self.web3.eth.protocolVersion),
             version=self.contracts_version,
             services=services,
         )
@@ -145,7 +145,7 @@ class ContractVerifyer:
             self,
             deployment_data: DeployedContracts,
     ):
-        chain_id = int(self.web3.version.network)
+        chain_id = int(self.web3.eth.protocolVersion)
         assert deployment_data is not None
 
         if self.contract_manager.version_string != deployment_data['contracts_version']:
@@ -245,7 +245,7 @@ class ContractVerifyer:
             user_deposit_whole_balance_limit: int,
             deployment_data: DeployedContracts,
     ):
-        chain_id = int(self.web3.version.network)
+        chain_id = int(self.web3.eth.protocolVersion)
         assert deployment_data is not None
 
         if self.contract_manager.version_string != deployment_data['contracts_version']:

--- a/raiden_contracts/tests/fixtures/one_to_n.py
+++ b/raiden_contracts/tests/fixtures/one_to_n.py
@@ -9,7 +9,7 @@ def one_to_n_contract(
         uninitialized_user_deposit_contract,
         web3,
 ):
-    chain_id = int(web3.version.network)
+    chain_id = int(web3.eth.protocolVersion)
     return deploy_tester_contract(
         CONTRACT_ONE_TO_N,
         [uninitialized_user_deposit_contract.address, chain_id],

--- a/raiden_contracts/tests/fixtures/test_contracts.py
+++ b/raiden_contracts/tests/fixtures/test_contracts.py
@@ -15,7 +15,7 @@ def token_network_test_storage(
         [
             custom_token.address,
             secret_registry_contract.address,
-            int(web3.version.network),
+            int(web3.eth.protocolVersion),
             TEST_SETTLE_TIMEOUT_MIN,
             TEST_SETTLE_TIMEOUT_MAX,
         ],
@@ -34,7 +34,7 @@ def token_network_test_signatures(
         [
             custom_token.address,
             secret_registry_contract.address,
-            int(web3.version.network),
+            int(web3.eth.protocolVersion),
             TEST_SETTLE_TIMEOUT_MIN,
             TEST_SETTLE_TIMEOUT_MAX,
         ],
@@ -53,7 +53,7 @@ def token_network_test_utils(
         [
             custom_token.address,
             secret_registry_contract.address,
-            int(web3.version.network),
+            int(web3.eth.protocolVersion),
             TEST_SETTLE_TIMEOUT_MIN,
             TEST_SETTLE_TIMEOUT_MAX,
         ],

--- a/raiden_contracts/tests/fixtures/token_network_fixtures.py
+++ b/raiden_contracts/tests/fixtures/token_network_fixtures.py
@@ -122,7 +122,7 @@ def token_network_contract(
         secret_registry_contract,
         standard_token_contract,
 ):
-    network_id = int(secret_registry_contract.web3.version.network)
+    network_id = int(secret_registry_contract.web3.protocolVersion)
     return deploy_tester_contract(
         CONTRACT_TOKEN_NETWORK,
         [standard_token_contract.address, secret_registry_contract.address, network_id],
@@ -141,7 +141,7 @@ def token_network_external(
     return get_token_network([
         custom_token.address,
         secret_registry_contract.address,
-        int(web3.version.network),
+        int(web3.eth.protocolVersion),
         TEST_SETTLE_TIMEOUT_MIN,
         TEST_SETTLE_TIMEOUT_MAX,
         CONTRACT_DEPLOYER_ADDRESS,

--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -27,7 +27,7 @@ def get_token_network_registry(deploy_tester_contract):
 def token_network_registry_constructor_args(web3, secret_registry_contract):
     return [
         secret_registry_contract.address,
-        int(web3.version.network),
+        int(web3.eth.protocolVersion),
         TEST_SETTLE_TIMEOUT_MIN,
         TEST_SETTLE_TIMEOUT_MAX,
         1,

--- a/raiden_contracts/tests/test_contract_limits.py
+++ b/raiden_contracts/tests/test_contract_limits.py
@@ -21,7 +21,7 @@ def test_register_three_but_not_four(
     """ Check that TokenNetworkRegistry observes the max number of tokens """
     token_network_registry = get_token_network_registry([
         secret_registry_contract.address,
-        int(web3.version.network),
+        int(web3.eth.protocolVersion),
         TEST_SETTLE_TIMEOUT_MIN,
         TEST_SETTLE_TIMEOUT_MAX,
         3,

--- a/raiden_contracts/tests/test_deploy_data.py
+++ b/raiden_contracts/tests/test_deploy_data.py
@@ -144,7 +144,7 @@ def test_verify_nonexistent_deployment(
 ):
     """ Test verify_deployed_contracts_in_filesystem() with a non-existent deployment data. """
     web3_mock = Mock()
-    web3_mock.version.network = 1
+    web3_mock.eth.protocolVersion = '1'
     # contracts_version 0.10.1 does not contain a main net deployment.
     verifyer = ContractVerifyer(web3=web3_mock, contracts_version='0.10.1')
     with pytest.raises(RuntimeError):

--- a/raiden_contracts/tests/test_deprecation_switch.py
+++ b/raiden_contracts/tests/test_deprecation_switch.py
@@ -42,7 +42,7 @@ def test_deprecation_executor(
         json_contract['bin'],
         [
             secret_registry_contract.address,
-            int(web3.version.network),
+            int(web3.eth.protocolVersion),
             TEST_SETTLE_TIMEOUT_MIN,
             TEST_SETTLE_TIMEOUT_MAX,
             1,

--- a/raiden_contracts/tests/test_one_to_n.py
+++ b/raiden_contracts/tests/test_one_to_n.py
@@ -21,7 +21,7 @@ def test_claim(
     # happy case
     amount = 10
     expiration = web3.eth.blockNumber + 2
-    chain_id = int(web3.version.network)
+    chain_id = int(web3.eth.protocolVersion)
 
     # IOU expired
     with pytest.raises(TransactionFailed):
@@ -131,7 +131,7 @@ def test_claim_with_insufficient_deposit(
     ev_handler = event_handler(one_to_n_contract)
     (A, B) = get_accounts(2)
     deposit_to_udc(A, 6)
-    chain_id = int(web3.version.network)
+    chain_id = int(web3.eth.protocolVersion)
 
     amount = 10
     expiration = web3.eth.blockNumber + 1

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -61,7 +61,7 @@ def print_gas_token_network_registry(
         CONTRACT_TOKEN_NETWORK_REGISTRY,
         [
             secret_registry_contract.address,
-            int(web3.version.network),
+            int(web3.eth.protocolVersion),
             TEST_SETTLE_TIMEOUT_MIN,
             TEST_SETTLE_TIMEOUT_MAX,
             10,
@@ -88,7 +88,7 @@ def print_gas_token_network_deployment(
         [
             custom_token.address,
             secret_registry_contract.address,
-            int(web3.version.network),
+            int(web3.eth.protocolVersion),
             TEST_SETTLE_TIMEOUT_MIN,
             TEST_SETTLE_TIMEOUT_MAX,
             deprecation_executor,
@@ -363,7 +363,7 @@ def print_gas_one_to_n(
     deposit_to_udc(A, 30)
 
     # happy case
-    chain_id = int(web3.version.network)
+    chain_id = int(web3.eth.protocolVersion)
     amount = 10
     expiration = web3.eth.blockNumber + 2
     signature = sign_one_to_n_iou(

--- a/raiden_contracts/tests/test_secret_registry.py
+++ b/raiden_contracts/tests/test_secret_registry.py
@@ -22,11 +22,10 @@ def test_register_secret_call(secret_registry_contract):
     with pytest.raises(ValidationError):
         secret_registry_contract.functions.registerSecret(0)
     with pytest.raises(ValidationError):
-        secret_registry_contract.functions.registerSecret('')
-    with pytest.raises(ValidationError):
         secret_registry_contract.functions.registerSecret(fake_bytes(33))
 
     assert secret_registry_contract.functions.registerSecret(fake_bytes(32)).call() is False
+    assert secret_registry_contract.functions.registerSecret('').call() is False
     assert secret_registry_contract.functions.registerSecret(fake_bytes(10, '02')).call() is True
     assert secret_registry_contract.functions.registerSecret(fake_bytes(32, '02')).call() is True
 

--- a/raiden_contracts/tests/test_token_network.py
+++ b/raiden_contracts/tests/test_token_network.py
@@ -26,7 +26,7 @@ def test_constructor_call(
     """ Try to deploy TokenNetwork with various wrong arguments """
 
     (A, deprecation_executor) = get_accounts(2)
-    chain_id = int(web3.version.network)
+    chain_id = int(web3.eth.protocolVersion)
     settle_min = TEST_SETTLE_TIMEOUT_MIN
     settle_max = TEST_SETTLE_TIMEOUT_MAX
 

--- a/raiden_contracts/tests/test_token_network_registry.py
+++ b/raiden_contracts/tests/test_token_network_registry.py
@@ -31,7 +31,7 @@ def test_constructor_call(
 ):
     """ Try to create a TokenNetworkRegistry with various wrong arguments. """
     A = get_accounts(1)[0]
-    chain_id = int(web3.version.network)
+    chain_id = int(web3.eth.protocolVersion)
     settle_min = TEST_SETTLE_TIMEOUT_MIN
     settle_max = TEST_SETTLE_TIMEOUT_MAX
 
@@ -195,7 +195,7 @@ def test_constructor_call(
 def test_constructor_call_state(web3, get_token_network_registry, secret_registry_contract):
     """ The constructor should set the parameters into the storage of the contract """
 
-    chain_id = int(web3.version.network)
+    chain_id = int(web3.eth.protocolVersion)
 
     registry = get_token_network_registry([
         secret_registry_contract.address,

--- a/raiden_contracts/tests/unit/test_recover_from_signature.py
+++ b/raiden_contracts/tests/unit/test_recover_from_signature.py
@@ -35,7 +35,7 @@ def test_verify(
     signature = balance_proof_A[3]
     balance_proof_hash = hash_balance_proof(
         token_network.address,
-        int(web3.version.network),
+        int(web3.eth.protocolVersion),
         channel_identifier,
         *balance_proof_A[:3],
     )
@@ -46,7 +46,7 @@ def test_verify(
     signature = balance_proof_B[3]
     balance_proof_hash = hash_balance_proof(
         token_network.address,
-        int(web3.version.network),
+        int(web3.eth.protocolVersion),
         channel_identifier,
         *balance_proof_B[:3],
     )
@@ -91,7 +91,7 @@ def test_ecrecover_output(
     v = signature[64:]
     balance_proof_hash = hash_balance_proof(
         token_network.address,
-        int(web3.version.network),
+        int(web3.eth.protocolVersion),
         channel_identifier,
         *balance_proof_A[:3],
     )

--- a/raiden_contracts/utils/logs.py
+++ b/raiden_contracts/utils/logs.py
@@ -3,9 +3,9 @@ from collections import defaultdict, namedtuple
 from inspect import getframeinfo, stack
 from typing import Dict, List
 
-from web3.utils.events import get_event_data
-from web3.utils.filters import construct_event_filter_params
-from web3.utils.threads import Timeout
+from web3._utils.events import get_event_data
+from web3._utils.filters import construct_event_filter_params
+from web3._utils.threads import Timeout
 
 # A concrete event added in a transaction.
 LogRecorded = namedtuple('LogRecorded', 'message callback count')

--- a/raiden_contracts/utils/proofs.py
+++ b/raiden_contracts/utils/proofs.py
@@ -16,7 +16,7 @@ def hash_balance_data(transferred_amount, locked_amount, locksroot):
 
 def eth_sign_hash_message(encoded_message):
     signature_prefix = '\x19Ethereum Signed Message:\n'
-    return Web3.sha3(
+    return Web3.keccak(
         Web3.toBytes(text=signature_prefix) +
         Web3.toBytes(text=str(len(encoded_message))) +
         encoded_message,

--- a/raiden_contracts/utils/transaction.py
+++ b/raiden_contracts/utils/transaction.py
@@ -1,7 +1,7 @@
 from typing import Tuple
 
 from web3 import Web3
-from web3.utils.threads import Timeout
+from web3._utils.threads import Timeout
 
 
 def check_successful_tx(web3: Web3, txid: str, timeout=180) -> Tuple[dict, dict]:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-eth-tester[py-evm]<=0.1.0b33
+eth-tester[py-evm]==0.1.0-beta.39
 pytest
 pytest-cov
 pyfakefs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,4 +15,4 @@ pylint
 pylint-quotes
 requests_mock
 isort
-eth-typing<2.0.0
+eth-typing<3.0.0,>=2.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,5 +15,4 @@ pylint
 pylint-quotes
 requests_mock
 isort
-pipdeptree
 eth-typing<2.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-eth-tester[py-evm]==0.1.0-beta.39
+eth-tester[py-evm]>=0.1.0-beta.39
 pytest
 pytest-cov
 pyfakefs

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ coincurve>=8.0.0
 py-solc>=3.0.0
 semver
 mypy-extensions
-web3
+web3>=5.0.0a1
 py_ecc<=1.5.0
-eth-abi<=1.2.2
+eth-abi<3.0.0,>=2.0.0b6


### PR DESCRIPTION
This PR upgrades eth-tester.  Then the tests run the Constantinople rules.  That enables upgrading the Solidity compiler to 0.5.7.

This closes https://github.com/raiden-network/raiden-contracts/issues/868