### PR TITLE
Enable pylint against too many instance attributes

### DIFF
--- a/.pylint.rc
+++ b/.pylint.rc
@@ -27,7 +27,7 @@ logging-modules=logging,structlog
 [MESSAGES CONTROL]
 
 disable=all
-enable=no-value-for-parameter,too-many-format-args,no-member,bad-except-order,redefined-builtin,bad-continuation,unused-variable,no-self-use,invalid-docstring-quote,invalid-string-quote,invalidt-triple-quote,import-self,gevent-joinall,useless-object-inheritance,unused-argument,unexpected-keyword-arg,expression-not-assigned,pointless-statement,unused-import,inconsistent-return-statements,reimported
+enable=no-value-for-parameter,too-many-format-args,no-member,bad-except-order,redefined-builtin,bad-continuation,unused-variable,no-self-use,invalid-docstring-quote,invalid-string-quote,invalidt-triple-quote,import-self,gevent-joinall,useless-object-inheritance,unused-argument,unexpected-keyword-arg,expression-not-assigned,pointless-statement,unused-import,inconsistent-return-statements,reimported,too-many-instance-attributes,duplicate-code
 
 [REPORTS]
 

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -754,7 +754,7 @@ def call_settle(
             token_network.functions.settleChannel(
                 channel_identifier=channel_identifier,
                 participant1=B,
-                participant1_transferred_amount=0,
+                participant1_transferred_amount=vals_B.transferred,
                 participant1_locked_amount=0,
                 participant1_locksroot=vals_B.locksroot,
                 participant2=A,

--- a/raiden_contracts/tests/fixtures/channel_test_values.py
+++ b/raiden_contracts/tests/fixtures/channel_test_values.py
@@ -1,4 +1,4 @@
-from raiden_contracts.tests.utils import MAX_UINT256, ChannelValues
+from raiden_contracts.tests.utils import MAX_UINT256, ChannelValues, LockedAmounts
 
 # We must cover the edge cases documented in
 # https://github.com/raiden-network/raiden-contracts/issues/188
@@ -20,15 +20,19 @@ channel_settle_test_values = [
                 deposit=35,
                 withdrawn=5,
                 transferred=20020,
-                claimable_locked=3,
-                unclaimable_locked=1,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=3,
+                    unclaimable_locked=1,
+                ),
             ),
             ChannelValues(
                 deposit=40,
                 withdrawn=10,
                 transferred=20030,
-                claimable_locked=4,
-                unclaimable_locked=2,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=4,
+                    unclaimable_locked=2,
+                ),
             ),
         ),
         # participant2 provides a valid but old balance proof of participant1
@@ -38,8 +42,7 @@ channel_settle_test_values = [
                 deposit=35,
                 withdrawn=5,
                 transferred=0,
-                claimable_locked=0,
-                unclaimable_locked=0,
+                locked_amounts=LockedAmounts(),
             ),
             # participant2 provides an old participant1 balance proof with a smaller
             # transferred amount
@@ -47,8 +50,10 @@ channel_settle_test_values = [
                 deposit=35,
                 withdrawn=5,
                 transferred=10000,
-                claimable_locked=3,
-                unclaimable_locked=1,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=3,
+                    unclaimable_locked=1,
+                ),
             ),
             # participant2 provides an old participant1 balance proof with a smaller
             # claimable locked amount
@@ -56,8 +61,10 @@ channel_settle_test_values = [
                 deposit=35,
                 withdrawn=5,
                 transferred=20020,
-                claimable_locked=0,
-                unclaimable_locked=1,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=0,
+                    unclaimable_locked=1,
+                ),
             ),
             # participant2 provides an old participant1 balance proof with a smaller
             # unclaimable locked amount
@@ -65,8 +72,10 @@ channel_settle_test_values = [
                 deposit=35,
                 withdrawn=5,
                 transferred=20020,
-                claimable_locked=3,
-                unclaimable_locked=0,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=3,
+                    unclaimable_locked=0,
+                ),
             ),
             # participant2 provides an old participant1 balance proof with a smaller transferred
             # & claimable locked amount
@@ -74,16 +83,20 @@ channel_settle_test_values = [
                 deposit=35,
                 withdrawn=5,
                 transferred=10000,
-                claimable_locked=0,
-                unclaimable_locked=1,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=0,
+                    unclaimable_locked=1,
+                ),
             ),
             # participant2 provides an old participant1 balance proof will all values smaller
             ChannelValues(
                 deposit=35,
                 withdrawn=5,
                 transferred=10000,
-                claimable_locked=0,
-                unclaimable_locked=0,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=0,
+                    unclaimable_locked=0,
+                ),
             ),
             # participant2 provides an old participant1 balance proof, but with the same
             # transferred + claimable_locked
@@ -94,8 +107,10 @@ channel_settle_test_values = [
                 deposit=35,
                 withdrawn=5,
                 transferred=20006,
-                claimable_locked=17,
-                unclaimable_locked=1,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=17,
+                    unclaimable_locked=1,
+                ),
             ),
             # participant2 provides an old participant1 balance proof, with a higher
             # unclaimable locked amount can happen if expired transfers are removed
@@ -104,8 +119,10 @@ channel_settle_test_values = [
                 deposit=35,
                 withdrawn=5,
                 transferred=20020,
-                claimable_locked=3,
-                unclaimable_locked=12,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=3,
+                    unclaimable_locked=12,
+                ),
             ),
             # participant2 provides an old participant1 balance proof with a higher
             # claimable locked amount, but lower transferred + claimable_locked
@@ -116,8 +133,10 @@ channel_settle_test_values = [
                 deposit=35,
                 withdrawn=5,
                 transferred=10020,
-                claimable_locked=17,
-                unclaimable_locked=1,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=17,
+                    unclaimable_locked=1,
+                ),
             ),
             # participant2 provides an old participant1 balance proof with a higher
             # unclaimable locked amount and a higher claimable locked amount but lower
@@ -126,8 +145,10 @@ channel_settle_test_values = [
                 deposit=35,
                 withdrawn=5,
                 transferred=10020,
-                claimable_locked=17,
-                unclaimable_locked=10,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=17,
+                    unclaimable_locked=10,
+                ),
             ),
         ],
         # participant1 provides a valid but old participant2 balance proof
@@ -140,8 +161,10 @@ channel_settle_test_values = [
                 deposit=40,
                 withdrawn=10,
                 transferred=20020,
-                claimable_locked=4,
-                unclaimable_locked=2,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=4,
+                    unclaimable_locked=2,
+                ),
             ),
             # participant1 provides an old participant2 balance proof with a smaller
             # claimable locked amount
@@ -149,8 +172,10 @@ channel_settle_test_values = [
                 deposit=40,
                 withdrawn=10,
                 transferred=20030,
-                claimable_locked=0,
-                unclaimable_locked=2,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=0,
+                    unclaimable_locked=2,
+                ),
             ),
             # participant1 provides an old participant2 balance proof with a smaller
             # unclaimable locked amount
@@ -158,8 +183,10 @@ channel_settle_test_values = [
                 deposit=40,
                 withdrawn=10,
                 transferred=20030,
-                claimable_locked=4,
-                unclaimable_locked=0,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=4,
+                    unclaimable_locked=0,
+                ),
             ),
             # participant1 provides an old participant2 balance proof with a smaller transferred
             # & claimable locked amount
@@ -167,16 +194,20 @@ channel_settle_test_values = [
                 deposit=40,
                 withdrawn=10,
                 transferred=20022,
-                claimable_locked=0,
-                unclaimable_locked=2,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=0,
+                    unclaimable_locked=2,
+                ),
             ),
             # participant1 provides an old participant2 balance proof will all values smaller
             ChannelValues(
                 deposit=40,
                 withdrawn=10,
                 transferred=20024,
-                claimable_locked=0,
-                unclaimable_locked=0,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=0,
+                    unclaimable_locked=0,
+                ),
             ),
             # participant1 provides an old participant2 balance proof, but with the same
             # transferred + claimable_locked
@@ -185,8 +216,10 @@ channel_settle_test_values = [
                 deposit=40,
                 withdrawn=10,
                 transferred=19994,
-                claimable_locked=40,
-                unclaimable_locked=2,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=40,
+                    unclaimable_locked=2,
+                ),
             ),
             # participant1 provides an old participant2 balance proof, with a higher
             # unclaimable locked amount
@@ -195,8 +228,10 @@ channel_settle_test_values = [
                 deposit=40,
                 withdrawn=10,
                 transferred=20030,
-                claimable_locked=4,
-                unclaimable_locked=20,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=4,
+                    unclaimable_locked=20,
+                ),
             ),
             # participant1 provides an old participant2 balance proof with a higher
             # claimable locked amount,
@@ -208,8 +243,10 @@ channel_settle_test_values = [
                 deposit=40,
                 withdrawn=10,
                 transferred=19990,
-                claimable_locked=40,
-                unclaimable_locked=2,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=40,
+                    unclaimable_locked=2,
+                ),
             ),
             # participant1 provides an old participant2 balance proof with a higher
             # unclaimable locked amount and a higher claimable locked amount but lower
@@ -218,8 +255,10 @@ channel_settle_test_values = [
                 deposit=40,
                 withdrawn=10,
                 transferred=19990,
-                claimable_locked=40,
-                unclaimable_locked=10,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=40,
+                    unclaimable_locked=10,
+                ),
             ),
         ],
     },
@@ -230,15 +269,11 @@ channel_settle_test_values = [
                 deposit=40,
                 withdrawn=10,
                 transferred=0,
-                claimable_locked=0,
-                unclaimable_locked=0,
             ),
             ChannelValues(
                 deposit=35,
                 withdrawn=5,
                 transferred=0,
-                claimable_locked=0,
-                unclaimable_locked=0,
             ),
         ),
     },
@@ -249,15 +284,19 @@ channel_settle_test_values = [
                 deposit=35,
                 withdrawn=5,
                 transferred=20,
-                claimable_locked=4,
-                unclaimable_locked=0,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=4,
+                    unclaimable_locked=0,
+                ),
             ),
             ChannelValues(
                 deposit=40,
                 withdrawn=10,
                 transferred=30,
-                claimable_locked=4,
-                unclaimable_locked=2,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=4,
+                    unclaimable_locked=2,
+                ),
             ),
         ),
     },
@@ -268,15 +307,11 @@ channel_settle_test_values = [
                 deposit=5,
                 withdrawn=15,
                 transferred=20,
-                claimable_locked=0,
-                unclaimable_locked=0,
             ),
             ChannelValues(
                 deposit=20,
                 withdrawn=10,
                 transferred=30,
-                claimable_locked=0,
-                unclaimable_locked=0,
             ),
         ),
     },
@@ -287,15 +322,19 @@ channel_settle_test_values = [
                 deposit=5,
                 withdrawn=5,
                 transferred=20,
-                claimable_locked=4,
-                unclaimable_locked=1,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=4,
+                    unclaimable_locked=1,
+                ),
             ),
             ChannelValues(
                 deposit=25,
                 withdrawn=5,
                 transferred=30,
-                claimable_locked=2,
-                unclaimable_locked=3,
+                locked_amounts=LockedAmounts(
+                    claimable_locked=2,
+                    unclaimable_locked=3,
+                ),
             ),
         ),
     },
@@ -308,15 +347,19 @@ channel_settle_invalid_test_values = [
             deposit=35,
             withdrawn=5,
             transferred=20020,
-            claimable_locked=30000000,
-            unclaimable_locked=10000000,
+            locked_amounts=LockedAmounts(
+                claimable_locked=30000000,
+                unclaimable_locked=10000000,
+            ),
         ),
         ChannelValues(
             deposit=40,
             withdrawn=10,
             transferred=20030,
-            claimable_locked=10000000,
-            unclaimable_locked=40000000,
+            locked_amounts=LockedAmounts(
+                claimable_locked=10000000,
+                unclaimable_locked=40000000,
+            ),
         ),
     ),
     # participant2 does not provide a balance proof + locked amount too big
@@ -325,15 +368,19 @@ channel_settle_invalid_test_values = [
             deposit=35,
             withdrawn=5,
             transferred=0,
-            claimable_locked=0,
-            unclaimable_locked=0,
+            locked_amounts=LockedAmounts(
+                claimable_locked=0,
+                unclaimable_locked=0,
+            ),
         ),
         ChannelValues(
             deposit=40,
             withdrawn=10,
             transferred=30,
-            claimable_locked=4,
-            unclaimable_locked=2,
+            locked_amounts=LockedAmounts(
+                claimable_locked=4,
+                unclaimable_locked=2,
+            ),
         ),
     ),
     # Participants have withdrawn all their finalized transfer tokens already,
@@ -343,15 +390,19 @@ channel_settle_invalid_test_values = [
             deposit=5,
             withdrawn=10,
             transferred=20,
-            claimable_locked=4,
-            unclaimable_locked=1,
+            locked_amounts=LockedAmounts(
+                claimable_locked=4,
+                unclaimable_locked=1,
+            ),
         ),
         ChannelValues(
             deposit=20,
             withdrawn=5,
             transferred=30,
-            claimable_locked=2,
-            unclaimable_locked=3,
+            locked_amounts=LockedAmounts(
+                claimable_locked=2,
+                unclaimable_locked=3,
+            ),
         ),
     ),
     (
@@ -359,15 +410,11 @@ channel_settle_invalid_test_values = [
             deposit=5,
             withdrawn=5,
             transferred=20,
-            claimable_locked=0,
-            unclaimable_locked=0,
         ),
         ChannelValues(
             deposit=10,
             withdrawn=10,
             transferred=30,
-            claimable_locked=0,
-            unclaimable_locked=0,
         ),
     ),
     (
@@ -375,15 +422,19 @@ channel_settle_invalid_test_values = [
             deposit=5,
             withdrawn=5,
             transferred=20,
-            claimable_locked=1,
-            unclaimable_locked=3,
+            locked_amounts=LockedAmounts(
+                claimable_locked=1,
+                unclaimable_locked=3,
+            ),
         ),
         ChannelValues(
             deposit=10,
             withdrawn=10,
             transferred=30,
-            claimable_locked=2,
-            unclaimable_locked=4,
+            locked_amounts=LockedAmounts(
+                claimable_locked=2,
+                unclaimable_locked=4,
+            ),
         ),
     ),
     # overflow on transferred amounts
@@ -392,15 +443,19 @@ channel_settle_invalid_test_values = [
             deposit=35,
             withdrawn=5,
             transferred=MAX_UINT256 - 15,
-            claimable_locked=3,
-            unclaimable_locked=1,
+            locked_amounts=LockedAmounts(
+                claimable_locked=3,
+                unclaimable_locked=1,
+            ),
         ),
         ChannelValues(
             deposit=40,
             withdrawn=10,
             transferred=MAX_UINT256 - 5,
-            claimable_locked=5,
-            unclaimable_locked=1,
+            locked_amounts=LockedAmounts(
+                claimable_locked=5,
+                unclaimable_locked=1,
+            ),
         ),
     ),
     # overflow on transferred amount
@@ -409,15 +464,19 @@ channel_settle_invalid_test_values = [
             deposit=35,
             withdrawn=5,
             transferred=0,
-            claimable_locked=4,
-            unclaimable_locked=0,
+            locked_amounts=LockedAmounts(
+                claimable_locked=4,
+                unclaimable_locked=0,
+            ),
         ),
         ChannelValues(
             deposit=40,
             withdrawn=10,
             transferred=MAX_UINT256 - 5,
-            claimable_locked=0,
-            unclaimable_locked=6,
+            locked_amounts=LockedAmounts(
+                claimable_locked=0,
+                unclaimable_locked=6,
+            ),
         ),
     ),
     # overflow on transferred amount
@@ -426,15 +485,19 @@ channel_settle_invalid_test_values = [
             deposit=40,
             withdrawn=10,
             transferred=0,
-            claimable_locked=6,
-            unclaimable_locked=0,
+            locked_amounts=LockedAmounts(
+                claimable_locked=6,
+                unclaimable_locked=0,
+            ),
         ),
         ChannelValues(
             deposit=35,
             withdrawn=5,
             transferred=MAX_UINT256 - 15,
-            claimable_locked=1,
-            unclaimable_locked=3,
+            locked_amounts=LockedAmounts(
+                claimable_locked=1,
+                unclaimable_locked=3,
+            ),
         ),
     ),
     # overflow on transferred amount
@@ -443,15 +506,15 @@ channel_settle_invalid_test_values = [
             deposit=35,
             withdrawn=5,
             transferred=20020,
-            claimable_locked=200000,
-            unclaimable_locked=200,
+            locked_amounts=LockedAmounts(
+                claimable_locked=200000,
+                unclaimable_locked=200,
+            ),
         ),
         ChannelValues(
             deposit=40,
             withdrawn=10,
             transferred=MAX_UINT256 - 5,
-            claimable_locked=0,
-            unclaimable_locked=0,
         ),
     ),
     # overflow on transferred amount, overflow on netted transfer + deposit
@@ -460,15 +523,15 @@ channel_settle_invalid_test_values = [
             deposit=35,
             withdrawn=5,
             transferred=20,
-            claimable_locked=200,
-            unclaimable_locked=200000,
+            locked_amounts=LockedAmounts(
+                claimable_locked=200,
+                unclaimable_locked=200000,
+            ),
         ),
         ChannelValues(
             deposit=40,
             withdrawn=10,
             transferred=MAX_UINT256 - 5,
-            claimable_locked=0,
-            unclaimable_locked=0,
         ),
     ),
 ]

--- a/raiden_contracts/tests/test_channel_close.py
+++ b/raiden_contracts/tests/test_channel_close.py
@@ -8,6 +8,7 @@ from raiden_contracts.tests.utils import (
     EMPTY_LOCKSROOT,
     EMPTY_SIGNATURE,
     ChannelValues,
+    LockedAmounts,
     fake_bytes,
 )
 from raiden_contracts.utils.events import check_channel_closed
@@ -195,8 +196,10 @@ def test_close_nonce_zero(
         deposit=20,
         transferred=5,
         locksroot=fake_bytes(32, '03'),
-        claimable_locked=3,
-        unclaimable_locked=4,
+        locked_amounts=LockedAmounts(
+            claimable_locked=3,
+            unclaimable_locked=4,
+        ),
         nonce=0,
     )
     # Create channel and deposit
@@ -207,7 +210,7 @@ def test_close_nonce_zero(
         channel_identifier,
         B,
         vals_B.transferred,
-        vals_B.locked,
+        vals_B.locked_amounts.locked,
         vals_B.nonce,
         vals_B.locksroot,
     )
@@ -377,8 +380,10 @@ def test_close_channel_state(
         deposit=20,
         transferred=5,
         locksroot=fake_bytes(32, '03'),
-        claimable_locked=3,
-        unclaimable_locked=4,
+        locked_amounts=LockedAmounts(
+            claimable_locked=3,
+            unclaimable_locked=4,
+        ),
         nonce=3,
     )
 
@@ -430,7 +435,7 @@ def test_close_channel_state(
         channel_identifier,
         B,
         vals_B.transferred,
-        vals_B.locked,
+        vals_B.locked_amounts.locked,
         vals_B.nonce,
         vals_B.locksroot,
     )
@@ -523,14 +528,10 @@ def test_close_replay_reopened_channel(
     values_A = ChannelValues(
         deposit=10,
         transferred=0,
-        locked=0,
-        locksroot=EMPTY_LOCKSROOT,
     )
     values_B = ChannelValues(
         deposit=20,
         transferred=15,
-        locked=0,
-        locksroot=EMPTY_LOCKSROOT,
     )
     channel_identifier1 = create_channel(A, B)[0]
     channel_deposit(channel_identifier1, B, values_B.deposit, A)
@@ -539,7 +540,7 @@ def test_close_replay_reopened_channel(
         channel_identifier1,
         B,
         values_B.transferred,
-        values_B.locked,
+        values_B.locked_amounts.locked,
         nonce,
         values_B.locksroot,
     )
@@ -553,11 +554,11 @@ def test_close_replay_reopened_channel(
         channel_identifier=channel_identifier1,
         participant1=A,
         participant1_transferred_amount=values_A.transferred,
-        participant1_locked_amount=values_A.locked,
+        participant1_locked_amount=values_A.locked_amounts.locked,
         participant1_locksroot=values_A.locksroot,
         participant2=B,
         participant2_transferred_amount=values_B.transferred,
-        participant2_locked_amount=values_B.locked,
+        participant2_locked_amount=values_B.locked_amounts.locked,
         participant2_locksroot=values_B.locksroot,
     ).call_and_transact({'from': A})
 
@@ -578,7 +579,7 @@ def test_close_replay_reopened_channel(
         channel_identifier2,
         B,
         values_B.transferred,
-        values_B.locked,
+        values_B.locked_amounts.locked,
         nonce,
         values_B.locksroot,
     )

--- a/raiden_contracts/tests/test_channel_deposit.py
+++ b/raiden_contracts/tests/test_channel_deposit.py
@@ -304,8 +304,8 @@ def test_deposit_wrong_state_fail(
 ):
     """ setTotalDeposit() fails on Closed or Settled channels. """
     (A, B) = get_accounts(2)
-    vals_A = ChannelValues(deposit=2, transferred=0, locked=0)
-    vals_B = ChannelValues(deposit=2, transferred=0, locked=0)
+    vals_A = ChannelValues(deposit=2, transferred=0)
+    vals_B = ChannelValues(deposit=2, transferred=0)
     channel_identifier = create_channel(A, B, TEST_SETTLE_TIMEOUT_MIN)[0]
     assign_tokens(A, vals_A.deposit)
     assign_tokens(B, vals_B.deposit)

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 
 import pytest
-from eth_tester.exceptions import TransactionFailed, ValidationError
+from eth_tester.exceptions import TransactionFailed
 
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN, ChannelEvent, ChannelState
 from raiden_contracts.tests.fixtures.channel import call_settle

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 
 import pytest
-from eth_tester.exceptions import TransactionFailed
+from eth_tester.exceptions import TransactionFailed, ValidationError
 
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN, ChannelEvent, ChannelState
 from raiden_contracts.tests.fixtures.channel import call_settle
@@ -12,6 +12,7 @@ from raiden_contracts.tests.utils import (
     EMPTY_SIGNATURE,
     MAX_UINT256,
     ChannelValues,
+    LockedAmounts,
     fake_bytes,
     get_onchain_settlement_amounts,
     get_settlement_amounts,
@@ -82,26 +83,30 @@ def test_settle_channel_state(
         deposit=40,
         withdrawn=10,
         transferred=20020,
-        claimable_locked=3,
-        unclaimable_locked=4,
+        locked_amounts=LockedAmounts(
+            claimable_locked=3,
+            unclaimable_locked=4,
+        ),
     )
     vals_B = ChannelValues(
         deposit=35,
         withdrawn=5,
         transferred=20030,
-        claimable_locked=2,
-        unclaimable_locked=3,
+        locked_amounts=LockedAmounts(
+            claimable_locked=2,
+            unclaimable_locked=3,
+        ),
     )
 
     pending_transfers_tree_A = get_pending_transfers_tree(
         web3,
-        unlockable_amount=vals_A.claimable_locked,
-        expired_amount=vals_A.unclaimable_locked,
+        unlockable_amount=vals_A.locked_amounts.claimable_locked,
+        expired_amount=vals_A.locked_amounts.unclaimable_locked,
     )
     pending_transfers_tree_B = get_pending_transfers_tree(
         web3,
-        unlockable_amount=vals_B.claimable_locked,
-        expired_amount=vals_B.unclaimable_locked,
+        unlockable_amount=vals_B.locked_amounts.claimable_locked,
+        expired_amount=vals_B.locked_amounts.unclaimable_locked,
     )
     vals_A.locksroot = pending_transfers_tree_A.merkle_root
     vals_B.locksroot = pending_transfers_tree_B.merkle_root
@@ -166,8 +171,8 @@ def test_settle_single_direct_transfer_for_closing_party(
     """
     (A, B) = get_accounts(2)
     (vals_A, vals_B) = (
-        ChannelValues(deposit=1, withdrawn=0, transferred=0, locked=0),
-        ChannelValues(deposit=10, withdrawn=0, transferred=5, locked=0),
+        ChannelValues(deposit=1, withdrawn=0, transferred=0),
+        ChannelValues(deposit=10, withdrawn=0, transferred=5),
     )
     settle_timeout = TEST_SETTLE_TIMEOUT_MIN
 
@@ -179,7 +184,7 @@ def test_settle_single_direct_transfer_for_closing_party(
         channel_identifier,
         B,
         vals_B.transferred,
-        vals_B.locked,
+        vals_B.locked_amounts.locked,
         1,
         EMPTY_LOCKSROOT,
     )
@@ -235,8 +240,8 @@ def test_settle_single_direct_transfer_for_counterparty(
     """
     (A, B) = get_accounts(2)
     (vals_A, vals_B) = (
-        ChannelValues(deposit=10, withdrawn=0, transferred=5, locked=0),
-        ChannelValues(deposit=1, withdrawn=0, transferred=0, locked=0),
+        ChannelValues(deposit=10, withdrawn=0, transferred=5),
+        ChannelValues(deposit=1, withdrawn=0, transferred=0),
     )
     settle_timeout = TEST_SETTLE_TIMEOUT_MIN
 
@@ -256,7 +261,7 @@ def test_settle_single_direct_transfer_for_counterparty(
         channel_identifier,
         A,
         vals_A.transferred,
-        vals_A.locked,
+        vals_A.locked_amounts.locked,
         1,
         EMPTY_LOCKSROOT,
     )
@@ -319,8 +324,8 @@ def test_settlement_with_unauthorized_token_transfer(
     externally_transferred_amount = 5
     (A, B) = get_accounts(2)
     (vals_A, vals_B) = (
-        ChannelValues(deposit=35, withdrawn=10, transferred=0, locked=0),
-        ChannelValues(deposit=40, withdrawn=10, transferred=0, locked=0),
+        ChannelValues(deposit=35, withdrawn=10, transferred=0),
+        ChannelValues(deposit=40, withdrawn=10, transferred=0),
     )
     vals_A.locksroot = fake_bytes(32, '02')
     vals_B.locksroot = fake_bytes(32, '03')
@@ -463,23 +468,27 @@ def test_settle_wrong_balance_hash(
         deposit=35,
         withdrawn=0,
         transferred=5,
-        claimable_locked=10,
-        unclaimable_locked=2,
+        locked_amounts=LockedAmounts(
+            claimable_locked=10,
+            unclaimable_locked=2,
+        ),
     )
     vals_B = ChannelValues(
         deposit=40,
         withdrawn=0,
         transferred=15,
-        claimable_locked=5,
-        unclaimable_locked=4,
+        locked_amounts=LockedAmounts(
+            claimable_locked=5,
+            unclaimable_locked=4,
+        ),
     )
     channel_identifier = create_channel_and_deposit(A, B, vals_A.deposit, vals_B.deposit)
 
     # Mock pending transfers data for A -> B
     pending_transfers_tree_A = get_pending_transfers_tree(
         web3,
-        unlockable_amount=vals_A.claimable_locked,
-        expired_amount=vals_A.unclaimable_locked,
+        unlockable_amount=vals_A.locked_amounts.claimable_locked,
+        expired_amount=vals_A.locked_amounts.unclaimable_locked,
     )
     vals_A.locksroot = pending_transfers_tree_A.merkle_root
     # Reveal A's secrets.
@@ -488,8 +497,8 @@ def test_settle_wrong_balance_hash(
     # Mock pending transfers data for B -> A
     pending_transfers_tree_B = get_pending_transfers_tree(
         web3,
-        unlockable_amount=vals_B.claimable_locked,
-        expired_amount=vals_B.unclaimable_locked,
+        unlockable_amount=vals_B.locked_amounts.claimable_locked,
+        expired_amount=vals_B.locked_amounts.unclaimable_locked,
     )
     vals_B.locksroot = pending_transfers_tree_B.merkle_root
     # Reveal B's secrets
@@ -522,15 +531,16 @@ def test_settle_wrong_balance_hash(
         call_settle(token_network, channel_identifier, B, vals_B, A, vals_A_fail)
 
     vals_A_fail = deepcopy(vals_A)
-    vals_A_fail.locked += 1
+    vals_A_fail.locked_amounts.claimable_locked += 1
     with pytest.raises(TransactionFailed):
         call_settle(token_network, channel_identifier, A, vals_A_fail, B, vals_B)
 
-    vals_A_fail.locked = 0
+    vals_A_fail.locked_amounts.claimable_locked = 0
     with pytest.raises(TransactionFailed):
         call_settle(token_network, channel_identifier, A, vals_A_fail, B, vals_B)
 
-    vals_A_fail.locked = MAX_UINT256
+    vals_A_fail.locked_amounts.unclaimable_locked = 0
+    vals_A_fail.locked_amounts.claimable_locked = MAX_UINT256
     with pytest.raises(TransactionFailed):
         call_settle(token_network, channel_identifier, B, vals_B, A, vals_A_fail)
 
@@ -557,15 +567,16 @@ def test_settle_wrong_balance_hash(
         call_settle(token_network, channel_identifier, A, vals_A, B, vals_B_fail)
 
     vals_B_fail = deepcopy(vals_B)
-    vals_B_fail.locked += 1
+    vals_B_fail.locked_amounts.claimable_locked += 1
     with pytest.raises(TransactionFailed):
         call_settle(token_network, channel_identifier, A, vals_A, B, vals_B_fail)
 
-    vals_B_fail.locked = 0
-    with pytest.raises(TransactionFailed):
+    vals_B_fail.locked_amounts.claimable_locked = 0
+    with pytest.raises(AssertionError):
         call_settle(token_network, channel_identifier, B, vals_B_fail, A, vals_A)
 
-    vals_B_fail.locked = MAX_UINT256
+    vals_B_fail.locked_amounts.unclaimable_locked = 0
+    vals_B_fail.locked_amounts.claimable_locked = MAX_UINT256
     with pytest.raises(TransactionFailed):
         call_settle(token_network, channel_identifier, A, vals_A, B, vals_B_fail)
 

--- a/raiden_contracts/tests/test_channel_settle_unlock_state.py
+++ b/raiden_contracts/tests/test_channel_settle_unlock_state.py
@@ -55,8 +55,8 @@ def test_settlement_outcome(
         # Mock pending transfers data for A -> B
         pending_transfers_tree_A = get_pending_transfers_tree(
             web3,
-            unlockable_amount=vals_A.claimable_locked,
-            expired_amount=vals_A.unclaimable_locked,
+            unlockable_amount=vals_A.locked_amounts.claimable_locked,
+            expired_amount=vals_A.locked_amounts.unclaimable_locked,
         )
         vals_A.locksroot = pending_transfers_tree_A.merkle_root
         # Reveal A's secrets.
@@ -65,8 +65,8 @@ def test_settlement_outcome(
         # Mock pending transfers data for B -> A
         pending_transfers_tree_B = get_pending_transfers_tree(
             web3,
-            unlockable_amount=vals_B.claimable_locked,
-            expired_amount=vals_B.unclaimable_locked,
+            unlockable_amount=vals_B.locked_amounts.claimable_locked,
+            expired_amount=vals_B.locked_amounts.unclaimable_locked,
         )
         vals_B.locksroot = pending_transfers_tree_B.merkle_root
         # Reveal B's secrets
@@ -130,7 +130,7 @@ def test_settlement_outcome(
         assert get_unlocked_amount(
             secret_registry_contract,
             pending_transfers_tree_B.packed_transfers,
-        ) == vals_B.claimable_locked
+        ) == vals_B.locked_amounts.claimable_locked
 
         # A unlocks B's pending transfers
         info_B = token_network.functions.getChannelParticipantInfo(
@@ -327,7 +327,9 @@ def test_channel_settle_old_balance_proof_values(
                 for vals_B in channel_test_values['last_old'][:5]:
                     # We only need to test for cases  where the we have the same argument ordering
                     # for settleChannel, keeping the order of balance calculations
-                    if vals_B.transferred + vals_B.locked >= vals_A.transferred + vals_A.locked:
+                    B_total = vals_B.transferred + vals_B.locked_amounts.locked
+                    A_total = vals_A.transferred + vals_A.locked_amounts.locked
+                    if B_total >= A_total:
                         test_settlement_outcome(
                             (A, B),
                             (vals_A, vals_B, 'invalid'),
@@ -342,7 +344,9 @@ def test_channel_settle_old_balance_proof_values(
                 for vals_B in channel_test_values['last_old'][5:]:
                     # We only need to test for cases  where the we have the same argument ordering
                     # for settleChannel, keeping the order of balance calculations
-                    if vals_B.transferred + vals_B.locked >= vals_A.transferred + vals_A.locked:
+                    B_total = vals_B.transferred + vals_B.locked_amounts.locked
+                    A_total = vals_A.transferred + vals_A.locked_amounts.locked
+                    if B_total >= A_total:
                         test_settlement_outcome(
                             (A, B),
                             (vals_A, vals_B, 'invalid'),
@@ -389,8 +393,8 @@ def test_channel_settle_invalid_balance_proof_values(
     # Mock pending transfers data for A -> B
     pending_transfers_tree_A = get_pending_transfers_tree(
         web3,
-        unlockable_amount=vals_A.claimable_locked,
-        expired_amount=vals_A.unclaimable_locked,
+        unlockable_amount=vals_A.locked_amounts.claimable_locked,
+        expired_amount=vals_A.locked_amounts.unclaimable_locked,
     )
     vals_A.locksroot = pending_transfers_tree_A.merkle_root
     # Reveal A's secrets.
@@ -399,8 +403,8 @@ def test_channel_settle_invalid_balance_proof_values(
     # Mock pending transfers data for B -> A
     pending_transfers_tree_B = get_pending_transfers_tree(
         web3,
-        unlockable_amount=vals_B.claimable_locked,
-        expired_amount=vals_B.unclaimable_locked,
+        unlockable_amount=vals_B.locked_amounts.claimable_locked,
+        expired_amount=vals_B.locked_amounts.unclaimable_locked,
     )
     vals_B.locksroot = pending_transfers_tree_B.merkle_root
     # Reveal B's secrets

--- a/raiden_contracts/tests/test_channel_update_transfer.py
+++ b/raiden_contracts/tests/test_channel_update_transfer.py
@@ -8,7 +8,6 @@ from raiden_contracts.tests.utils import (
     EMPTY_ADDITIONAL_HASH,
     EMPTY_ADDRESS,
     EMPTY_BALANCE_HASH,
-    EMPTY_LOCKSROOT,
     EMPTY_SIGNATURE,
     ChannelValues,
     fake_bytes,
@@ -998,14 +997,10 @@ def test_update_replay_reopened_channel(
     values_A = ChannelValues(
         deposit=10,
         transferred=0,
-        locked=0,
-        locksroot=EMPTY_LOCKSROOT,
     )
     values_B = ChannelValues(
         deposit=20,
         transferred=15,
-        locked=0,
-        locksroot=EMPTY_LOCKSROOT,
     )
 
     channel_identifier1 = create_channel(A, B)[0]
@@ -1014,7 +1009,7 @@ def test_update_replay_reopened_channel(
         channel_identifier1,
         B,
         values_B.transferred,
-        values_B.locked,
+        values_B.locked_amounts.locked,
         nonce_B,
         values_B.locksroot,
     )
@@ -1046,11 +1041,11 @@ def test_update_replay_reopened_channel(
         channel_identifier1,
         A,
         values_A.transferred,
-        values_A.locked,
+        values_A.locked_amounts.locked,
         values_A.locksroot,
         B,
         values_B.transferred,
-        values_B.locked,
+        values_B.locked_amounts.locked,
         values_B.locksroot,
     ).call_and_transact({'from': A})
 
@@ -1091,7 +1086,7 @@ def test_update_replay_reopened_channel(
         channel_identifier2,
         B,
         values_B.transferred,
-        values_B.locked,
+        values_B.locked_amounts.locked,
         nonce_B,
         values_B.locksroot,
     )

--- a/raiden_contracts/tests/test_deprecation_switch.py
+++ b/raiden_contracts/tests/test_deprecation_switch.py
@@ -10,7 +10,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MIN,
 )
 from raiden_contracts.tests.fixtures.channel import call_settle
-from raiden_contracts.tests.utils import ChannelValues
+from raiden_contracts.tests.utils import ChannelValues, LockedAmounts
 from raiden_contracts.utils.pending_transfers import get_pending_transfers_tree
 
 
@@ -174,15 +174,19 @@ def test_deprecation_switch_settle(
             deposit=deposit,
             withdrawn=0,
             transferred=5,
-            claimable_locked=2,
-            unclaimable_locked=4,
+            locked_amounts=LockedAmounts(
+                claimable_locked=2,
+                unclaimable_locked=4,
+            ),
         ),
         ChannelValues(
             deposit=deposit,
             withdrawn=0,
             transferred=10,
-            claimable_locked=4,
-            unclaimable_locked=6,
+            locked_amounts=LockedAmounts(
+                claimable_locked=4,
+                unclaimable_locked=6,
+            ),
         ),
     )
 
@@ -197,8 +201,8 @@ def test_deprecation_switch_settle(
     # Mock pending transfers data for A -> B
     pending_transfers_tree_A = get_pending_transfers_tree(
         web3,
-        unlockable_amount=vals_A.claimable_locked,
-        expired_amount=vals_A.unclaimable_locked,
+        unlockable_amount=vals_A.locked_amounts.claimable_locked,
+        expired_amount=vals_A.locked_amounts.unclaimable_locked,
     )
     vals_A.locksroot = pending_transfers_tree_A.merkle_root
     # Reveal A's secrets.
@@ -207,8 +211,8 @@ def test_deprecation_switch_settle(
     # Mock pending transfers data for B -> A
     pending_transfers_tree_B = get_pending_transfers_tree(
         web3,
-        unlockable_amount=vals_B.claimable_locked,
-        expired_amount=vals_B.unclaimable_locked,
+        unlockable_amount=vals_B.locked_amounts.claimable_locked,
+        expired_amount=vals_B.locked_amounts.unclaimable_locked,
     )
     vals_B.locksroot = pending_transfers_tree_B.merkle_root
     # Reveal B's secrets


### PR DESCRIPTION
This hit ChannelValues class so I introduced LockedAmounts that
combined three attributes of ChannelValues.