### PR TITLE
0.19.0 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.18.0
+current_version = 0.19.0
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ Documents changes that result in:
 
 ## Unreleased
 
-- get_contracts_deployment_info() returns None instead of raising a ValueError when no deployment file is found.
-- Deploy 0.4.0 version on Goerli
-- [#853](https://github.com/raiden-network/raiden-contracts/pull/853) add chain_id in the IOU claims
+## [0.19.0](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.19.0) - 2019-05-09
+
+- [#909](https://github.com/raiden-network/raiden-contracts/pull/909) MonitoringService prioritizes services
+- [#853](https://github.com/raiden-network/raiden-contracts/pull/853) add chain_id in the IOU claims for OneToN
+- [#928](https://github.com/raiden-network/raiden-contracts/pull/928) [#956](https://github.com/raiden-network/raiden-contracts/pull/956) black formatter is enabled
+- [#896](https://github.com/raiden-network/raiden-contracts/pull/896) [#941](https://github.com/raiden-network/raiden-contracts/pull/941) Some Python code cleanup
+- [#867](https://github.com/raiden-network/raiden-contracts/pull/867) get_contracts_deployment_info() returns None instead of raising a ValueError when no deployment file is found.
+- [#863](https://github.com/raiden-network/raiden-contracts/pull/863) Deploy 0.4.0 version on Goerli
 
 ## [0.18.0](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.18.0) - 2019-04-12
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools.command.build_py import build_py
 
 
 DESCRIPTION = 'Raiden contracts library and utilities'
-VERSION = '0.18.0'
+VERSION = '0.19.0'
 
 
 def read_requirements(path: str) -> List[str]:


### PR DESCRIPTION
After this is merged, I'll tag `v0.19.0` on `master`.  That will trigger the PyPI packaging.

The contract deployment has been done in #954.