### PR TITLE
Replace asserts in sign()

### DIFF
--- a/raiden_contracts/tests/unit/test_recover_from_signature.py
+++ b/raiden_contracts/tests/unit/test_recover_from_signature.py
@@ -143,3 +143,35 @@ def test_ecrecover_output_fail(
         ).call()
         != A
     )
+
+
+def test_sign_not_bytes(get_private_key, get_accounts):
+    """ sign() raises when message is not bytes """
+    A = get_accounts(1)[0]
+    privatekey = get_private_key(A)
+    with pytest.raises(TypeError):
+        sign(privatekey, "a" * 32, v=27)  # type: ignore
+
+
+def test_sign_not_32_bytes(get_private_key, get_accounts):
+    """ sign() raises when message is not exactly 32 bytes """
+    A = get_accounts(1)[0]
+    privatekey = get_private_key(A)
+    with pytest.raises(ValueError):
+        sign(privatekey, bytes("a" * 31, "ascii"), v=27)  # type: ignore
+
+
+def test_sign_privatekey_not_string(get_private_key, get_accounts):
+    """ sign() raises when the private key is not a string """
+    A = get_accounts(1)[0]
+    privatekey = get_private_key(A)
+    with pytest.raises(TypeError):
+        sign(bytes(privatekey, "ascii"), bytes("a" * 32, "ascii"), v=27)  # type: ignore
+
+
+def test_sign_wrong_v(get_private_key, get_accounts):
+    """ sign() raises when the private key is not a string """
+    A = get_accounts(1)[0]
+    privatekey = get_private_key(A)
+    with pytest.raises(ValueError):
+        sign(privatekey, bytes("a" * 32, "ascii"), v=22)  # type: ignore

--- a/raiden_contracts/utils/proofs.py
+++ b/raiden_contracts/utils/proofs.py
@@ -140,7 +140,7 @@ def sign_balance_proof(
         additional_hash=additional_hash,
     )
 
-    return sign(privkey=privatekey, msg=message_hash, v=v)
+    return sign(privkey=privatekey, msg_hash=message_hash, v=v)
 
 
 def sign_balance_proof_update_message(
@@ -164,7 +164,7 @@ def sign_balance_proof_update_message(
         closing_signature=closing_signature,
     )
 
-    return sign(privkey=privatekey, msg=message_hash, v=v)
+    return sign(privkey=privatekey, msg_hash=message_hash, v=v)
 
 
 def sign_cooperative_settle_message(
@@ -188,7 +188,7 @@ def sign_cooperative_settle_message(
         participant2_balance=participant2_balance,
     )
 
-    return sign(privkey=privatekey, msg=message_hash, v=v)
+    return sign(privkey=privatekey, msg_hash=message_hash, v=v)
 
 
 def sign_withdraw_message(
@@ -208,7 +208,7 @@ def sign_withdraw_message(
         amount_to_withdraw=amount_to_withdraw,
     )
 
-    return sign(privkey=privatekey, msg=message_hash, v=v)
+    return sign(privkey=privatekey, msg_hash=message_hash, v=v)
 
 
 def sign_reward_proof(
@@ -230,7 +230,7 @@ def sign_reward_proof(
         nonce=nonce,
     )
 
-    return sign(privkey=privatekey, msg=message_hash, v=v)
+    return sign(privkey=privatekey, msg_hash=message_hash, v=v)
 
 
 def sign_one_to_n_iou(
@@ -252,4 +252,4 @@ def sign_one_to_n_iou(
         + encode_single("uint256", amount)
         + encode_single("uint256", expiration_block)
     )
-    return sign(privkey=privatekey, msg=iou_hash, v=v)
+    return sign(privkey=privatekey, msg_hash=iou_hash, v=v)

--- a/raiden_contracts/utils/signature.py
+++ b/raiden_contracts/utils/signature.py
@@ -7,22 +7,22 @@ from eth_utils.typing import ChecksumAddress
 sha3 = keccak
 
 
-def sign(privkey: str, msg: bytes, v: int = 0) -> bytes:
-    if not isinstance(msg, bytes):
-        raise TypeError("sign(): msg is not an instance of bytes")
-    if len(msg) != 32:
-        raise ValueError("sign(): msg has to be exactly 32 bytes")
+def sign(privkey: str, msg_hash: bytes, v: int = 0) -> bytes:
+    if not isinstance(msg_hash, bytes):
+        raise TypeError("sign(): msg_hash is not an instance of bytes")
+    if len(msg_hash) != 32:
+        raise ValueError("sign(): msg_hash has to be exactly 32 bytes")
     if not isinstance(privkey, str):
         raise TypeError("sign(): privkey is not an instance of str")
     if v not in {0, 27}:
         raise ValueError(f"sign(): got v = {v} expected 0 or 27.")
 
     pk = PrivateKey.from_hex(remove_0x_prefix(privkey))
-    sig: bytes = pk.sign_recoverable(msg, hasher=None)
+    sig: bytes = pk.sign_recoverable(msg_hash, hasher=None)
     assert len(sig) == 65
 
     pub = pk.public_key
-    recovered = PublicKey.from_signature_and_message(sig, msg, hasher=None)
+    recovered = PublicKey.from_signature_and_message(sig, msg_hash, hasher=None)
     assert pub == recovered
 
     sig = sig[:-1] + bytes([sig[-1] + v])

--- a/raiden_contracts/utils/signature.py
+++ b/raiden_contracts/utils/signature.py
@@ -9,11 +9,11 @@ sha3 = keccak
 
 def sign(privkey: str, msg: bytes, v: int = 0) -> bytes:
     if not isinstance(msg, bytes):
-        raise TypeError('sign(): msg is not an instance of bytes')
+        raise TypeError("sign(): msg is not an instance of bytes")
     if len(msg) != 32:
-        raise ValueError('sign(): msg has to be exactly 32 bytes')
+        raise ValueError("sign(): msg has to be exactly 32 bytes")
     if not isinstance(privkey, str):
-        raise TypeError('sign(): privkey is not an instance of str')
+        raise TypeError("sign(): privkey is not an instance of str")
 
     pk = PrivateKey.from_hex(remove_0x_prefix(privkey))
     sig: bytes = pk.sign_recoverable(msg, hasher=None)

--- a/raiden_contracts/utils/signature.py
+++ b/raiden_contracts/utils/signature.py
@@ -14,10 +14,16 @@ def sign(privkey: str, msg: bytes, v: int = 0) -> bytes:
         raise ValueError("sign(): msg has to be exactly 32 bytes")
     if not isinstance(privkey, str):
         raise TypeError("sign(): privkey is not an instance of str")
+    if v not in {0, 27}:
+        raise ValueError(f"sign(): got v = {v} expected 0 or 27.")
 
     pk = PrivateKey.from_hex(remove_0x_prefix(privkey))
     sig: bytes = pk.sign_recoverable(msg, hasher=None)
     assert len(sig) == 65
+
+    pub = pk.public_key
+    recovered = PublicKey.from_signature_and_message(sig, msg, hasher=None)
+    assert pub == recovered
 
     sig = sig[:-1] + bytes([sig[-1] + v])
 

--- a/raiden_contracts/utils/signature.py
+++ b/raiden_contracts/utils/signature.py
@@ -8,12 +8,14 @@ sha3 = keccak
 
 
 def sign(privkey: str, msg: bytes, v: int = 0) -> bytes:
-    assert isinstance(msg, bytes)
-    assert isinstance(privkey, str)
+    if not isinstance(msg, bytes):
+        raise TypeError('sign(): msg is not an instance of bytes')
+    if len(msg) != 32:
+        raise ValueError('sign(): msg has to be exactly 32 bytes')
+    if not isinstance(privkey, str):
+        raise TypeError('sign(): privkey is not an instance of str')
 
     pk = PrivateKey.from_hex(remove_0x_prefix(privkey))
-    assert len(msg) == 32
-
     sig: bytes = pk.sign_recoverable(msg, hasher=None)
     assert len(sig) == 65
 


### PR DESCRIPTION
This PR replaces asserts in `sign()` with `if not ...: raise ...`.  Sometimes `assert` is omitted in an optimised execution, but input checks should be always performed.

This PR is a part of #847.

I expect a CodeCov failure, and then I'll add tests to cover the new paths.