### PR TITLE
Move eth-abi<=1.2.2 into requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,3 +20,4 @@ requests_mock
 isort
 pipdeptree
 eth-typing<2.0.0
+eth-abi<=1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ semver
 mypy-extensions
 web3
 py_ecc<=1.5.0
-eth-abi<=1.2.2


### PR DESCRIPTION
because having eth-abi<=1.2.2 in requirements.txt caused
an undesirable downgrade in `raiden` package.

https://github.com/raiden-network/raiden/pull/4043#issuecomment-492248307

By the way, if I simply remove `eth-abi<=1.2.2` from both files, I get
```
ERROR: eth-abi 1.3.0 has requirement eth-typing<3.0.0,>=2.0.0, but you'll have eth-typing 1.3.0 which is incompatible.
```
during `pip install -r requirements-dev.txt`.

The cause and effects follow like this:
* web3 4.9.1 requires eth-tester[py-evm]==0.1.0-beta.33
* eth-tester 0.1.0-beta.33 requires py-evm==0.2.0a33
* py-evm 0.2.0a33 requires eth-typing<2.0.0,>=1.1.0
* `eth-typing 1.3.0` is too new for `eth-abi 1.3.0`.
