### PR TITLE
Release 0.19.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.19.0
+current_version = 0.19.1
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Documents changes that result in:
 
 ## Unreleased
 
+## [0.19.1](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.19.1) - 2019-05-14
+
+- [#973](https://github.com/raiden-network/raiden-contracts/pull/973) Stop forcing a development-time dependency during the usual installation
+
 ## [0.19.0](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.19.0) - 2019-05-09
 
 - [#909](https://github.com/raiden-network/raiden-contracts/pull/909) MonitoringService prioritizes services

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools.command.build_py import build_py
 
 
 DESCRIPTION = 'Raiden contracts library and utilities'
-VERSION = '0.19.0'
+VERSION = '0.19.1'
 
 
 def read_requirements(path: str) -> List[str]:


### PR DESCRIPTION
When this is merged, the plan is to make a PyPI release 0.19.1, and then create a replacement for https://github.com/raiden-network/raiden/pull/4043 .