### PR TITLE
Check whether the contracts field is None

### DIFF
--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -62,6 +62,10 @@ class ContractManager:
             raise ContractManagerLoadError(f"Can't load precompiled smart contracts: {ex}") from ex
         try:
             self.contracts: Dict[str, DeployedContract] = precompiled_content["contracts"]
+            if not self.contracts:
+                raise RuntimeError(
+                    f"Cannot find precompiled contracts data in the JSON file {path}."
+                )
             self.overall_checksum = precompiled_content["overall_checksum"]
             self.contracts_checksums = precompiled_content["contracts_checksums"]
             self.contracts_version = precompiled_content["contracts_version"]

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -204,6 +204,15 @@ def contract_manager_meta(contracts_path, source: bool):
             manager.get_event_abi(CONTRACT_TOKEN_NETWORK, "NonExistant")
 
 
+def test_contract_manager_without_contracts():
+    """ ContractManager's constructor fails on a JSON with "contracts": null """
+    with NamedTemporaryFile() as tmpfile:
+        tmpfile.write(b'{"contracts": null}')
+        tmpfile.flush()
+        with pytest.raises(RuntimeError):
+            ContractManager(Path(tmpfile.name))
+
+
 def test_contract_manager_compile():
     """ Check the ABI in the sources """
     contract_manager_meta(contracts_source_path(), source=True)


### PR DESCRIPTION
The new check makes sure that
`assert self.contracts` in `get_contract()` never fails.

This is a part of #847.