### PR TITLE
Use double quote in bumpversion template

### DIFF
--- a/.bumpversion_contracts.cfg
+++ b/.bumpversion_contracts.cfg
@@ -4,7 +4,7 @@ commit = True
 tag = False
 
 [bumpversion:file:raiden_contracts/constants.py]
-serialize = CONTRACTS_VERSION = '{major}.{minor}.{patch}'
+serialize = CONTRACTS_VERSION = "{major}.{minor}.{patch}"
 
 [bumpversion:file:raiden_contracts/data/source/raiden/EndpointRegistry.sol]
 serialize = contract_version = "{major}.{minor}.{patch}";


### PR DESCRIPTION
Since we introduced black, we are using double quotes.

This fixes https://github.com/raiden-network/raiden-contracts/issues/983