### PR TITLE
Why mypy forces so many changes

### DIFF
--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -17,6 +17,12 @@ _BASE = Path(__file__).parent
 # Classes for static type checking of deployed_contracts dictionary.
 
 
+CompiledContract = TypedDict(
+    "CompiledContract",
+    {"abi": List[Dict[str, Any]], "bin-runtime": str, "bin": str, "metadata": str},
+)
+
+
 DeployedContract = TypedDict(
     "DeployedContract",
     {
@@ -25,10 +31,6 @@ DeployedContract = TypedDict(
         "block_number": int,
         "gas_cost": int,
         "constructor_arguments": List[Any],
-        "abi": List[Dict[str, Any]],
-        "bin-runtime": str,
-        "bin": str,
-        "metadata": str,
     },
 )
 
@@ -61,7 +63,7 @@ class ContractManager:
         except (JSONDecodeError, UnicodeDecodeError) as ex:
             raise ContractManagerLoadError(f"Can't load precompiled smart contracts: {ex}") from ex
         try:
-            self.contracts: Dict[str, DeployedContract] = precompiled_content["contracts"]
+            self.contracts: Dict[str, CompiledContract] = precompiled_content["contracts"]
             if not self.contracts:
                 raise RuntimeError(
                     f"Cannot find precompiled contracts data in the JSON file {path}."
@@ -74,7 +76,7 @@ class ContractManager:
                 f"Precompiled contracts json has unexpected format: {ex}"
             ) from ex
 
-    def get_contract(self, contract_name: str) -> DeployedContract:
+    def get_contract(self, contract_name: str) -> CompiledContract:
         """ Return ABI, BIN of the given contract. """
         assert self.contracts, "ContractManager should have contracts compiled"
         try:

--- a/raiden_contracts/contract_source_manager.py
+++ b/raiden_contracts/contract_source_manager.py
@@ -41,7 +41,7 @@ class ContractSourceManager:
         old_working_dir = Path.cwd()
         chdir(_BASE)
 
-        def relativise(path):
+        def relativise(path: Path) -> Path:
             return path.relative_to(_BASE)
 
         import_dir_map = [
@@ -144,11 +144,11 @@ class ContractSourceManager:
         self.contracts_checksums = checksums
 
 
-def contracts_source_path():
-    return contracts_source_path_with_stem("data/source")
+def contracts_source_path() -> Dict[str, Path]:
+    return contracts_source_path_with_stem(Path("data/source"))
 
 
-def contracts_source_path_of_deployment_module(module: DeploymentModule):
+def contracts_source_path_of_deployment_module(module: DeploymentModule) -> Path:
     if module == DeploymentModule.RAIDEN:
         return contracts_source_path()["raiden"]
     elif module == DeploymentModule.SERVICES:
@@ -157,7 +157,7 @@ def contracts_source_path_of_deployment_module(module: DeploymentModule):
         raise ValueError(f"No source known for module {module}")
 
 
-def contracts_source_path_with_stem(stem):
+def contracts_source_path_with_stem(stem: Path) -> Dict[str, Path]:
     """The directory remapping given to the Solidity compiler."""
     return {
         "lib": _BASE.joinpath(stem, "lib"),

--- a/raiden_contracts/deploy/contract_verifier.py
+++ b/raiden_contracts/deploy/contract_verifier.py
@@ -54,7 +54,7 @@ class ContractVerifier:
 
     def verify_deployed_service_contracts_in_filesystem(
         self, token_address: HexAddress, user_deposit_whole_balance_limit: int
-    ):
+    ) -> None:
         chain_id = int(self.web3.version.network)
 
         deployment_data = get_contracts_deployment_info(
@@ -78,7 +78,9 @@ class ContractVerifier:
                 "and it is CORRECT."
             )
 
-    def store_and_verify_deployment_info_raiden(self, deployed_contracts_info: DeployedContracts):
+    def store_and_verify_deployment_info_raiden(
+        self, deployed_contracts_info: DeployedContracts
+    ) -> None:
         self._store_deployment_info(deployment_info=deployed_contracts_info, services=False)
         self.verify_deployed_contracts_in_filesystem()
 
@@ -87,14 +89,14 @@ class ContractVerifier:
         deployed_contracts_info: DeployedContracts,
         token_address: HexAddress,
         user_deposit_whole_balance_limit: int,
-    ):
+    ) -> None:
         self._store_deployment_info(services=True, deployment_info=deployed_contracts_info)
         self.verify_deployed_service_contracts_in_filesystem(
             token_address=token_address,
             user_deposit_whole_balance_limit=user_deposit_whole_balance_limit,
         )
 
-    def _store_deployment_info(self, services: bool, deployment_info: DeployedContracts):
+    def _store_deployment_info(self, services: bool, deployment_info: DeployedContracts) -> None:
         deployment_file_path = contracts_deployed_path(
             chain_id=int(self.web3.version.network),
             version=self.contracts_version,
@@ -108,7 +110,7 @@ class ContractVerifier:
             f" has been updated at {deployment_file_path}."
         )
 
-    def verify_deployment_data(self, deployment_data: DeployedContracts):
+    def verify_deployment_data(self, deployment_data: DeployedContracts) -> bool:
         chain_id = int(self.web3.version.network)
         assert deployment_data is not None
 
@@ -214,7 +216,7 @@ class ContractVerifier:
         token_address: HexAddress,
         user_deposit_whole_balance_limit: int,
         deployed_contracts_info: DeployedContracts,
-    ):
+    ) -> bool:
         chain_id = int(self.web3.version.network)
         assert deployed_contracts_info is not None
 
@@ -271,7 +273,7 @@ def _verify_user_deposit_deployment(
     user_deposit_whole_balance_limit: int,
     one_to_n_address: HexAddress,
     monitoring_service_address: HexAddress,
-):
+) -> None:
     """ Check an onchain deployment of UserDeposit and constructor arguments at deployment time """
     if len(constructor_arguments) != 2:
         raise RuntimeError("UserDeposit has a wrong number of constructor arguments.")

--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -62,7 +62,7 @@ CONTRACT_NAMES_SEPARATED = " | ".join([c.name for c in CONTRACT_LIST])
 )
 def etherscan_verify(
     chain_id: int, apikey: str, guid: Optional[str], contract_name: Optional[str]
-):
+) -> None:
     if guid:
         guid_status(etherscan_api=api_of_chain_id[chain_id], guid=guid)
         return
@@ -86,7 +86,7 @@ api_of_chain_id = {
 }
 
 
-def join_sources(source_module: DeploymentModule, contract_name: str):
+def join_sources(source_module: DeploymentModule, contract_name: str) -> str:
     """ Use join-contracts.py to concatenate all imported Solidity files.
 
     Args:
@@ -118,7 +118,7 @@ def join_sources(source_module: DeploymentModule, contract_name: str):
 
 def get_constructor_args(
     deployment_info: DeployedContracts, contract_name: str, contract_manager: ContractManager
-):
+) -> str:
     constructor_arguments = deployment_info["contracts"][contract_name]["constructor_arguments"]
     if constructor_arguments != []:
         constructor_types = contract_manager.get_constructor_argument_types(contract_name)
@@ -137,7 +137,7 @@ def post_data_for_etherscan_verification(
     contract_name: str,
     metadata: Dict,
     constructor_args: str,
-):
+) -> Dict:
     data = {
         # A valid API-Key is required
         "apikey": apikey,
@@ -161,7 +161,7 @@ def post_data_for_etherscan_verification(
 
 def etherscan_verify_contract(
     chain_id: int, apikey: str, source_module: DeploymentModule, contract_name: str
-):
+) -> None:
     """ Calls Etherscan API for verifying the Solidity source of a contract.
 
     Args:
@@ -226,7 +226,7 @@ def etherscan_verify_contract(
     raise TimeoutError(manual_submission_guide)
 
 
-def guid_status(etherscan_api: str, guid: str):
+def guid_status(etherscan_api: str, guid: str) -> Dict:
     data = {"guid": guid, "module": "contract", "action": "checkverifystatus"}
     r = requests.get(etherscan_api, data)
     status_content = json.loads(r.content.decode())

--- a/raiden_contracts/tests/fixtures/base/contract_manager.py
+++ b/raiden_contracts/tests/fixtures/base/contract_manager.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from typing import Generator
 
 import pytest
 
@@ -7,11 +8,11 @@ from raiden_contracts.contract_source_manager import ContractSourceManager, cont
 
 
 @pytest.fixture(scope="session")
-def contract_source_manager():
+def contract_source_manager() -> ContractSourceManager:
     return ContractSourceManager(contracts_source_path())
 
 
 @pytest.fixture(scope="session")
-def contracts_manager(contract_source_manager):
+def contracts_manager(contract_source_manager: ContractSourceManager) -> Generator:
     with NamedTemporaryFile() as target_path:
         yield contract_source_manager.compile_contracts(Path(target_path.name))

--- a/raiden_contracts/tests/fixtures/contracts.py
+++ b/raiden_contracts/tests/fixtures/contracts.py
@@ -72,6 +72,6 @@ def deploy_tester_contract_txhash(web3, contracts_manager, deploy_contract_txhas
 
 
 @pytest.fixture
-def utils_contract(deploy_tester_contract):
+def utils_contract(deploy_tester_contract: Callable):
     """Deployed Utils contract"""
     return deploy_tester_contract("Utils")

--- a/raiden_contracts/tests/fixtures/endpoint_registry.py
+++ b/raiden_contracts/tests/fixtures/endpoint_registry.py
@@ -1,9 +1,12 @@
+from typing import Callable
+
 import pytest
+from web3.contract import Contract
 
 from raiden_contracts.constants import CONTRACT_ENDPOINT_REGISTRY
 
 
 @pytest.fixture
-def endpoint_registry_contract(deploy_tester_contract):
+def endpoint_registry_contract(deploy_tester_contract: Callable) -> Contract:
     """Deployed SecretRegistry contract"""
     return deploy_tester_contract(CONTRACT_ENDPOINT_REGISTRY)

--- a/raiden_contracts/tests/fixtures/one_to_n.py
+++ b/raiden_contracts/tests/fixtures/one_to_n.py
@@ -1,10 +1,14 @@
 import pytest
+from web3 import Web3
+from web3.contract import Contract
 
 from raiden_contracts.constants import CONTRACT_ONE_TO_N
 
 
 @pytest.fixture(scope="session")
-def one_to_n_contract(deploy_tester_contract, uninitialized_user_deposit_contract, web3):
+def one_to_n_contract(
+    deploy_tester_contract: Contract, uninitialized_user_deposit_contract: Contract, web3: Web3
+) -> Contract:
     chain_id = int(web3.version.network)
     return deploy_tester_contract(
         CONTRACT_ONE_TO_N, [uninitialized_user_deposit_contract.address, chain_id]

--- a/raiden_contracts/tests/fixtures/secret_registry.py
+++ b/raiden_contracts/tests/fixtures/secret_registry.py
@@ -1,9 +1,12 @@
+from typing import Callable
+
 import pytest
+from web3.contract import Contract
 
 from raiden_contracts.constants import CONTRACT_SECRET_REGISTRY
 
 
 @pytest.fixture(scope="session")
-def secret_registry_contract(deploy_tester_contract):
+def secret_registry_contract(deploy_tester_contract: Callable) -> Contract:
     """Deployed SecretRegistry contract"""
     return deploy_tester_contract(CONTRACT_SECRET_REGISTRY)

--- a/raiden_contracts/tests/fixtures/service_registry_fixtures.py
+++ b/raiden_contracts/tests/fixtures/service_registry_fixtures.py
@@ -1,8 +1,11 @@
+from typing import Callable
+
 import pytest
+from web3.contract import Contract
 
 from raiden_contracts.constants import CONTRACT_SERVICE_REGISTRY
 
 
 @pytest.fixture(scope="session")
-def service_registry(deploy_tester_contract, custom_token):
+def service_registry(deploy_tester_contract: Callable, custom_token: Contract) -> Contract:
     return deploy_tester_contract(CONTRACT_SERVICE_REGISTRY, [custom_token.address])

--- a/raiden_contracts/tests/fixtures/test_contracts.py
+++ b/raiden_contracts/tests/fixtures/test_contracts.py
@@ -1,12 +1,19 @@
+from typing import Callable
+
 import pytest
+from web3 import Web3
+from web3.contract import Contract
 
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MAX, TEST_SETTLE_TIMEOUT_MIN
 
 
 @pytest.fixture()
 def token_network_test_storage(
-    deploy_tester_contract, web3, custom_token, secret_registry_contract
-):
+    deploy_tester_contract: Callable,
+    web3: Web3,
+    custom_token: Web3,
+    secret_registry_contract: Contract,
+) -> Contract:
     return deploy_tester_contract(
         "TokenNetworkInternalStorageTest",
         [
@@ -21,8 +28,11 @@ def token_network_test_storage(
 
 @pytest.fixture()
 def token_network_test_signatures(
-    deploy_tester_contract, web3, custom_token, secret_registry_contract
-):
+    deploy_tester_contract: Contract,
+    web3: Web3,
+    custom_token: Contract,
+    secret_registry_contract: Contract,
+) -> Contract:
     return deploy_tester_contract(
         "TokenNetworkSignatureTest",
         [
@@ -36,7 +46,12 @@ def token_network_test_signatures(
 
 
 @pytest.fixture()
-def token_network_test_utils(deploy_tester_contract, web3, custom_token, secret_registry_contract):
+def token_network_test_utils(
+    deploy_tester_contract: Contract,
+    web3: Web3,
+    custom_token: Contract,
+    secret_registry_contract: Contract,
+) -> Contract:
     return deploy_tester_contract(
         "TokenNetworkUtilsTest",
         [

--- a/raiden_contracts/tests/fixtures/token.py
+++ b/raiden_contracts/tests/fixtures/token.py
@@ -1,4 +1,7 @@
+from typing import Callable, List, Tuple
+
 import pytest
+from web3.contract import Contract
 
 from raiden_contracts.constants import CONTRACT_CUSTOM_TOKEN, CONTRACT_HUMAN_STANDARD_TOKEN
 
@@ -6,37 +9,37 @@ CUSTOM_TOKEN_TOTAL_SUPPLY = 10 ** 26
 
 
 @pytest.fixture(scope="session")
-def token_args():
+def token_args() -> Tuple:
     return (CUSTOM_TOKEN_TOTAL_SUPPLY, 18, CONTRACT_CUSTOM_TOKEN, "TKN")
 
 
 @pytest.fixture(scope="session")
-def custom_token_factory(deploy_tester_contract, token_args):
+def custom_token_factory(deploy_tester_contract: Callable, token_args: List) -> Callable:
     """A function that deploys a CustomToken contract"""
 
-    def f():
+    def f() -> Contract:
         return deploy_tester_contract(CONTRACT_CUSTOM_TOKEN, token_args)
 
     return f
 
 
 @pytest.fixture(scope="session")
-def custom_token(custom_token_factory):
+def custom_token(custom_token_factory: Callable) -> Contract:
     """Deploy CustomToken contract"""
     return custom_token_factory()
 
 
 @pytest.fixture()
-def human_standard_token(deploy_token_contract, token_args):
+def human_standard_token(deploy_token_contract: Callable, token_args: List) -> Contract:
     """Deploy HumanStandardToken contract"""
     return deploy_token_contract(*token_args)
 
 
 @pytest.fixture
-def deploy_token_contract(deploy_tester_contract):
+def deploy_token_contract(deploy_tester_contract: Contract) -> Callable:
     """Returns a function that deploys a generic HumanStandardToken contract"""
 
-    def f(initial_amount: int, decimals: int, token_name: str, token_symbol: str):
+    def f(initial_amount: int, decimals: int, token_name: str, token_symbol: str) -> Contract:
         assert initial_amount > 0
         assert decimals > 0
         return deploy_tester_contract(
@@ -47,6 +50,6 @@ def deploy_token_contract(deploy_tester_contract):
 
 
 @pytest.fixture
-def standard_token_contract(custom_token):
+def standard_token_contract(custom_token: Contract) -> Contract:
     """Deployed CustomToken contract"""
     return custom_token

--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -1,6 +1,8 @@
+from typing import Callable
+
 import pytest
 from eth_utils import is_address
-from web3.contract import get_event_data
+from web3.contract import Contract, get_event_data
 
 from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK,
@@ -14,7 +16,7 @@ from raiden_contracts.utils.transaction import check_successful_tx
 
 
 @pytest.fixture()
-def get_token_network_registry(deploy_tester_contract):
+def get_token_network_registry(deploy_tester_contract: Contract) -> Callable:
     def get(arguments):
         return deploy_tester_contract(CONTRACT_TOKEN_NETWORK_REGISTRY, arguments)
 

--- a/raiden_contracts/tests/fixtures/user_deposit.py
+++ b/raiden_contracts/tests/fixtures/user_deposit.py
@@ -1,4 +1,7 @@
+from typing import Callable
+
 import pytest
+from eth_typing.evm import HexAddress
 from web3.contract import Contract
 
 from raiden_contracts.constants import CONTRACT_USER_DEPOSIT
@@ -6,14 +9,14 @@ from raiden_contracts.tests.fixtures.token import CUSTOM_TOKEN_TOTAL_SUPPLY
 
 
 @pytest.fixture(scope="session")
-def user_deposit_whole_balance_limit():
+def user_deposit_whole_balance_limit() -> int:
     return CUSTOM_TOKEN_TOTAL_SUPPLY // 100
 
 
 @pytest.fixture(scope="session")
 def uninitialized_user_deposit_contract(
-    deploy_tester_contract, custom_token, user_deposit_whole_balance_limit
-):
+    deploy_tester_contract: Callable, custom_token: Contract, user_deposit_whole_balance_limit: int
+) -> Contract:
     return deploy_tester_contract(
         CONTRACT_USER_DEPOSIT, [custom_token.address, user_deposit_whole_balance_limit]
     )
@@ -21,7 +24,9 @@ def uninitialized_user_deposit_contract(
 
 @pytest.fixture
 def user_deposit_contract(
-    uninitialized_user_deposit_contract: Contract, monitoring_service_external, one_to_n_contract
+    uninitialized_user_deposit_contract: Contract,
+    monitoring_service_external: Contract,
+    one_to_n_contract: Contract,
 ) -> Contract:
     uninitialized_user_deposit_contract.functions.init(
         monitoring_service_external.address, one_to_n_contract.address
@@ -30,13 +35,15 @@ def user_deposit_contract(
 
 
 @pytest.fixture
-def udc_transfer_contract(deploy_tester_contract, uninitialized_user_deposit_contract):
+def udc_transfer_contract(
+    deploy_tester_contract: Callable, uninitialized_user_deposit_contract: Contract
+) -> Contract:
     return deploy_tester_contract("UDCTransfer", [uninitialized_user_deposit_contract.address])
 
 
 @pytest.fixture
-def deposit_to_udc(user_deposit_contract: Contract, custom_token):
-    def deposit(receiver, amount):
+def deposit_to_udc(user_deposit_contract: Contract, custom_token: Contract) -> Callable:
+    def deposit(receiver: HexAddress, amount: int) -> None:
         """ Uses UDC's monotonous deposit amount handling
 
         If you call it twice, only amount2 - amount1 will be deposited. More

--- a/raiden_contracts/tests/test_contract_limits.py
+++ b/raiden_contracts/tests/test_contract_limits.py
@@ -2,6 +2,7 @@ from typing import Callable
 
 import pytest
 from eth_tester.exceptions import TransactionFailed
+from eth_typing.evm import HexAddress
 from web3 import Web3
 from web3.contract import Contract
 
@@ -138,7 +139,9 @@ def test_network_deposit_limit(
             - last_deposit
         )
 
-    def send_remaining(channel_identifier, participant1, participant2) -> None:
+    def send_remaining(
+        channel_identifier: int, participant1: HexAddress, participant2: HexAddress
+    ) -> None:
         remaining_to_reach_limit = remaining()
         assign_tokens(participant1, remaining_to_reach_limit)
         token_network.functions.setTotalDeposit(

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -580,24 +580,26 @@ def test_deploy_script_service(web3, deployed_service_info, token_address: HexAd
 
 def test_validate_address_on_none():
     """ validate_address(x, y, None) should return None """
-    assert validate_address(None, None, None) is None
+    mock_command = MagicMock()
+    mock_parameter = MagicMock()
+    assert validate_address(mock_command, mock_parameter, None) is None
 
 
 def test_validate_address_empty_string():
     """ validate_address(x, y, '') should return None """
-    assert validate_address(None, None, "") is None
+    assert validate_address(MagicMock(), MagicMock(), "") is None
 
 
 def test_validate_address_not_an_address():
     """ validate_address(x, y, 'not an address') should raise click.BadParameter """
     with pytest.raises(BadParameter):
-        validate_address(None, None, "not an address")
+        validate_address(MagicMock(), MagicMock(), "not an address")
 
 
 def test_validate_address_happy_path():
     """ validate_address(x, y, address) should return the same address checksumed """
     address = CONTRACT_DEPLOYER_ADDRESS
-    assert validate_address(None, None, address) == to_checksum_address(address)
+    assert validate_address(MagicMock(), MagicMock(), address) == to_checksum_address(address)
 
 
 @pytest.fixture

--- a/raiden_contracts/tests/test_etherscan_verify.py
+++ b/raiden_contracts/tests/test_etherscan_verify.py
@@ -1,8 +1,7 @@
-from typing import Dict, List
+from typing import Any, Dict, List
 
 import requests_mock
 from click.testing import CliRunner
-from eth_typing.evm import HexAddress
 
 from raiden_contracts.constants import (
     CONTRACT_ENDPOINT_REGISTRY,
@@ -31,30 +30,25 @@ from raiden_contracts.deploy.etherscan_verify import (
 contract_name = "DummyContract"
 
 
-def test_get_constructor_args_no_args():
+def test_get_constructor_args_no_args() -> None:
     """ Test get_constructor_args() on no arguments """
     contract_manager = ContractManager(contracts_precompiled_path())
     deploy_info: Dict = {"contracts": {contract_name: {"constructor_arguments": []}}}
     assert get_constructor_args(deploy_info, contract_name, contract_manager) == ""  # type: ignore
 
 
-def abi_with_constructor_input_types(types: List[str]):
+def abi_with_constructor_input_types(types: List[str]) -> List[Dict]:
     return [{"type": "constructor", "inputs": [{"type": ty} for ty in types]}]
 
 
-def test_get_constructor_args_one_arg():
+def test_get_constructor_args_one_arg() -> None:
     """ Test get_constructor_args() on one argument """
     contract_manager = ContractManager(contracts_precompiled_path())
     contract_manager.contracts[contract_name] = {
-        "address": HexAddress("0x00112233445566778899aabbccddeeff00112233"),
         "abi": abi_with_constructor_input_types(["uint256"]),
-        "transaction_hash": "dummy",
-        "gas_cost": 300,
-        "constructor_arguments": ["dummy"],
         "bin": "dummy",
         "bin-runtime": "dummy",
         "metadata": "dummy",
-        "block_number": 3,
     }
     deploy_info: DeployedContracts = {  # type: ignore
         "contracts": {contract_name: {"constructor_arguments": [16]}}
@@ -65,19 +59,14 @@ def test_get_constructor_args_one_arg():
     )
 
 
-def test_get_constructor_args_two_args():
+def test_get_constructor_args_two_args() -> None:
     """ Test get_constructor_args() on two arguments """
     contract_manager = ContractManager(contracts_precompiled_path())
     contract_manager.contracts[contract_name] = {
-        "address": HexAddress("0x00112233445566778899aabbccddeeff00112233"),
         "abi": abi_with_constructor_input_types(["uint256", "bool"]),
-        "block_number": 0,
         "bin-runtime": "dummy",
         "bin": "dummy",
-        "constructor_arguments": ["dummy"],
         "metadata": "dummy",
-        "gas_cost": 300,
-        "transaction_hash": "dummy",
     }
     deploy_info: DeployedContracts = {  # type: ignore
         "contracts": {contract_name: {"constructor_arguments": [16, True]}}
@@ -89,7 +78,7 @@ def test_get_constructor_args_two_args():
     )
 
 
-def test_post_data_for_etherscan_verification():
+def test_post_data_for_etherscan_verification() -> None:
     output = post_data_for_etherscan_verification(
         apikey="jkl;jkl;jkl;",
         deployment_info={"address": "dummy_address"},  # type: ignore
@@ -115,7 +104,7 @@ def test_post_data_for_etherscan_verification():
     }
 
 
-def test_run_join_contracts():
+def test_run_join_contracts() -> None:
     """ Just running join_sources() """
     join_sources(DeploymentModule.RAIDEN, CONTRACT_TOKEN_NETWORK_REGISTRY)
     join_sources(DeploymentModule.RAIDEN, CONTRACT_SECRET_REGISTRY)
@@ -126,14 +115,14 @@ def test_run_join_contracts():
     join_sources(DeploymentModule.SERVICES, CONTRACT_USER_DEPOSIT)
 
 
-def test_guid_status():
+def test_guid_status() -> None:
     with requests_mock.Mocker() as m:
         etherscan_api = api_of_chain_id[3]
         m.get(etherscan_api, text='{ "content": 1 }')
         assert guid_status(etherscan_api, "something") == {"content": 1}
 
 
-def test_etherscan_verify_with_guid():
+def test_etherscan_verify_with_guid() -> None:
     with requests_mock.Mocker() as m:
         chain_id = 3
         etherscan_api = api_of_chain_id[chain_id]
@@ -146,7 +135,7 @@ def test_etherscan_verify_with_guid():
         assert result.exit_code == 0
 
 
-def test_etherscan_verify_already_verified():
+def test_etherscan_verify_already_verified() -> None:
     with requests_mock.Mocker() as m:
         chain_id = 3
         etherscan_api = api_of_chain_id[chain_id]
@@ -175,7 +164,7 @@ def test_etherscan_verify_already_verified():
         assert result.exit_code == 0
 
 
-def test_etherscan_verify_unknown_error():
+def test_etherscan_verify_unknown_error() -> None:
     with requests_mock.Mocker() as m:
         chain_id = 3
         etherscan_api = api_of_chain_id[chain_id]
@@ -204,7 +193,7 @@ def test_etherscan_verify_unknown_error():
         assert result.exit_code != 0
 
 
-def test_etherscan_verify_unable_to_verify():
+def test_etherscan_verify_unable_to_verify() -> None:
     with requests_mock.Mocker() as m:
         chain_id = 3
         etherscan_api = api_of_chain_id[chain_id]
@@ -243,7 +232,7 @@ def test_etherscan_verify_unable_to_verify():
         assert result.exit_code != 0
 
 
-def test_etherscan_verify_success():
+def test_etherscan_verify_success() -> None:
     with requests_mock.Mocker() as m:
         chain_id = 3
         etherscan_api = api_of_chain_id[chain_id]
@@ -273,7 +262,7 @@ def test_etherscan_verify_success():
         assert result.exit_code == 0
 
 
-def first_fail_second_succeed(_, context):
+def first_fail_second_succeed(_: Any, context: Any) -> str:
     """ Simulate Etherscan saying for the first time 'wait', but for the second time 'success'. """
     context.status_code = 200
     try:
@@ -285,7 +274,7 @@ def first_fail_second_succeed(_, context):
     return '{ "status": "0", "result" : "wait for a moment", "message" : "" }'
 
 
-def test_etherscan_verify_success_after_a_loop():
+def test_etherscan_verify_success_after_a_loop() -> None:
     with requests_mock.Mocker() as m:
         chain_id = 3
         etherscan_api = api_of_chain_id[chain_id]

--- a/raiden_contracts/tests/test_monitoring_service.py
+++ b/raiden_contracts/tests/test_monitoring_service.py
@@ -91,7 +91,7 @@ def test_claimReward_with_settle_call(
     ms_address,
     web3,
     with_settle,
-):
+) -> None:
     A, B = monitor_data["participants"]
     channel_identifier = monitor_data["channel_identifier"]
 

--- a/raiden_contracts/tests/test_priv_key.py
+++ b/raiden_contracts/tests/test_priv_key.py
@@ -1,56 +1,62 @@
 import os
 import stat
 import tempfile
+from pathlib import Path
 
 import pytest
 
 from raiden_contracts.utils.private_key import check_permission_safety, get_private_key
 
 
-def test_permission_safety_different_uid():
+def test_permission_safety_different_uid() -> None:
     """ check_permission_safety() should fail on a file with a different uid """
-    assert not check_permission_safety("/")
+    assert not check_permission_safety(Path("/"))
 
 
-def test_permission_safety_group_writable():
+def test_permission_safety_group_writable() -> None:
     """ check_permission_safety() should fail on a file that is writable to group """
     with tempfile.NamedTemporaryFile() as tmpfile:
         orig = os.stat(tmpfile.name).st_mode
         os.chmod(tmpfile.name, stat.S_IWGRP | orig)
-        assert not check_permission_safety(tmpfile.name)
+        assert not check_permission_safety(Path(tmpfile.name))
 
 
-def test_permission_safety_executable():
+def test_permission_safety_executable() -> None:
     """ check_permission_safety() should fail on a file that is executable to others """
     with tempfile.NamedTemporaryFile() as tmpfile:
         orig = os.stat(tmpfile.name).st_mode
         os.chmod(tmpfile.name, stat.S_IXOTH | orig)
-        assert not check_permission_safety(tmpfile.name)
+        assert not check_permission_safety(Path(tmpfile.name))
 
 
-def test_get_private_key_empty_path():
+def test_get_private_key_empty_path() -> None:
     """ get_private_key() should raise AssertionFailure on an empty key path """
     with pytest.raises(AssertionError):
-        get_private_key("")
+        get_private_key(None)  # type: ignore
 
 
-def test_get_private_key_nonexistent():
+def test_get_private_key_nonexistent() -> None:
     """ get_private_key() should return None on a nonexistent file path """
-    assert get_private_key("ggg") is None
+    assert get_private_key(Path("ggg")) is None
 
 
-def test_get_private_key_writable_keyfile():
+def test_get_private_key_writable_keyfile() -> None:
     """ get_private_key() should return None on a key path with wrong permissions """
     with tempfile.NamedTemporaryFile() as tmpfile:
         orig = os.stat(tmpfile.name).st_mode
         os.chmod(tmpfile.name, stat.S_IWGRP | orig)
-        assert get_private_key(tmpfile.name) is None
+        assert get_private_key(Path(tmpfile.name)) is None
 
 
-def test_get_private_key_writable_password_file():
+def test_get_private_key_writable_password_file() -> None:
     """ get_private_key() should return None on a password path with wrong permissions """
     with tempfile.NamedTemporaryFile() as keyfile:
         with tempfile.NamedTemporaryFile() as password_file:
             orig = os.stat(password_file.name).st_mode
             os.chmod(password_file.name, stat.S_IWGRP | orig)
-            assert get_private_key(key_path=keyfile.name, password_path=password_file.name) is None
+            assert (
+                get_private_key(
+                    key_path=Path(keyfile.name), password_path=Path(password_file.name)
+                )
+                is None
+            )

--- a/raiden_contracts/tests/test_secret_registry.py
+++ b/raiden_contracts/tests/test_secret_registry.py
@@ -1,6 +1,8 @@
 from hashlib import sha256
+from typing import Callable
 
 import pytest
+from web3.contract import Contract
 from web3.exceptions import ValidationError
 
 from raiden_contracts.constants import CONTRACTS_VERSION, EVENT_SECRET_REVEALED
@@ -8,13 +10,13 @@ from raiden_contracts.tests.utils.mock import fake_bytes
 from raiden_contracts.utils.events import check_secret_revealed, check_secrets_revealed
 
 
-def test_version(secret_registry_contract):
+def test_version(secret_registry_contract: Contract) -> None:
     """ Test the return value of contract_version() """
     version = secret_registry_contract.functions.contract_version().call()
     assert version == CONTRACTS_VERSION
 
 
-def test_register_secret_call(secret_registry_contract):
+def test_register_secret_call(secret_registry_contract: Contract) -> None:
     """ Test the registrable and not registrable secrets """
     with pytest.raises(ValidationError):
         secret_registry_contract.functions.registerSecret()
@@ -33,7 +35,9 @@ def test_register_secret_call(secret_registry_contract):
     assert secret_registry_contract.functions.registerSecret(fake_bytes(32, "02")).call() is True
 
 
-def test_register_secret_return_value(secret_registry_contract, get_accounts):
+def test_register_secret_return_value(
+    secret_registry_contract: Contract, get_accounts: Callable
+) -> None:
     """ The same secret cannot be registered twice """
     (A, B) = get_accounts(2)
     secret = b"secretsecretsecretsecretsecretse"
@@ -49,7 +53,9 @@ def test_register_secret_return_value(secret_registry_contract, get_accounts):
     assert secret_registry_contract.functions.registerSecret(secret).call({"from": B}) is False
 
 
-def test_register_secret(secret_registry_contract, get_accounts, get_block):
+def test_register_secret(
+    secret_registry_contract: Contract, get_accounts: Callable, get_block: Callable
+) -> None:
     """ Register a secret and see it's registered """
     A = get_accounts(1)[0]
     secret = b"secretsecretsecretsecretsecretse"
@@ -70,7 +76,9 @@ def test_register_secret(secret_registry_contract, get_accounts, get_block):
     secret_registry_contract.functions.registerSecret(secret2).call_and_transact({"from": A})
 
 
-def test_register_secret_batch(secret_registry_contract, get_accounts, get_block):
+def test_register_secret_batch(
+    secret_registry_contract: Contract, get_accounts: Callable, get_block: Callable
+) -> None:
     """ Register four secrets and see them registered """
     (A,) = get_accounts(1)
     secrets = [fake_bytes(32, fill) for fill in ("02", "03", "04", "05")]
@@ -88,7 +96,9 @@ def test_register_secret_batch(secret_registry_contract, get_accounts, get_block
         assert secret_registry_contract.functions.getSecretRevealBlockHeight(h).call() == block
 
 
-def test_register_secret_batch_return_value(secret_registry_contract, get_accounts):
+def test_register_secret_batch_return_value(
+    secret_registry_contract: Contract, get_accounts: Callable
+) -> None:
     """ See registerSecret returns True only when all secrets are registered """
     (A,) = get_accounts(1)
     secrets = [fake_bytes(32, "02"), fake_bytes(32, "03"), fake_bytes(32)]
@@ -102,7 +112,7 @@ def test_register_secret_batch_return_value(secret_registry_contract, get_accoun
     assert secret_registry_contract.functions.registerSecretBatch(secrets).call() is False
 
 
-def test_events(secret_registry_contract, event_handler):
+def test_events(secret_registry_contract: Contract, event_handler: Callable) -> None:
     """ A successful registerSecret() call causes an EVENT_SECRET_REVEALED event """
     secret = b"secretsecretsecretsecretsecretse"
     secrethash = sha256(secret).digest()
@@ -114,7 +124,9 @@ def test_events(secret_registry_contract, event_handler):
     ev_handler.check()
 
 
-def test_register_secret_batch_events(secret_registry_contract, event_handler):
+def test_register_secret_batch_events(
+    secret_registry_contract: Contract, event_handler: Callable
+) -> None:
     """ A registerSecretBatch() with three secrets causes three EVENT_SECRET_REVEALED events """
     secrets = [fake_bytes(32, "02"), fake_bytes(32, "03"), fake_bytes(32, "04")]
     secret_hashes = [sha256(secret).digest() for secret in secrets]

--- a/raiden_contracts/tests/test_token.py
+++ b/raiden_contracts/tests/test_token.py
@@ -73,14 +73,18 @@ def test_token_transfer_funds(web3: Web3, custom_token: Contract, get_accounts: 
     assert web3.eth.getBalance(token.address) == 0
 
 
-def test_custom_token(custom_token: Contract, web3: Web3, contracts_manager: ContractManager):
+def test_custom_token(
+    custom_token: Contract, web3: Web3, contracts_manager: ContractManager
+) -> None:
     """ See custom_token.address contains the expected code """
     blockchain_bytecode = web3.eth.getCode(custom_token.address).hex()
     compiled_bytecode = contracts_manager.get_runtime_hexcode(CONTRACT_CUSTOM_TOKEN)
     assert blockchain_bytecode == compiled_bytecode
 
 
-def test_human_standard_token(human_standard_token, web3, contracts_manager):
+def test_human_standard_token(
+    human_standard_token: Contract, web3: Web3, contracts_manager: ContractManager
+) -> None:
     """ See human_standard_token.address contains the expected code """
     blockchain_bytecode = web3.eth.getCode(human_standard_token.address).hex()
     compiled_bytecode = contracts_manager.get_runtime_hexcode(CONTRACT_HUMAN_STANDARD_TOKEN)

--- a/raiden_contracts/tests/test_token_network.py
+++ b/raiden_contracts/tests/test_token_network.py
@@ -1,5 +1,6 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
+from web3.contract import Contract
 
 from raiden_contracts.constants import (
     CONTRACTS_VERSION,
@@ -433,8 +434,11 @@ def test_token_network_variables(token_network, token_network_test_utils):
 
 @pytest.mark.usefixtures("no_token_network")
 def test_constructor_not_registered(
-    custom_token, secret_registry_contract, token_network_registry_contract, token_network_external
-):
+    custom_token: Contract,
+    secret_registry_contract: Contract,
+    token_network_registry_contract: Contract,
+    token_network_external: Contract,
+) -> None:
     """ Check that the TokenNetwork refers to the right Token address and chain_id """
 
     token_network = token_network_external

--- a/raiden_contracts/tests/test_token_network_registry.py
+++ b/raiden_contracts/tests/test_token_network_registry.py
@@ -1,5 +1,6 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
+from web3.contract import Contract
 from web3.exceptions import ValidationError
 
 from raiden_contracts.constants import (
@@ -16,7 +17,7 @@ from raiden_contracts.tests.utils.constants import (
 from raiden_contracts.utils.events import check_token_network_created
 
 
-def test_version(token_network_registry_contract):
+def test_version(token_network_registry_contract: Contract) -> None:
     """ Check the result of contract_version() call on the TokenNetworkRegistry """
     version = token_network_registry_contract.functions.contract_version().call()
     assert version == CONTRACTS_VERSION
@@ -282,11 +283,11 @@ def test_create_erc20_token_network(
 
 @pytest.mark.usefixtures("no_token_network")
 def test_create_erc20_token_network_twice_fails(
-    token_network_registry_contract,
-    custom_token,
-    channel_participant_deposit_limit,
-    token_network_deposit_limit,
-):
+    token_network_registry_contract: Contract,
+    custom_token: Contract,
+    channel_participant_deposit_limit: int,
+    token_network_deposit_limit: int,
+) -> None:
     """ Only one TokenNetwork should be creatable from a TokenNetworkRegistry """
 
     token_network_registry_contract.functions.createERC20TokenNetwork(

--- a/raiden_contracts/tests/unit/test_files.py
+++ b/raiden_contracts/tests/unit/test_files.py
@@ -6,7 +6,7 @@ import pytest
 from raiden_contracts.contract_manager import _load_json_from_path
 
 
-def test_load_json_from_corrupt_file():
+def test_load_json_from_corrupt_file() -> None:
     with tempfile.NamedTemporaryFile() as f:
         f.write(b"not a JSON")
         with pytest.raises(ValueError):

--- a/raiden_contracts/tests/unit/test_web3_interaction.py
+++ b/raiden_contracts/tests/unit/test_web3_interaction.py
@@ -1,10 +1,12 @@
 import pytest
 from eth_typing.evm import HexAddress
+from web3 import Web3
+from web3.contract import Contract
 
 from raiden_contracts.utils.logs import LogFilter
 
 
-def test_logfilter_with_nonexistent_event(web3):
+def test_logfilter_with_nonexistent_event(web3: Web3) -> None:
     """ Try to create a LogFilter with a nonexistent event """
 
     with pytest.raises(ValueError):
@@ -18,7 +20,7 @@ def test_logfilter_with_nonexistent_event(web3):
         )
 
 
-def test_call_and_transact_does_not_mine(web3, custom_token):
+def test_call_and_transact_does_not_mine(web3: Web3, custom_token: Contract) -> None:
     """ See call_and_transact() does not mine a block """
 
     before = web3.eth.blockNumber

--- a/raiden_contracts/tests/utils/channel.py
+++ b/raiden_contracts/tests/utils/channel.py
@@ -48,7 +48,7 @@ class ChannelValues:
         self.locksroot = locksroot
         self.additional_hash = additional_hash
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"ChannelValues deposit:{self.deposit} withdrawn:{self.withdrawn} "
             f"transferred:{self.transferred} claimable_"

--- a/raiden_contracts/tests/utils/mock.py
+++ b/raiden_contracts/tests/utils/mock.py
@@ -2,13 +2,13 @@ import string
 from random import choice
 
 
-def fake_hex(size, fill="00"):
+def fake_hex(size: int, fill: str = "00") -> str:
     return "0x" + "".join([fill for i in range(0, size)])
 
 
-def fake_bytes(size, fill="00"):
+def fake_bytes(size: int, fill: str = "00") -> bytes:
     return bytes.fromhex(fake_hex(size, fill)[2:])
 
 
-def make_address():
+def make_address() -> bytes:
     return bytes("".join(choice(string.printable) for _ in range(20)), encoding="utf-8")

--- a/raiden_contracts/utils/mint_tokens.py
+++ b/raiden_contracts/utils/mint_tokens.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
+from pathlib import Path
+from typing import Optional
+
 import click
+from eth_typing import HexAddress
 from eth_utils import encode_hex
 from web3 import HTTPProvider, Web3
 from web3.middleware import construct_sign_and_send_raw_middleware
@@ -19,12 +23,12 @@ WEI_TO_ETH = 10 ** 18
 @click.option("--private-key", required=True, type=click.Path(exists=True, dir_okay=False))
 @click.option("--token-address", help="address of the token contract", required=True)
 @click.option("--amount", help="Amount of tokens to mint", required=True, type=click.INT)
-def main(rpc_url, private_key, token_address, amount):
+def main(rpc_url: str, private_key: Path, token_address: HexAddress, amount: int) -> None:
     web3 = Web3(HTTPProvider(rpc_url))
-    private_key = get_private_key(private_key)
-    assert private_key is not None
-    owner = private_key_to_address(private_key)
-    web3.middleware_stack.add(construct_sign_and_send_raw_middleware(private_key))
+    private_key_string: Optional[str] = get_private_key(private_key)
+    assert private_key_string is not None
+    owner = private_key_to_address(private_key_string)
+    web3.middleware_stack.add(construct_sign_and_send_raw_middleware(private_key_string))
     token_code = web3.eth.getCode(token_address, "latest")
     assert token_code != b""
     token_contract = ContractManager(contracts_precompiled_path()).get_contract(

--- a/raiden_contracts/utils/private_key.py
+++ b/raiden_contracts/utils/private_key.py
@@ -3,6 +3,8 @@ import json
 import logging
 import os
 import stat
+from pathlib import Path
+from typing import Optional
 
 from eth_keyfile import decode_keyfile_json
 from eth_utils import decode_hex, encode_hex, is_hex
@@ -14,7 +16,7 @@ log = logging.getLogger(__name__)
 # during the deprecation of raiden-lib.
 
 
-def check_permission_safety(path):
+def check_permission_safety(path: Path) -> bool:
     """Check if the file at the given path is safe to use as a state file.
 
     This checks that group and others have no permissions on the file and that the current user is
@@ -24,7 +26,7 @@ def check_permission_safety(path):
     return (f_stats.st_mode & (stat.S_IRWXG | stat.S_IRWXO)) == 0 and f_stats.st_uid == os.getuid()
 
 
-def get_private_key(key_path, password_path=None):
+def get_private_key(key_path: Path, password_path: Optional[Path] = None) -> Optional[str]:
     """Open a JSON-encoded private key and return it
 
     If a password file is provided, uses it to decrypt the key. If not, the

--- a/raiden_contracts/utils/proofs.py
+++ b/raiden_contracts/utils/proofs.py
@@ -7,7 +7,7 @@ from raiden_contracts.constants import MessageTypeId
 from .signature import sign
 
 
-def hash_balance_data(transferred_amount, locked_amount, locksroot):
+def hash_balance_data(transferred_amount: int, locked_amount: int, locksroot: bytes) -> bytes:
     # pylint: disable=E1120
     return Web3.soliditySha3(
         abi_types=["uint256", "uint256", "bytes32"],
@@ -86,8 +86,12 @@ def hash_cooperative_settle_message(
 
 
 def hash_withdraw_message(
-    token_network_address, chain_identifier, channel_identifier, participant, amount_to_withdraw
-):
+    token_network_address: HexAddress,
+    chain_identifier: int,
+    channel_identifier: int,
+    participant: HexAddress,
+    amount_to_withdraw: int,
+) -> bytes:
     return eth_sign_hash_message(
         Web3.toBytes(hexstr=token_network_address)
         + encode_single("uint256", chain_identifier)
@@ -115,15 +119,15 @@ def hash_reward_proof(
 
 
 def sign_balance_proof(
-    privatekey,
-    token_network_address,
-    chain_identifier,
-    channel_identifier,
-    balance_hash,
-    nonce,
-    additional_hash,
-    v=27,
-):
+    privatekey: str,
+    token_network_address: HexAddress,
+    chain_identifier: int,
+    channel_identifier: int,
+    balance_hash: bytes,
+    nonce: int,
+    additional_hash: bytes,
+    v: int = 27,
+) -> bytes:
     message_hash = hash_balance_proof(
         token_network_address=token_network_address,
         chain_identifier=chain_identifier,
@@ -146,7 +150,7 @@ def sign_balance_proof_update_message(
     additional_hash: bytes,
     closing_signature: bytes,
     v: int = 27,
-):
+) -> bytes:
     message_hash = hash_balance_proof_update_message(
         token_network_address=token_network_address,
         chain_identifier=chain_identifier,
@@ -161,16 +165,16 @@ def sign_balance_proof_update_message(
 
 
 def sign_cooperative_settle_message(
-    privatekey,
-    token_network_address,
-    chain_identifier,
-    channel_identifier,
-    participant1_address,
-    participant1_balance,
-    participant2_address,
-    participant2_balance,
-    v=27,
-):
+    privatekey: str,
+    token_network_address: HexAddress,
+    chain_identifier: int,
+    channel_identifier: int,
+    participant1_address: HexAddress,
+    participant1_balance: HexAddress,
+    participant2_address: HexAddress,
+    participant2_balance: HexAddress,
+    v: int = 27,
+) -> bytes:
     message_hash = hash_cooperative_settle_message(
         token_network_address=token_network_address,
         chain_identifier=chain_identifier,
@@ -185,14 +189,14 @@ def sign_cooperative_settle_message(
 
 
 def sign_withdraw_message(
-    privatekey,
-    token_network_address,
-    chain_identifier,
-    channel_identifier,
-    participant,
-    amount_to_withdraw,
-    v=27,
-):
+    privatekey: str,
+    token_network_address: HexAddress,
+    chain_identifier: int,
+    channel_identifier: int,
+    participant: HexAddress,
+    amount_to_withdraw: int,
+    v: int = 27,
+) -> bytes:
     message_hash = hash_withdraw_message(
         token_network_address=token_network_address,
         chain_identifier=chain_identifier,
@@ -205,8 +209,14 @@ def sign_withdraw_message(
 
 
 def sign_reward_proof(
-    privatekey, channel_identifier, reward_amount, token_network_address, chain_id, nonce, v=27
-):
+    privatekey: str,
+    channel_identifier: int,
+    reward_amount: int,
+    token_network_address: HexAddress,
+    chain_id: int,
+    nonce: int,
+    v: int = 27,
+) -> bytes:
     message_hash = hash_reward_proof(
         channel_identifier=channel_identifier,
         reward_amount=reward_amount,
@@ -227,7 +237,7 @@ def sign_one_to_n_iou(
     one_to_n_address: str,
     chain_id: int,
     v: int = 27,
-):
+) -> bytes:
     iou_hash = eth_sign_hash_message(
         Web3.toBytes(hexstr=sender)
         + Web3.toBytes(hexstr=receiver)


### PR DESCRIPTION
because we have been so lazy to annotate types.

This PR introduces a lot of type annotations together with a few interesting changes.

* A new TypedDict `CompiledContract` is introduced.  Previously, a single type `DeployedContract` was used for two completely different kinds of dictionaries.
* A single function with a boolean parameter was duplicated into two.  Depending on the boolean, the function's type signature changed. `contract_manager_meta(_, True)` is now `contract_source_manager_meta(_)`; `contract_manager_meta(_, False)` is now `contract_manager_meta(_)`.