### PR TITLE
More type annotations and a small fix

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -6,7 +6,7 @@ import json
 import logging
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import click
 from click import BadParameter, Context, Option, Parameter
@@ -37,12 +37,12 @@ def validate_address(
         raise click.BadParameter("must be a valid ethereum address")
 
 
-def error_removed_option(message: str):
+def error_removed_option(message: str) -> Callable:
     """ Takes a message and returns a callback that raises NoSuchOption
 
     if the value is not None. The message is used as an argument to NoSuchOption. """
 
-    def f(_, param: Parameter, value: Optional[Any]):
+    def f(_: Any, param: Parameter, value: Any) -> None:
         if value is not None:
             raise click.NoSuchOption(
                 f'--{param.name.replace("_", "-")} is no longer a valid option. ' + message
@@ -51,7 +51,7 @@ def error_removed_option(message: str):
     return f
 
 
-def common_options(func):
+def common_options(func: Callable) -> Callable:
     """A decorator that combines commonly appearing @click.option decorators."""
 
     @click.option("--private-key", required=True, help="Path to a private key store.")
@@ -69,7 +69,7 @@ def common_options(func):
         help="Contracts version to verify. Current version will be used by default.",
     )
     @functools.wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: List, **kwargs: Dict) -> Any:
         return func(*args, **kwargs)
 
     return wrapper
@@ -84,7 +84,7 @@ def setup_ctx(
     gas_price: int,
     gas_limit: int,
     contracts_version: Optional[str] = None,
-):
+) -> None:
     """Set up deployment context according to common options (shared among all
     subcommands).
     """
@@ -255,17 +255,17 @@ def services(
 @click.option("--token-symbol", default="TKN", help="Token contract symbol.")
 @click.pass_context
 def token(
-    ctx,
-    private_key,
-    rpc_provider,
-    wait,
-    gas_price,
-    gas_limit,
-    contracts_version,
-    token_supply,
-    token_name,
-    token_decimals,
-    token_symbol,
+    ctx: click.Context,
+    private_key: Optional[str],
+    rpc_provider: str,
+    wait: int,
+    gas_price: int,
+    gas_limit: int,
+    contracts_version: Optional[str],
+    token_supply: int,
+    token_name: str,
+    token_decimals: int,
+    token_symbol: str,
 ):
     setup_ctx(ctx, private_key, rpc_provider, wait, gas_price, gas_limit, contracts_version)
     deployer = ctx.obj["deployer"]

--- a/raiden_contracts/tests/fixtures/base/web3_fixtures.py
+++ b/raiden_contracts/tests/fixtures/base/web3_fixtures.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session")
-def ethereum_tester(patch_genesis_gas_limit):  # pylint: disable=W0613
+def ethereum_tester(patch_genesis_gas_limit) -> EthereumTester:  # pylint: disable=W0613
     """Returns an instance of an Ethereum tester"""
     return EthereumTester(PyEVMBackend())
 

--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -1,7 +1,8 @@
-from typing import Callable
+from typing import Any, Callable, Collection, List
 
 import pytest
 from eth_utils import is_address
+from web3 import Web3
 from web3.contract import Contract, get_event_data
 
 from raiden_contracts.constants import (
@@ -17,14 +18,16 @@ from raiden_contracts.utils.transaction import check_successful_tx
 
 @pytest.fixture()
 def get_token_network_registry(deploy_tester_contract: Contract) -> Callable:
-    def get(arguments):
+    def get(arguments: Collection[Any]) -> Contract:
         return deploy_tester_contract(CONTRACT_TOKEN_NETWORK_REGISTRY, arguments)
 
     return get
 
 
 @pytest.fixture(scope="session")
-def token_network_registry_constructor_args(web3, secret_registry_contract):
+def token_network_registry_constructor_args(
+    web3: Web3, secret_registry_contract: Contract
+) -> List:
     return [
         secret_registry_contract.address,
         int(web3.version.network),

--- a/raiden_contracts/tests/test_channel_cooperative_settle.py
+++ b/raiden_contracts/tests/test_channel_cooperative_settle.py
@@ -1,5 +1,8 @@
+from typing import Callable
+
 import pytest
 from eth_tester.exceptions import TransactionFailed
+from web3.contract import Contract
 from web3.exceptions import ValidationError
 
 from raiden_contracts.constants import ChannelEvent
@@ -9,8 +12,11 @@ from raiden_contracts.utils.events import check_channel_settled
 
 @pytest.mark.skip(reason="Delayed until another milestone")
 def test_cooperative_settle_channel_call(
-    token_network, create_channel_and_deposit, get_accounts, create_cooperative_settle_signatures
-):
+    token_network: Contract,
+    create_channel_and_deposit: Callable,
+    get_accounts: Callable,
+    create_cooperative_settle_signatures: Callable,
+) -> None:
     (A, B, C) = get_accounts(3)
     deposit_A = 20
     deposit_B = 10
@@ -64,8 +70,11 @@ def test_cooperative_settle_channel_call(
 
 @pytest.mark.skip(reason="Delayed until another milestone")
 def test_cooperative_settle_channel_signatures(
-    token_network, create_channel_and_deposit, get_accounts, create_cooperative_settle_signatures
-):
+    token_network: Contract,
+    create_channel_and_deposit: Callable,
+    get_accounts: Callable,
+    create_cooperative_settle_signatures: Callable,
+) -> None:
     (A, B, C) = get_accounts(3)
     deposit_A = 20
     deposit_B = 10
@@ -98,13 +107,13 @@ def test_cooperative_settle_channel_signatures(
 
 @pytest.mark.skip(reason="Delayed until another milestone")
 def test_cooperative_settle_channel_0(
-    custom_token,
-    token_network,
-    create_channel_and_deposit,
-    get_accounts,
-    create_cooperative_settle_signatures,
-    cooperative_settle_state_tests,
-):
+    custom_token: Contract,
+    token_network: Contract,
+    create_channel_and_deposit: Callable,
+    get_accounts: Callable,
+    create_cooperative_settle_signatures: Callable,
+    cooperative_settle_state_tests: Callable,
+) -> None:
     (A, B, C) = get_accounts(3)
     deposit_A = 20
     deposit_B = 10
@@ -139,13 +148,13 @@ def test_cooperative_settle_channel_0(
 
 @pytest.mark.skip(reason="Delayed until another milestone")
 def test_cooperative_settle_channel_00(
-    custom_token,
-    token_network,
-    create_channel_and_deposit,
-    get_accounts,
-    create_cooperative_settle_signatures,
-    cooperative_settle_state_tests,
-):
+    custom_token: Contract,
+    token_network: Contract,
+    create_channel_and_deposit: Callable,
+    get_accounts: Callable,
+    create_cooperative_settle_signatures: Callable,
+    cooperative_settle_state_tests: Callable,
+) -> None:
     (A, B, C) = get_accounts(3)
     deposit_A = 0
     deposit_B = 0
@@ -180,13 +189,13 @@ def test_cooperative_settle_channel_00(
 
 @pytest.mark.skip(reason="Delayed until another milestone")
 def test_cooperative_settle_channel_state(
-    custom_token,
-    token_network,
-    create_channel_and_deposit,
-    get_accounts,
-    create_cooperative_settle_signatures,
-    cooperative_settle_state_tests,
-):
+    custom_token: Contract,
+    token_network: Contract,
+    create_channel_and_deposit: Callable,
+    get_accounts: Callable,
+    create_cooperative_settle_signatures: Callable,
+    cooperative_settle_state_tests: Callable,
+) -> None:
     (A, B, C) = get_accounts(3)
     deposit_A = 20
     deposit_B = 10
@@ -222,14 +231,14 @@ def test_cooperative_settle_channel_state(
 
 @pytest.mark.skip(reason="Delayed until another milestone")
 def test_cooperative_settle_channel_state_withdraw(
-    custom_token,
-    token_network,
-    create_channel_and_deposit,
-    withdraw_channel,
-    get_accounts,
-    create_cooperative_settle_signatures,
-    cooperative_settle_state_tests,
-):
+    custom_token: Contract,
+    token_network: Contract,
+    create_channel_and_deposit: Callable,
+    withdraw_channel: Callable,
+    get_accounts: Callable,
+    create_cooperative_settle_signatures: Callable,
+    cooperative_settle_state_tests: Callable,
+) -> None:
     (A, B, C) = get_accounts(3)
     deposit_A = 20
     deposit_B = 10
@@ -269,12 +278,12 @@ def test_cooperative_settle_channel_state_withdraw(
 
 @pytest.mark.skip(reason="Delayed until another milestone")
 def test_cooperative_settle_channel_bigger_withdraw(
-    token_network,
-    create_channel_and_deposit,
-    withdraw_channel,
-    get_accounts,
-    create_cooperative_settle_signatures,
-):
+    token_network: Contract,
+    create_channel_and_deposit: Callable,
+    withdraw_channel: Callable,
+    get_accounts: Callable,
+    create_cooperative_settle_signatures: Callable,
+) -> None:
     (A, B, C) = get_accounts(3)
     deposit_A = 20
     deposit_B = 10
@@ -300,8 +309,11 @@ def test_cooperative_settle_channel_bigger_withdraw(
 
 @pytest.mark.skip(reason="Delayed until another milestone")
 def test_cooperative_settle_channel_wrong_balances(
-    token_network, create_channel_and_deposit, get_accounts, create_cooperative_settle_signatures
-):
+    token_network: Contract,
+    create_channel_and_deposit: Callable,
+    get_accounts: Callable,
+    create_cooperative_settle_signatures: Callable,
+) -> None:
     (A, B, C) = get_accounts(3)
     deposit_A = 20
     deposit_B = 10
@@ -353,12 +365,12 @@ def test_cooperative_settle_channel_wrong_balances(
 
 @pytest.mark.skip(reason="Delayed until another milestone")
 def test_cooperative_close_replay_reopened_channel(
-    get_accounts,
-    token_network,
-    create_channel,
-    channel_deposit,
-    create_cooperative_settle_signatures,
-):
+    get_accounts: Callable,
+    token_network: Contract,
+    create_channel: Callable,
+    channel_deposit: Callable,
+    create_cooperative_settle_signatures: Callable,
+) -> None:
     (A, B) = get_accounts(2)
     deposit_A = 15
     deposit_B = 10
@@ -399,13 +411,13 @@ def test_cooperative_close_replay_reopened_channel(
 
 @pytest.mark.skip(reason="Delayed until another milestone")
 def test_cooperative_settle_channel_event(
-    get_accounts,
-    token_network,
-    create_channel,
-    channel_deposit,
-    create_cooperative_settle_signatures,
-    event_handler,
-):
+    get_accounts: Callable,
+    token_network: Contract,
+    create_channel: Callable,
+    channel_deposit: Callable,
+    create_cooperative_settle_signatures: Callable,
+    event_handler: Callable,
+) -> None:
     ev_handler = event_handler(token_network)
     (A, B) = get_accounts(2)
     deposit_A = 10

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -759,7 +759,7 @@ def test_channel_unlock_unregistered_locks(
         ChannelValues(deposit=40, withdrawn=10, transferred=20),
     )
 
-    vals_A.locksroot = "0x" + get_merkle_root(pending_transfers_tree.merkle_tree).hex()
+    vals_A.locksroot = get_merkle_root(pending_transfers_tree.merkle_tree)
     vals_B.locksroot = fake_bytes(32, "03")
     channel_identifier = create_channel_and_deposit(A, B, vals_A.deposit, vals_B.deposit)
     withdraw_channel(channel_identifier, A, vals_A.withdrawn, B)

--- a/raiden_contracts/tests/test_token_network.py
+++ b/raiden_contracts/tests/test_token_network.py
@@ -1,5 +1,8 @@
+from typing import Callable
+
 import pytest
 from eth_tester.exceptions import TransactionFailed
+from web3 import Web3
 from web3.contract import Contract
 
 from raiden_contracts.constants import (
@@ -10,20 +13,20 @@ from raiden_contracts.constants import (
 from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS, FAKE_ADDRESS, MAX_UINT256
 
 
-def test_version(token_network):
+def test_version(token_network: Contract) -> None:
     """ Check the output of contract_version() of the TokenNetwork contract """
     assert token_network.functions.contract_version().call() == CONTRACTS_VERSION
 
 
 def test_constructor_call(
-    web3,
-    get_token_network,
-    custom_token,
-    secret_registry_contract,
-    get_accounts,
-    channel_participant_deposit_limit,
-    token_network_deposit_limit,
-):
+    web3: Web3,
+    get_token_network: Contract,
+    custom_token: Contract,
+    secret_registry_contract: Contract,
+    get_accounts: Callable,
+    channel_participant_deposit_limit: int,
+    token_network_deposit_limit: int,
+) -> None:
     """ Try to deploy TokenNetwork with various wrong arguments """
 
     (A, deprecation_executor) = get_accounts(2)
@@ -421,7 +424,9 @@ def test_constructor_call(
     )
 
 
-def test_token_network_variables(token_network, token_network_test_utils):
+def test_token_network_variables(
+    token_network: Contract, token_network_test_utils: Contract
+) -> None:
     """ Check values of storage variables of the TokenNetwork contract """
     max_safe_uint256 = token_network_test_utils.functions.get_max_safe_uint256().call()
 

--- a/raiden_contracts/tests/test_token_network_registry.py
+++ b/raiden_contracts/tests/test_token_network_registry.py
@@ -1,5 +1,8 @@
+from typing import Callable
+
 import pytest
 from eth_tester.exceptions import TransactionFailed
+from web3 import Web3
 from web3.contract import Contract
 from web3.exceptions import ValidationError
 
@@ -25,8 +28,11 @@ def test_version(token_network_registry_contract: Contract) -> None:
 
 @pytest.mark.usefixtures("no_token_network")
 def test_constructor_call(
-    web3, get_token_network_registry, secret_registry_contract, get_accounts
-):
+    web3: Web3,
+    get_token_network_registry: Contract,
+    secret_registry_contract: Contract,
+    get_accounts: Callable,
+) -> None:
     """ Try to create a TokenNetworkRegistry with various wrong arguments. """
     A = get_accounts(1)[0]
     chain_id = int(web3.version.network)
@@ -141,7 +147,9 @@ def test_constructor_call(
 
 
 @pytest.mark.usefixtures("no_token_network")
-def test_constructor_call_state(web3, get_token_network_registry, secret_registry_contract):
+def test_constructor_call_state(
+    web3: Web3, get_token_network_registry: Contract, secret_registry_contract: Contract
+) -> None:
     """ The constructor should set the parameters into the storage of the contract """
 
     chain_id = int(web3.version.network)
@@ -164,12 +172,12 @@ def test_constructor_call_state(web3, get_token_network_registry, secret_registr
 
 @pytest.mark.usefixtures("no_token_network")
 def test_create_erc20_token_network_call(
-    token_network_registry_contract,
-    custom_token,
-    get_accounts,
-    channel_participant_deposit_limit,
-    token_network_deposit_limit,
-):
+    token_network_registry_contract: Contract,
+    custom_token: Contract,
+    get_accounts: Callable,
+    channel_participant_deposit_limit: int,
+    token_network_deposit_limit: int,
+) -> None:
     """ Calling createERC20TokenNetwork() with various wrong arguments """
 
     A = get_accounts(1)[0]
@@ -239,12 +247,12 @@ def test_create_erc20_token_network_call(
 
 @pytest.mark.usefixtures("no_token_network")
 def test_create_erc20_token_network(
-    register_token_network,
-    token_network_registry_contract,
-    custom_token,
-    channel_participant_deposit_limit,
-    token_network_deposit_limit,
-):
+    register_token_network: Contract,
+    token_network_registry_contract: Contract,
+    custom_token: Contract,
+    channel_participant_deposit_limit: int,
+    token_network_deposit_limit: int,
+) -> None:
     """ Create a TokenNetwork through a TokenNetworkRegistry """
 
     assert (
@@ -302,13 +310,13 @@ def test_create_erc20_token_network_twice_fails(
 
 @pytest.mark.usefixtures("no_token_network")
 def test_events(
-    register_token_network,
-    token_network_registry_contract,
-    custom_token,
-    event_handler,
-    channel_participant_deposit_limit,
-    token_network_deposit_limit,
-):
+    register_token_network: Contract,
+    token_network_registry_contract: Contract,
+    custom_token: Contract,
+    event_handler: Callable,
+    channel_participant_deposit_limit: int,
+    token_network_deposit_limit: int,
+) -> None:
     """ TokenNetwokRegistry should raise an event when deploying a new TokenNetwork """
 
     ev_handler = event_handler(token_network_registry_contract)

--- a/raiden_contracts/tests/utils/contracts.py
+++ b/raiden_contracts/tests/utils/contracts.py
@@ -1,12 +1,19 @@
+from typing import List, Optional
+
+from coincurve import PrivateKey
+from eth_tester import EthereumTester
+from eth_typing.evm import HexAddress
 from web3 import Web3
+from web3.contract import Contract
 from web3.providers.eth_tester import EthereumTesterProvider
 
 from raiden_contracts.constants import CONTRACT_CUSTOM_TOKEN, CONTRACT_TOKEN_NETWORK
+from raiden_contracts.contract_manager import ContractManager
 from raiden_contracts.tests.utils.constants import FAUCET_ALLOWANCE
 from raiden_contracts.utils.signature import private_key_to_address
 
 
-def get_web3(eth_tester, deployer_key):
+def get_web3(eth_tester: EthereumTester, deployer_key: PrivateKey) -> Web3:
     """Returns an initialized Web3 instance"""
     provider = EthereumTesterProvider(eth_tester)
     web3 = Web3(provider)
@@ -27,7 +34,13 @@ def get_web3(eth_tester, deployer_key):
     return web3
 
 
-def deploy_contract(web3, contracts_manager, contract_name, deployer_key, args=None):
+def deploy_contract(
+    web3: Web3,
+    contracts_manager: ContractManager,
+    contract_name: str,
+    deployer_key: PrivateKey,
+    args: Optional[List] = None,
+) -> Contract:
     deployer_address = private_key_to_address(deployer_key.to_hex())
     json_contract = contracts_manager.get_contract(contract_name)
     contract = web3.eth.contract(abi=json_contract["abi"], bytecode=json_contract["bin"])
@@ -37,13 +50,21 @@ def deploy_contract(web3, contracts_manager, contract_name, deployer_key, args=N
     return contract(contract_address)
 
 
-def deploy_custom_token(web3, deployer_key):
+def deploy_custom_token(
+    web3: Web3, deployer_key: PrivateKey, contract_manager: ContractManager
+) -> Contract:
     return deploy_contract(
-        web3, CONTRACT_CUSTOM_TOKEN, deployer_key, [], (10 ** 26, 18, CONTRACT_CUSTOM_TOKEN, "TKN")
+        web3=web3,
+        contracts_manager=contract_manager,
+        contract_name=CONTRACT_CUSTOM_TOKEN,
+        deployer_key=deployer_key,
+        args=[10 ** 26, 18, CONTRACT_CUSTOM_TOKEN, "TKN"],
     )
 
 
-def get_token_network(web3, address, contracts_manager):
+def get_token_network(
+    web3: Web3, address: HexAddress, contracts_manager: ContractManager
+) -> Contract:
     json_contract = contracts_manager.get_contract(CONTRACT_TOKEN_NETWORK)
 
     return web3.eth.contract(abi=json_contract["abi"], address=address)

--- a/raiden_contracts/utils/proofs.py
+++ b/raiden_contracts/utils/proofs.py
@@ -170,9 +170,9 @@ def sign_cooperative_settle_message(
     chain_identifier: int,
     channel_identifier: int,
     participant1_address: HexAddress,
-    participant1_balance: HexAddress,
+    participant1_balance: int,
     participant2_address: HexAddress,
-    participant2_balance: HexAddress,
+    participant2_balance: int,
     v: int = 27,
 ) -> bytes:
     message_hash = hash_cooperative_settle_message(


### PR DESCRIPTION
This commit is mostly type annotations.  There is one change that affects the runtime behavior.  Somehow `bytes` were converted into `str` when there was no need to.

This is a part of #918.