### PR TITLE
Separate get_pending_transfers_tree() into two

### DIFF
--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -17,7 +17,7 @@ from raiden_contracts.tests.utils import (
     get_onchain_settlement_amounts,
     get_settlement_amounts,
 )
-from raiden_contracts.utils import get_pending_transfers_tree
+from raiden_contracts.utils import get_pending_transfers_tree_with_generated_lists
 from raiden_contracts.utils.events import check_channel_settled
 
 
@@ -83,12 +83,12 @@ def test_settle_channel_state(
         locked_amounts=LockedAmounts(claimable_locked=2, unclaimable_locked=3),
     )
 
-    pending_transfers_tree_A = get_pending_transfers_tree(
+    pending_transfers_tree_A = get_pending_transfers_tree_with_generated_lists(
         web3,
         unlockable_amount=vals_A.locked_amounts.claimable_locked,
         expired_amount=vals_A.locked_amounts.unclaimable_locked,
     )
-    pending_transfers_tree_B = get_pending_transfers_tree(
+    pending_transfers_tree_B = get_pending_transfers_tree_with_generated_lists(
         web3,
         unlockable_amount=vals_B.locked_amounts.claimable_locked,
         expired_amount=vals_B.locked_amounts.unclaimable_locked,
@@ -408,7 +408,7 @@ def test_settle_wrong_balance_hash(
     channel_identifier = create_channel_and_deposit(A, B, vals_A.deposit, vals_B.deposit)
 
     # Mock pending transfers data for A -> B
-    pending_transfers_tree_A = get_pending_transfers_tree(
+    pending_transfers_tree_A = get_pending_transfers_tree_with_generated_lists(
         web3,
         unlockable_amount=vals_A.locked_amounts.claimable_locked,
         expired_amount=vals_A.locked_amounts.unclaimable_locked,
@@ -418,7 +418,7 @@ def test_settle_wrong_balance_hash(
     reveal_secrets(A, pending_transfers_tree_A.unlockable)
 
     # Mock pending transfers data for B -> A
-    pending_transfers_tree_B = get_pending_transfers_tree(
+    pending_transfers_tree_B = get_pending_transfers_tree_with_generated_lists(
         web3,
         unlockable_amount=vals_B.locked_amounts.claimable_locked,
         expired_amount=vals_B.locked_amounts.unclaimable_locked,

--- a/raiden_contracts/tests/test_channel_settle_unlock_state.py
+++ b/raiden_contracts/tests/test_channel_settle_unlock_state.py
@@ -18,7 +18,7 @@ from raiden_contracts.tests.utils import (
     is_balance_proof_old,
     were_balance_proofs_valid,
 )
-from raiden_contracts.utils import get_pending_transfers_tree
+from raiden_contracts.utils import get_pending_transfers_tree_with_generated_lists
 
 
 @pytest.fixture()
@@ -48,7 +48,7 @@ def test_settlement_outcome(
         # are revealed before their expiration.
 
         # Mock pending transfers data for A -> B
-        pending_transfers_tree_A = get_pending_transfers_tree(
+        pending_transfers_tree_A = get_pending_transfers_tree_with_generated_lists(
             web3,
             unlockable_amount=vals_A.locked_amounts.claimable_locked,
             expired_amount=vals_A.locked_amounts.unclaimable_locked,
@@ -58,7 +58,7 @@ def test_settlement_outcome(
         reveal_secrets(A, pending_transfers_tree_A.unlockable)
 
         # Mock pending transfers data for B -> A
-        pending_transfers_tree_B = get_pending_transfers_tree(
+        pending_transfers_tree_B = get_pending_transfers_tree_with_generated_lists(
             web3,
             unlockable_amount=vals_B.locked_amounts.claimable_locked,
             expired_amount=vals_B.locked_amounts.unclaimable_locked,
@@ -352,8 +352,8 @@ def test_channel_settle_invalid_balance_proof_values(
     # are revealed before their expiration.
 
     # Mock pending transfers data for A -> B
-    pending_transfers_tree_A = get_pending_transfers_tree(
-        web3,
+    pending_transfers_tree_A = get_pending_transfers_tree_with_generated_lists(
+        web3=web3,
         unlockable_amount=vals_A.locked_amounts.claimable_locked,
         expired_amount=vals_A.locked_amounts.unclaimable_locked,
     )
@@ -362,7 +362,7 @@ def test_channel_settle_invalid_balance_proof_values(
     reveal_secrets(A, pending_transfers_tree_A.unlockable)
 
     # Mock pending transfers data for B -> A
-    pending_transfers_tree_B = get_pending_transfers_tree(
+    pending_transfers_tree_B = get_pending_transfers_tree_with_generated_lists(
         web3,
         unlockable_amount=vals_B.locked_amounts.claimable_locked,
         expired_amount=vals_B.locked_amounts.unclaimable_locked,

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -39,7 +39,9 @@ def test_merkle_root_1_item_unlockable(
 ):
     """ Test getMerkleRootAndUnlockedAmount() on a single item whose secret has been registered """
     A = get_accounts(1)[0]
-    pending_transfers_tree = get_pending_transfers_tree(web3, [6])
+    pending_transfers_tree = get_pending_transfers_tree(
+        web3=web3, unlockable_amounts=[6], expired_amounts=[]
+    )
 
     secret_registry_contract.functions.registerSecret(
         pending_transfers_tree.unlockable[0][TestLockIndex.SECRET]

--- a/raiden_contracts/tests/test_deprecation_switch.py
+++ b/raiden_contracts/tests/test_deprecation_switch.py
@@ -11,7 +11,9 @@ from raiden_contracts.constants import (
 )
 from raiden_contracts.tests.fixtures.channel import call_settle
 from raiden_contracts.tests.utils import ChannelValues, LockedAmounts
-from raiden_contracts.utils.pending_transfers import get_pending_transfers_tree
+from raiden_contracts.utils.pending_transfers import (
+    get_pending_transfers_tree_with_generated_lists,
+)
 
 
 def test_deprecation_executor(
@@ -167,7 +169,7 @@ def test_deprecation_switch_settle(
     channel_deposit(channel_identifier, B, vals_B.deposit, A)
 
     # Mock pending transfers data for A -> B
-    pending_transfers_tree_A = get_pending_transfers_tree(
+    pending_transfers_tree_A = get_pending_transfers_tree_with_generated_lists(
         web3,
         unlockable_amount=vals_A.locked_amounts.claimable_locked,
         expired_amount=vals_A.locked_amounts.unclaimable_locked,
@@ -177,7 +179,7 @@ def test_deprecation_switch_settle(
     reveal_secrets(A, pending_transfers_tree_A.unlockable)
 
     # Mock pending transfers data for B -> A
-    pending_transfers_tree_B = get_pending_transfers_tree(
+    pending_transfers_tree_B = get_pending_transfers_tree_with_generated_lists(
         web3,
         unlockable_amount=vals_B.locked_amounts.claimable_locked,
         expired_amount=vals_B.locked_amounts.unclaimable_locked,

--- a/raiden_contracts/utils/pending_transfers.py
+++ b/raiden_contracts/utils/pending_transfers.py
@@ -25,24 +25,29 @@ PendingTransfersTree = namedtuple(
 )
 
 
-def get_pending_transfers_tree(
+def get_pending_transfers_tree_with_generated_lists(
     web3: Web3,
-    unlockable_amounts: Optional[Collection[int]] = None,
-    expired_amounts: Optional[Iterable] = None,
+    unlockable_amount: int,
+    expired_amount: int,
     min_expiration_delta: Optional[int] = None,
     max_expiration_delta: Optional[int] = None,
-    unlockable_amount: Optional[int] = None,
-    expired_amount: Optional[int] = None,
 ) -> PendingTransfersTree:
-    if isinstance(unlockable_amount, int):
-        unlockable_amounts = get_random_values_for_sum(unlockable_amount)
-    elif unlockable_amounts is None:
-        unlockable_amounts = []
-    if isinstance(expired_amount, int):
-        expired_amounts = get_random_values_for_sum(expired_amount)
-    elif expired_amounts is None:
-        expired_amounts = []
+    return get_pending_transfers_tree(
+        web3=web3,
+        unlockable_amounts=get_random_values_for_sum(unlockable_amount),
+        expired_amounts=get_random_values_for_sum(expired_amount),
+        min_expiration_delta=min_expiration_delta,
+        max_expiration_delta=max_expiration_delta,
+    )
 
+
+def get_pending_transfers_tree(
+    web3: Web3,
+    unlockable_amounts: Collection[int],
+    expired_amounts: Collection[int],
+    min_expiration_delta: Optional[int] = None,
+    max_expiration_delta: Optional[int] = None,
+) -> PendingTransfersTree:
     types = ["uint256", "uint256", "bytes32"]
     packed_transfers = b""
     (unlockable_locks, expired_locks) = get_pending_transfers(


### PR DESCRIPTION
because the function had many optional arguments and had
essentially two separate usage patterns.

This fixes #1002.