### PR TITLE
Move a small function to util/versions.py

### DIFF
--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -7,9 +7,9 @@ from typing import Any, Dict, List, Optional
 
 from eth_typing.evm import HexAddress
 from mypy_extensions import TypedDict
-from semver import compare
 
 from raiden_contracts.constants import CONTRACTS_VERSION, ID_TO_NETWORKNAME, DeploymentModule
+from raiden_contracts.utils.versions import contracts_version_provides_services
 
 _BASE = Path(__file__).parent
 
@@ -188,16 +188,6 @@ def merge_deployment_data(dict1: DeployedContracts, dict2: DeployedContracts) ->
     }
 
 
-def version_provides_services(version: Optional[str]) -> bool:
-    if version is None:
-        return True
-    if version == "0.3._":
-        return False
-    if version == "0.8.0_unlimited":
-        return True
-    return compare(version, "0.8.0") >= 0
-
-
 def get_contracts_deployment_info(
     chain_id: int, version: Optional[str] = None, module: DeploymentModule = DeploymentModule.ALL
 ) -> Optional[DeployedContracts]:
@@ -218,13 +208,13 @@ def get_contracts_deployment_info(
     if module_chosen(DeploymentModule.RAIDEN):
         files.append(contracts_deployed_path(chain_id=chain_id, version=version, services=False))
 
-    if module == DeploymentModule.SERVICES and not version_provides_services(version):
+    if module == DeploymentModule.SERVICES and not contracts_version_provides_services(version):
         raise ValueError(
             f"SERVICES module queried for version {version}, but {version} "
             "does not provide service contracts."
         )
 
-    if module_chosen(DeploymentModule.SERVICES) and version_provides_services(version):
+    if module_chosen(DeploymentModule.SERVICES) and contracts_version_provides_services(version):
         files.append(contracts_deployed_path(chain_id=chain_id, version=version, services=True))
 
     deployment_data: DeployedContracts = {}  # type: ignore

--- a/raiden_contracts/tests/test_deploy_data.py
+++ b/raiden_contracts/tests/test_deploy_data.py
@@ -13,7 +13,10 @@ from raiden_contracts.contract_manager import (
 )
 from raiden_contracts.deploy.contract_verifier import ContractVerifier
 from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS
-from raiden_contracts.utils.versions import contracts_version_provides_services
+from raiden_contracts.utils.versions import (
+    contract_version_with_max_token_networks,
+    contracts_version_provides_services,
+)
 
 
 @pytest.mark.parametrize("version", [None, CONTRACTS_VERSION])
@@ -126,6 +129,11 @@ def test_version_provides_services() -> None:
     assert contracts_version_provides_services("0.11.0")
     with pytest.raises(ValueError):
         assert contracts_version_provides_services("not a semver")
+
+
+def test_version_with_max_token_networks() -> None:
+    assert contract_version_with_max_token_networks(None)
+    assert not contract_version_with_max_token_networks("0.8.0_unlimited")
 
 
 def test_verify_nonexistent_deployment(user_deposit_whole_balance_limit: int) -> None:

--- a/raiden_contracts/tests/test_deploy_data.py
+++ b/raiden_contracts/tests/test_deploy_data.py
@@ -10,10 +10,10 @@ from raiden_contracts.contract_manager import (
     contracts_data_path,
     contracts_deployed_path,
     get_contracts_deployment_info,
-    version_provides_services,
 )
 from raiden_contracts.deploy.contract_verifier import ContractVerifier
 from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS
+from raiden_contracts.utils.versions import contracts_version_provides_services
 
 
 @pytest.mark.parametrize("version", [None, CONTRACTS_VERSION])
@@ -118,14 +118,14 @@ def test_service_deploy_data_for_redeyes_fail(chain_id: int) -> None:
 
 
 def test_version_provides_services() -> None:
-    assert not version_provides_services("0.3._")
-    assert not version_provides_services("0.4.0")
-    assert version_provides_services("0.8.0")
-    assert version_provides_services("0.8.0_unlimited")
-    assert version_provides_services("0.10.1")
-    assert version_provides_services("0.11.0")
+    assert not contracts_version_provides_services("0.3._")
+    assert not contracts_version_provides_services("0.4.0")
+    assert contracts_version_provides_services("0.8.0")
+    assert contracts_version_provides_services("0.8.0_unlimited")
+    assert contracts_version_provides_services("0.10.1")
+    assert contracts_version_provides_services("0.11.0")
     with pytest.raises(ValueError):
-        assert version_provides_services("not a semver")
+        assert contracts_version_provides_services("not a semver")
 
 
 def test_verify_nonexistent_deployment(user_deposit_whole_balance_limit: int) -> None:

--- a/raiden_contracts/utils/versions.py
+++ b/raiden_contracts/utils/versions.py
@@ -2,9 +2,6 @@ from typing import Optional
 
 from semver import compare
 
-from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY
-from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
-
 
 def contracts_version_expects_deposit_limits(contracts_version: Optional[str]) -> bool:
     """ Answers whether TokenNetworkRegistry of the contracts_vesion needs deposit limits """
@@ -16,19 +13,20 @@ def contracts_version_expects_deposit_limits(contracts_version: Optional[str]) -
 
 
 def contract_version_with_max_token_networks(version: Optional[str]) -> bool:
-    manager = ContractManager(contracts_precompiled_path(version))
-    abi = manager.get_contract_abi(CONTRACT_TOKEN_NETWORK_REGISTRY)
-    constructors = list(filter(lambda x: x["type"] == "constructor", abi))
-    assert len(constructors) == 1
-    inputs = constructors[0]["inputs"]
-    max_token_networks_args = list(filter(lambda x: x["name"] == "_max_token_networks", inputs))
-    found_args = len(max_token_networks_args)
-    if found_args == 0:
-        return False
-    elif found_args == 1:
+    if version is None:
         return True
-    else:
-        raise ValueError(
-            "TokenNetworkRegistry's constructor has more than one arguments that are "
-            'called "_max_token_networks".'
-        )
+    if version == "0.3._":
+        return False
+    if version == "0.8.0_unlimited":
+        return False
+    return compare(version, "0.9.0") >= 0
+
+
+def contracts_version_provides_services(version: Optional[str]) -> bool:
+    if version is None:
+        return True
+    if version == "0.3._":
+        return False
+    if version == "0.8.0_unlimited":
+        return True
+    return compare(version, "0.8.0") >= 0

--- a/raiden_contracts/utils/versions.py
+++ b/raiden_contracts/utils/versions.py
@@ -6,6 +6,7 @@ from semver import compare
 def contracts_version_expects_deposit_limits(contracts_version: Optional[str]) -> bool:
     """ Answers whether TokenNetworkRegistry of the contracts_vesion needs deposit limits """
     if contracts_version is None:
+        # contracts_version == None means the stock version in development.
         return True
     if contracts_version == "0.3._":
         return False
@@ -14,6 +15,7 @@ def contracts_version_expects_deposit_limits(contracts_version: Optional[str]) -
 
 def contract_version_with_max_token_networks(version: Optional[str]) -> bool:
     if version is None:
+        # contracts_version == None means the stock version in development.
         return True
     if version == "0.3._":
         return False
@@ -24,6 +26,7 @@ def contract_version_with_max_token_networks(version: Optional[str]) -> bool:
 
 def contracts_version_provides_services(version: Optional[str]) -> bool:
     if version is None:
+        # contracts_version == None means the stock version in development.
         return True
     if version == "0.3._":
         return False


### PR DESCRIPTION
and somehow util modules should not depend on contract_manager.

This fixes #1009.