### PR TITLE
Expose the gas measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Documents changes that result in:
 
 ## Unreleased
 
+- Add `gas_measurements(contracts_version)` that shows the gas measurements as a dictionary.
 - Unlock-related functions' and events' arguments are renamed into `sender` and `receiver`
 
 ## [0.20.0](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.20.0) - 2019-05-17

--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,17 @@ If you want to use the officially deployed contracts, please use the ``raiden_co
     deployed_services = get_contracts_deployed(int(web3.version.network), services=True)
     MONITORING_SERVICE_ADDRESS = deployment_data['contracts'][CONTRACT_MONITORING_SERVICE].address
 
+Looking Up Gas Consumption
+--------------------------
+
+Each ``contracts_version`` (at least ``0.8.0``) comes with gas consumption measurements::
+
+    gas = gas_measurements(contracts_version)
+    gas["TokenNetwork.setTotalDeposit"]
+
+evaluates to something like 45000.
+
+
 Test-only Contracts
 -------------------
 

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -145,6 +145,13 @@ def contracts_gas_path(version: Optional[str] = None) -> Any:
     return data_path.joinpath("gas.json")
 
 
+def gas_measurements(version: Optional[str] = None) -> Dict[str, int]:
+    """Returns gas usage measurement."""
+    json_path = contracts_gas_path(version)
+    with json_path.open() as gas_file:
+        return json.load(gas_file)
+
+
 def contracts_deployed_path(
     chain_id: int, version: Optional[str] = None, services: bool = False
 ) -> Path:

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -15,7 +15,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MAX,
     TEST_SETTLE_TIMEOUT_MIN,
 )
-from raiden_contracts.contract_manager import contracts_gas_path
+from raiden_contracts.contract_manager import gas_measurements
 from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
 from raiden_contracts.utils.merkle import get_merkle_root
 from raiden_contracts.utils.pending_transfers import get_locked_amount, get_pending_transfers_tree
@@ -25,31 +25,30 @@ from raiden_contracts.utils.proofs import sign_one_to_n_iou
 @pytest.mark.parametrize("version", [None])
 def test_gas_json_has_enough_fields(version):
     """ Check is gas.json contains enough fields """
-    with contracts_gas_path(version).open(mode="r") as gas_file:
-        doc = json.load(gas_file)
-        keys = {
-            "EndpointRegistry.registerEndpoint",
-            "MonitoringService.claimReward",
-            "MonitoringService.monitor",
-            "OneToN.claim",
-            "SecretRegistry.registerSecret",
-            "TokenNetwork DEPLOYMENT",
-            "TokenNetwork.closeChannel",
-            "TokenNetwork.openChannel",
-            "TokenNetwork.setTotalDeposit",
-            "TokenNetwork.setTotalWithdraw",
-            "TokenNetwork.settleChannel",
-            "TokenNetwork.unlock 1 locks",
-            "TokenNetwork.unlock 6 locks",
-            "TokenNetwork.updateNonClosingBalanceProof",
-            "TokenNetworkRegistry DEPLOYMENT",
-            "TokenNetworkRegistry createERC20TokenNetwork",
-            "UserDeposit.deposit",
-            "UserDeposit.deposit (increase balance)",
-            "UserDeposit.planWithdraw",
-            "UserDeposit.withdraw",
-        }
-        assert set(doc.keys()) == keys
+    doc = gas_measurements(version)
+    keys = {
+        "EndpointRegistry.registerEndpoint",
+        "MonitoringService.claimReward",
+        "MonitoringService.monitor",
+        "OneToN.claim",
+        "SecretRegistry.registerSecret",
+        "TokenNetwork DEPLOYMENT",
+        "TokenNetwork.closeChannel",
+        "TokenNetwork.openChannel",
+        "TokenNetwork.setTotalDeposit",
+        "TokenNetwork.setTotalWithdraw",
+        "TokenNetwork.settleChannel",
+        "TokenNetwork.unlock 1 locks",
+        "TokenNetwork.unlock 6 locks",
+        "TokenNetwork.updateNonClosingBalanceProof",
+        "TokenNetworkRegistry DEPLOYMENT",
+        "TokenNetworkRegistry createERC20TokenNetwork",
+        "UserDeposit.deposit",
+        "UserDeposit.deposit (increase balance)",
+        "UserDeposit.planWithdraw",
+        "UserDeposit.withdraw",
+    }
+    assert set(doc.keys()) == keys
 
 
 @pytest.fixture

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -1,4 +1,3 @@
-import json
 from typing import Callable, List
 
 import pytest


### PR DESCRIPTION
This PR adds an API `gas_measurements(contracts_version)` that exposes the gas measurements as a dictionary.