### PR TITLE
Replace an assert that might fail

### DIFF
--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -174,7 +174,11 @@ def merge_deployment_data(dict1: DeployedContracts, dict2: DeployedContracts) ->
     if not dict2:
         return dict1
     common_contracts: Dict[str, DeployedContract] = deepcopy(dict1["contracts"])
-    assert not common_contracts.keys() & dict2["contracts"].keys()
+    if common_contracts.keys() & dict2["contracts"].keys():
+        raise ValueError(
+            "dict1 and dict2 contain contracts of the same name. "
+            "Now failing instead of overwriting any of these."
+        )
     common_contracts.update(dict2["contracts"])
 
     if dict2["chain_id"] != dict1["chain_id"]:

--- a/raiden_contracts/tests/unit/test_merge_dict.py
+++ b/raiden_contracts/tests/unit/test_merge_dict.py
@@ -5,6 +5,13 @@ import pytest
 from raiden_contracts.contract_manager import merge_deployment_data
 
 
+def test_merge_deployment_data_identical():
+    """ merge_deployment_data() throws ValueError when identical two dictionaries are given """
+    deployment = {"contract_version": "0.12.0", "contracts": {"TokenNetworkRegistry": "something"}}
+    with pytest.raises(ValueError):
+        merge_deployment_data(deployment, deployment)  # type: ignore
+
+
 def test_merge_deployment_data_wrong_chain_id():
     """ merge_deployment_data() throws ValueError on two dictionaries with different chain_id's"""
     deployment1 = {


### PR DESCRIPTION
merge_deployment_data() might get two dictionaries that have the
same keys.

This is a part of #847.