### PR TITLE
Combine make lint and make mypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - make verify_contracts
 
 before_script:
-  - make lint mypy
+  - make lint
 
 script:
   - travis_wait 50 pytest --cov=./ raiden_contracts/tests/ -n 2 --cov-config setup.cfg

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ lint:
 	black --check --diff $(BLACK_PARAMS)
 	flake8 raiden_contracts/
 	pylint raiden_contracts/
+	mypy --ignore-missing-imports --check-untyped-defs raiden_contracts
 	isort $(ISORT_PARAMS) --check-only
 
 isort:
@@ -29,9 +30,6 @@ black:
 	black $(BLACK_PARAMS)
 
 format: isort black
-
-mypy:
-	mypy --ignore-missing-imports --check-untyped-defs raiden_contracts
 
 clean:
 	rm -rf build/ *egg-info/ dist .eggs


### PR DESCRIPTION
Rather than making lint dependent on mypy, I just moved the contents
of `make mypy` task into `make lint`. Usually linting should run
before mypy runs.

This closes #911.