### PR TITLE
contract_version -> contracts_version

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -20,7 +20,7 @@ from raiden_contracts.deploy.contract_deployer import ContractDeployer
 from raiden_contracts.deploy.contract_verifier import ContractVerifier
 from raiden_contracts.utils.private_key import get_private_key
 from raiden_contracts.utils.signature import private_key_to_address
-from raiden_contracts.utils.versions import contract_version_with_max_token_networks
+from raiden_contracts.utils.versions import contracts_version_with_max_token_networks
 
 LOG = getLogger(__name__)
 
@@ -128,19 +128,19 @@ def main() -> int:
 def check_version_dependent_parameters(
     contracts_version: Optional[str], max_token_networks: Optional[int]
 ) -> None:
-    required = contract_version_with_max_token_networks(contracts_version)
+    required = contracts_version_with_max_token_networks(contracts_version)
     got = max_token_networks is not None
 
     # For newer conracts --max-token-networks is necessary.
     if required and not got:
         raise BadParameter(
-            f"For contract_version {contracts_version},"
+            f"For contracts_version {contracts_version},"
             " --max-token-networks option is necessary.  See --help."
         )
     # For older contracts --max_token_networks is forbidden.
     if not required and got:
         raise BadParameter(
-            f"For contract_version {contracts_version},"
+            f"For contracts_version {contracts_version},"
             " --max-token-networks option is forbidden"
             " because TokenNetworkRegistry this version is not configurable this way."
         )

--- a/raiden_contracts/tests/test_deploy_data.py
+++ b/raiden_contracts/tests/test_deploy_data.py
@@ -15,8 +15,8 @@ from raiden_contracts.deploy.contract_verifier import ContractVerifier
 from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS
 from raiden_contracts.utils.type_aliases import ChainID
 from raiden_contracts.utils.versions import (
-    contract_version_with_max_token_networks,
     contracts_version_provides_services,
+    contracts_version_with_max_token_networks,
 )
 
 
@@ -137,8 +137,8 @@ def test_version_provides_services() -> None:
 
 
 def test_version_with_max_token_networks() -> None:
-    assert contract_version_with_max_token_networks(None)
-    assert not contract_version_with_max_token_networks("0.8.0_unlimited")
+    assert contracts_version_with_max_token_networks(None)
+    assert not contracts_version_with_max_token_networks("0.8.0_unlimited")
 
 
 def test_verify_nonexistent_deployment(user_deposit_whole_balance_limit: int) -> None:

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -30,7 +30,7 @@ from raiden_contracts.contract_manager import (
 from raiden_contracts.deploy.__main__ import (
     ContractDeployer,
     ContractVerifier,
-    contract_version_with_max_token_networks,
+    contracts_version_with_max_token_networks,
     error_removed_option,
     raiden,
     register,
@@ -130,7 +130,7 @@ def deployed_service_info(
 def test_contract_version_with_max_token_networks(
     version: Optional[str], expectation: bool
 ) -> None:
-    assert contract_version_with_max_token_networks(version) == expectation
+    assert contracts_version_with_max_token_networks(version) == expectation
 
 
 @pytest.mark.slow
@@ -775,7 +775,7 @@ def deploy_raiden_arguments(
     elif save_info is False:
         arguments.append("--no-save-info")
 
-    if contract_version_with_max_token_networks(contracts_version):
+    if contracts_version_with_max_token_networks(contracts_version):
         arguments.extend(["--max-token-networks", 1])
 
     if contracts_version:

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -127,7 +127,7 @@ def deployed_service_info(
         (None, True),
     ],
 )
-def test_contract_version_with_max_token_networks(
+def test_contracts_version_with_max_token_networks(
     version: Optional[str], expectation: bool
 ) -> None:
     assert contracts_version_with_max_token_networks(version) == expectation

--- a/raiden_contracts/utils/versions.py
+++ b/raiden_contracts/utils/versions.py
@@ -13,7 +13,7 @@ def contracts_version_expects_deposit_limits(contracts_version: Optional[str]) -
     return compare(contracts_version, "0.9.0") > -1
 
 
-def contract_version_with_max_token_networks(version: Optional[str]) -> bool:
+def contracts_version_with_max_token_networks(version: Optional[str]) -> bool:
     if version is None:
         # contracts_version == None means the stock version in development.
         return True


### PR DESCRIPTION
Since this version is about a combination of contracts,
I chose to use contracts_version everywhere, and never
contract_version.

This fixes #1007.