### PR TITLE
Reusing SecretRegistry from a previous deployment file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,6 +178,8 @@ Deploying the main Raiden Network contracts with the ``raiden`` command::
 
     python -m raiden_contracts.deploy raiden --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --gas-limit 6000000 --max-token-networks 1
 
+When the ``raiden`` command takes an optional argument ``--secret-registry-from-deployment-file <deployment-file>``, the command tries to reuse ``SecretRegistry`` instance found in ``<deployment-file>``.  For example, some deployment files are found under ``raiden_contracts/data*/deployment_*.json``.
+
 Deploying the mock token contract for paying for the services (not to be done on the mainnet)::
 
     python -m raiden_contracts.deploy token --rpc-provider http://127.0.0.1:8545 --private-key /path/to/your/private_key/file --gas-price 10 --token-supply 20000000 --token-name ServiceToken --token-decimals 18 --token-symbol SVT

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -9,6 +9,7 @@ from eth_typing.evm import HexAddress
 from mypy_extensions import TypedDict
 
 from raiden_contracts.constants import ID_TO_NETWORKNAME, DeploymentModule
+from raiden_contracts.utils.load_json import load_json_from_path
 from raiden_contracts.utils.type_aliases import ChainID
 from raiden_contracts.utils.versions import contracts_version_provides_services
 
@@ -219,7 +220,7 @@ def get_contracts_deployment_info(
     deployment_data: DeployedContracts = {}  # type: ignore
 
     for f in files:
-        j = _load_json_from_path(f)
+        j = load_json_from_path(f)
         if j is None:
             continue
         deployment_data = merge_deployment_data(
@@ -236,13 +237,3 @@ def get_contracts_deployment_info(
     if not deployment_data:
         deployment_data = None
     return deployment_data
-
-
-def _load_json_from_path(f: Path) -> Optional[Dict[str, Any]]:
-    try:
-        with f.open() as deployment_file:
-            return json.load(deployment_file)
-    except FileNotFoundError:
-        return None
-    except (JSONDecodeError, UnicodeDecodeError) as ex:
-        raise ValueError(f"Deployment data file is corrupted: {ex}") from ex

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -9,7 +9,7 @@ from eth_typing.evm import HexAddress
 from mypy_extensions import TypedDict
 
 from raiden_contracts.constants import ID_TO_NETWORKNAME, DeploymentModule
-from raiden_contracts.utils.load_json import load_json_from_path
+from raiden_contracts.utils.file_ops import load_json_from_path
 from raiden_contracts.utils.type_aliases import ChainID
 from raiden_contracts.utils.versions import contracts_version_provides_services
 

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -174,7 +174,8 @@ def raiden(
     setup_ctx(ctx, private_key, rpc_provider, wait, gas_price, gas_limit, contracts_version)
     deployer = ctx.obj["deployer"]
     deployed_contracts_info = deployer.deploy_raiden_contracts(
-        max_num_of_token_networks=max_token_networks
+        max_num_of_token_networks=max_token_networks,
+        secret_registry_from_deployment_file=secret_registry_from_deployment_file,
     )
     deployed_contracts = {
         contract_name: info["address"]

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -152,6 +152,10 @@ def check_version_dependent_parameters(
 @click.option(
     "--max-token-networks", help="The maximum number of tokens that can be registered.", type=int
 )
+@click.option(
+    "--secret-registry-from-deployment-file",
+    help="The deployment file from which SecretRegistry should be reused",
+)
 @click.pass_context
 def raiden(
     ctx: click.Context,
@@ -163,6 +167,7 @@ def raiden(
     save_info: int,
     contracts_version: Optional[str],
     max_token_networks: Optional[int],
+    secret_registry_from_deployment_file: Optional[str],
 ) -> None:
     check_version_dependent_parameters(contracts_version, max_token_networks)
 

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -148,18 +148,19 @@ class ContractDeployer(ContractVerifier):
         }
 
         if reuse_secret_registry_from_deploy_file:
-            # FIXME: the following several lines duplicate a part of _verify_deployed_contract()
-            reused_doc = load_json_from_path(reuse_secret_registry_from_deploy_file)
+            reused_doc = DeployedContracts(  # type: ignore
+                load_json_from_path(reuse_secret_registry_from_deploy_file)
+            )
             if not reused_doc:
                 raise RuntimeError(
                     f"{reuse_secret_registry_from_deploy_file} does not contain deployment data."
                 )
             reused_contracts = reused_doc["contracts"]
-            reused_address = reused_contracts[CONTRACT_SECRET_REGISTRY]["address"]
-            secret_registry = self.web3.eth.contract(
-                abi=self.contract_manager.get_contract_abi(CONTRACT_SECRET_REGISTRY),
-                address=reused_address,
+
+            secret_registry = self.contract_instance_from_deployment_data(
+                reused_doc, CONTRACT_SECRET_REGISTRY
             )
+
             deployed_contracts["contracts"][CONTRACT_SECRET_REGISTRY] = deepcopy(
                 reused_contracts[CONTRACT_SECRET_REGISTRY]
             )

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -1,4 +1,5 @@
 from logging import getLogger
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from eth_typing import HexAddress
@@ -126,7 +127,9 @@ class ContractDeployer(ContractVerifier):
         return {token_type: token_address}
 
     def deploy_raiden_contracts(
-        self, max_num_of_token_networks: Optional[int]
+        self,
+        max_num_of_token_networks: Optional[int],
+        reuse_secret_registry_from_deploy_file: Optional[Path],
     ) -> DeployedContracts:
         """ Deploy all required raiden contracts and return a dict of contract_name:address
 
@@ -142,11 +145,14 @@ class ContractDeployer(ContractVerifier):
             "contracts": {},
         }
 
-        secret_registry = self._deploy_and_remember(
-            contract_name=CONTRACT_SECRET_REGISTRY,
-            arguments=[],
-            deployed_contracts=deployed_contracts,
-        )
+        if reuse_secret_registry_from_deploy_file:
+            raise NotImplementedError
+        else:
+            secret_registry = self._deploy_and_remember(
+                contract_name=CONTRACT_SECRET_REGISTRY,
+                arguments=[],
+                deployed_contracts=deployed_contracts,
+            )
         token_network_registry_args = [
             secret_registry.address,
             deployed_contracts["chain_id"],

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -24,7 +24,7 @@ from raiden_contracts.constants import (
 from raiden_contracts.contract_manager import CompiledContract, DeployedContract, DeployedContracts
 from raiden_contracts.contract_source_manager import ContractSourceManager, contracts_source_path
 from raiden_contracts.deploy.contract_verifier import ContractVerifier
-from raiden_contracts.utils.load_json import load_json_from_path
+from raiden_contracts.utils.file_ops import load_json_from_path
 from raiden_contracts.utils.signature import private_key_to_address
 from raiden_contracts.utils.transaction import check_successful_tx
 from raiden_contracts.utils.versions import contracts_version_expects_deposit_limits

--- a/raiden_contracts/tests/deprecation_switch_testnet.py
+++ b/raiden_contracts/tests/deprecation_switch_testnet.py
@@ -98,7 +98,9 @@ def deprecation_test_setup(
     channel_participant_deposit_limit: int,
     token_network_deposit_limit: int,
 ) -> Tuple:
-    deployed_contracts = deployer.deploy_raiden_contracts(max_num_of_token_networks=1)["contracts"]
+    deployed_contracts = deployer.deploy_raiden_contracts(
+        max_num_of_token_networks=1, reuse_secret_registry_from_deploy_file=None
+    )["contracts"]
 
     token_network_registry_abi = deployer.contract_manager.get_contract_abi(
         CONTRACT_TOKEN_NETWORK_REGISTRY

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -786,7 +786,7 @@ def test_deploy_token_with_balance(get_accounts: Callable, get_private_key: Call
 
 
 def deploy_raiden_arguments(
-    privkey: str, save_info: Optional[bool], contracts_version: Optional[str]
+    privkey: str, save_info: Optional[bool], contracts_version: Optional[str], reuse_secret_registry: bool
 ) -> List:
     arguments: List = ["--private-key", privkey, "--rpc-provider", "rpc_provider"]
 
@@ -801,18 +801,23 @@ def deploy_raiden_arguments(
     if contracts_version:
         arguments.extend(["--contracts-version", contracts_version])
 
+    if reuse_secret_registry:
+        arguments.extend(["--secret-registry-from-deployment-file", "./old-deployment-file.json"])
+
     return arguments
 
 
 @patch.object(ContractDeployer, "deploy_raiden_contracts")
 @patch.object(ContractVerifier, "store_and_verify_deployment_info_raiden")
 @pytest.mark.parametrize("contracts_version", [None, "0.4.0"])
+@pytest.mark.parametrize("reuse_secret_registry", [False, True])
 def test_deploy_raiden(
     mock_deploy: MagicMock,
     mock_verify: MagicMock,
     get_accounts: Callable,
     get_private_key: Callable,
     contracts_version: Optional[str],
+    reuse_secret_registry: bool,
 ) -> None:
     """ Calling deploy raiden command """
     (signer,) = get_accounts(1)
@@ -825,7 +830,7 @@ def test_deploy_raiden(
             result = runner.invoke(
                 raiden,
                 deploy_raiden_arguments(
-                    privkey=privkey_file.name, save_info=None, contracts_version=contracts_version
+                    privkey=privkey_file.name, save_info=None, contracts_version=contracts_version, reuse_secret_registry=reuse_secret_registry
                 ),
             )
             assert result.exception is None

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -92,7 +92,9 @@ def deployed_raiden_info(deployer: ContractDeployer) -> DeployedContracts:
 @pytest.mark.slow
 @pytest.fixture(scope="session")
 def deployed_raiden_info2(deployer: ContractDeployer) -> DeployedContracts:
-    return deployer.deploy_raiden_contracts(max_num_of_token_networks=1)
+    return deployer.deploy_raiden_contracts(
+        max_num_of_token_networks=1, reuse_secret_registry_from_deploy_file=None
+    )
 
 
 @pytest.mark.slow

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -249,14 +249,17 @@ def test_deploy_raiden_reuse_secret_registry(
     with NamedTemporaryFile() as previous_deployment_file:
         previous_deployment_file.write(bytearray(json.dumps(deployed_raiden_info), "ascii"))
         previous_deployment_file.flush()
-        deployer.deploy_raiden_contracts(
+        new_deployment = deployer.deploy_raiden_contracts(
             1, reuse_secret_registry_from_deploy_file=Path(previous_deployment_file.name)
         )
-
-
-#        call_deploy_with_previous_deployment_file_no_save()
-#        compare_secret_registry()
-#        check_result()
+        assert (
+            new_deployment["contracts"][CONTRACT_SECRET_REGISTRY]
+            == deployed_raiden_info["contracts"][CONTRACT_SECRET_REGISTRY]
+        )
+        assert (
+            new_deployment["contracts"][CONTRACT_TOKEN_NETWORK_REGISTRY]
+            != deployed_raiden_info["contracts"][CONTRACT_TOKEN_NETWORK_REGISTRY]
+        )
 
 
 def test_deploy_script_token(web3: Web3) -> None:

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -932,7 +932,7 @@ def test_deploy_raiden_save_info_false(
             result = runner.invoke(
                 raiden,
                 deploy_raiden_arguments(
-                    privkey=privkey_file.name, save_info=False, contracts_version=None
+                    privkey=privkey_file.name, save_info=False, contracts_version=None, reuse_secret_registry=False
                 ),
             )
             assert result.exception is None

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -248,6 +248,7 @@ def test_deploy_raiden_reuse_secret_registry(
     """ Run deploy_raiden_contracts with a previous SecretRegistry deployment data """
     with NamedTemporaryFile() as previous_deployment_file:
         previous_deployment_file.write(bytearray(json.dumps(deployed_raiden_info), "ascii"))
+        previous_deployment_file.flush()
         deployer.deploy_raiden_contracts(
             1, reuse_secret_registry_from_deploy_file=Path(previous_deployment_file.name)
         )

--- a/raiden_contracts/tests/unit/test_files.py
+++ b/raiden_contracts/tests/unit/test_files.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from raiden_contracts.utils.load_json import load_json_from_path
+from raiden_contracts.utils.file_ops import load_json_from_path
 
 
 def test_load_json_from_corrupt_file() -> None:

--- a/raiden_contracts/tests/unit/test_files.py
+++ b/raiden_contracts/tests/unit/test_files.py
@@ -3,11 +3,11 @@ from pathlib import Path
 
 import pytest
 
-from raiden_contracts.contract_manager import _load_json_from_path
+from raiden_contracts.utils.load_json import load_json_from_path
 
 
 def test_load_json_from_corrupt_file() -> None:
     with tempfile.NamedTemporaryFile() as f:
         f.write(b"not a JSON")
         with pytest.raises(ValueError):
-            _load_json_from_path(Path(f.name))
+            load_json_from_path(Path(f.name))

--- a/raiden_contracts/utils/file_ops.py
+++ b/raiden_contracts/utils/file_ops.py
@@ -1,0 +1,14 @@
+import json
+from json import JSONDecodeError
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def load_json_from_path(f: Path) -> Optional[Dict[str, Any]]:
+    try:
+        with f.open() as deployment_file:
+            return json.load(deployment_file)
+    except FileNotFoundError:
+        return None
+    except (JSONDecodeError, UnicodeDecodeError) as ex:
+        raise ValueError(f"Deployment data file is corrupted: {ex}") from ex


### PR DESCRIPTION
This PR implements the feature of reusing SecretRegistry form a previous deployment file.

After this PR, users are able to use the same SecretRegistry instance for multiple deployments of TokenNetworkRegistrys.  Then a payment spanning the multiple TokenNetworks become possible.

This fixes #963 .