### PR TITLE
Checking constructor args should not be assert

### DIFF
--- a/raiden_contracts/deploy/contract_verifier.py
+++ b/raiden_contracts/deploy/contract_verifier.py
@@ -132,7 +132,10 @@ class ContractVerifier:
             != secret_registry.address
         ):
             raise RuntimeError("secret_registry_address onchain has an unexpected value.")
-        assert secret_registry.address == constructor_arguments[0]
+        if secret_registry.address != constructor_arguments[0]:
+            raise RuntimeError(
+                "TokenNetwork's constructor received a different SecretRegistry address."
+            )
         assert token_network_registry.functions.chain_id().call() == constructor_arguments[1]
         assert (
             token_network_registry.functions.settlement_timeout_min().call()

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -236,6 +236,13 @@ def test_deploy_script_raiden(
     with pytest.raises(RuntimeError):
         deployer.verify_deployment_data(deployed_contracts_info_fail)
 
+    deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
+    deployed_contracts_info_fail["contracts"][CONTRACT_TOKEN_NETWORK_REGISTRY][
+        "constructor_arguments"
+    ][0] = CONTRACT_DEPLOYER_ADDRESS
+    with pytest.raises(RuntimeError):
+        deployer.verify_deployment_data(deployed_contracts_info_fail)
+
     # check that it fails if sender has no eth
     deployer = ContractDeployer(
         web3=web3, private_key=get_random_privkey(), gas_limit=GAS_LIMIT, gas_price=1, wait=10


### PR DESCRIPTION
because assertions can be omitted by optimizations.