### PR TITLE
Make mypy read all config from `setup.cfg`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint:
 	black --check --diff $(BLACK_PARAMS)
 	flake8 raiden_contracts/
 	pylint raiden_contracts/
-	mypy --ignore-missing-imports --check-untyped-defs raiden_contracts
+	mypy raiden_contracts
 	isort $(ISORT_PARAMS) --check-only
 
 isort:

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,4 @@ combine_as_imports=1
 
 [mypy]
 disallow_untyped_defs = True
+ignore_missing_imports = True


### PR DESCRIPTION
This allows running mypy without any arguments, which makes more tooling
work out of the box.

`--check-untyped-defs` is not needed anymore, since untyped defs are disallowed.