### PR TITLE
 Use `pack_*` instead of `hash_*` proof functions

### DIFF
--- a/raiden_contracts/tests/unit/test_recover_from_signature.py
+++ b/raiden_contracts/tests/unit/test_recover_from_signature.py
@@ -6,7 +6,7 @@ from web3 import Web3
 from web3.contract import Contract
 
 from raiden_contracts.tests.utils.constants import EMPTY_ADDRESS
-from raiden_contracts.utils.proofs import hash_balance_proof
+from raiden_contracts.utils.proofs import eth_sign_hash_message, pack_balance_proof
 from raiden_contracts.utils.signature import sign
 
 # pylint: disable=E1120
@@ -34,16 +34,26 @@ def test_verify(
 
     balance_proof_A = create_balance_proof(channel_identifier, A, 2, 0, 3)
     signature = balance_proof_A[3]
-    balance_proof_hash = hash_balance_proof(
-        token_network.address, int(web3.version.network), channel_identifier, *balance_proof_A[:3]
+    balance_proof_hash = eth_sign_hash_message(
+        pack_balance_proof(
+            token_network.address,
+            int(web3.version.network),
+            channel_identifier,
+            *balance_proof_A[:3]
+        )
     )
     address = signature_test_contract.functions.verify(balance_proof_hash, signature).call()
     assert address == A
 
     balance_proof_B = create_balance_proof(channel_identifier, B, 0, 0, 0)
     signature = balance_proof_B[3]
-    balance_proof_hash = hash_balance_proof(
-        token_network.address, int(web3.version.network), channel_identifier, *balance_proof_B[:3]
+    balance_proof_hash = eth_sign_hash_message(
+        pack_balance_proof(
+            token_network.address,
+            int(web3.version.network),
+            channel_identifier,
+            *balance_proof_B[:3]
+        )
     )
     address = signature_test_contract.functions.verify(balance_proof_hash, signature).call()
     assert address == B
@@ -87,8 +97,13 @@ def test_ecrecover_output(
     r = signature[:32]
     s = signature[32:64]
     v = signature[64:]
-    balance_proof_hash = hash_balance_proof(
-        token_network.address, int(web3.version.network), channel_identifier, *balance_proof_A[:3]
+    balance_proof_hash = eth_sign_hash_message(
+        pack_balance_proof(
+            token_network.address,
+            int(web3.version.network),
+            channel_identifier,
+            *balance_proof_A[:3]
+        )
     )
 
     address = signature_test_contract.functions.verifyEcrecoverOutput(

--- a/raiden_contracts/utils/proofs.py
+++ b/raiden_contracts/utils/proofs.py
@@ -24,7 +24,7 @@ def eth_sign_hash_message(encoded_message: bytes) -> bytes:
     )
 
 
-def hash_balance_proof(
+def pack_balance_proof(
     token_network_address: HexAddress,
     chain_identifier: int,
     channel_identifier: int,
@@ -32,7 +32,7 @@ def hash_balance_proof(
     nonce: int,
     additional_hash: bytes,
 ) -> bytes:
-    return eth_sign_hash_message(
+    return (
         Web3.toBytes(hexstr=token_network_address)
         + encode_single("uint256", chain_identifier)
         + encode_single("uint256", MessageTypeId.BALANCE_PROOF)
@@ -43,7 +43,7 @@ def hash_balance_proof(
     )
 
 
-def hash_balance_proof_update_message(
+def pack_balance_proof_update_message(
     token_network_address: HexAddress,
     chain_identifier: int,
     channel_identifier: int,
@@ -52,7 +52,7 @@ def hash_balance_proof_update_message(
     additional_hash: bytes,
     closing_signature: bytes,
 ) -> bytes:
-    return eth_sign_hash_message(
+    return (
         Web3.toBytes(hexstr=token_network_address)
         + encode_single("uint256", chain_identifier)
         + encode_single("uint256", MessageTypeId.BALANCE_PROOF_UPDATE)
@@ -64,7 +64,7 @@ def hash_balance_proof_update_message(
     )
 
 
-def hash_cooperative_settle_message(
+def pack_cooperative_settle_message(
     token_network_address: HexAddress,
     chain_identifier: int,
     channel_identifier: int,
@@ -73,7 +73,7 @@ def hash_cooperative_settle_message(
     participant2_address: HexAddress,
     participant2_balance: int,
 ) -> bytes:
-    return eth_sign_hash_message(
+    return (
         Web3.toBytes(hexstr=token_network_address)
         + encode_single("uint256", chain_identifier)
         + encode_single("uint256", MessageTypeId.COOPERATIVE_SETTLE)
@@ -85,7 +85,7 @@ def hash_cooperative_settle_message(
     )
 
 
-def hash_withdraw_message(
+def pack_withdraw_message(
     token_network_address: HexAddress,
     chain_identifier: int,
     channel_identifier: int,
@@ -93,7 +93,7 @@ def hash_withdraw_message(
     amount_to_withdraw: int,
     expiration_block: int,
 ) -> bytes:
-    return eth_sign_hash_message(
+    return (
         Web3.toBytes(hexstr=token_network_address)
         + encode_single("uint256", chain_identifier)
         + encode_single("uint256", MessageTypeId.WITHDRAW)
@@ -129,13 +129,15 @@ def sign_balance_proof(
     additional_hash: bytes,
     v: int = 27,
 ) -> bytes:
-    message_hash = hash_balance_proof(
-        token_network_address=token_network_address,
-        chain_identifier=chain_identifier,
-        channel_identifier=channel_identifier,
-        balance_hash=balance_hash,
-        nonce=nonce,
-        additional_hash=additional_hash,
+    message_hash = eth_sign_hash_message(
+        pack_balance_proof(
+            token_network_address=token_network_address,
+            chain_identifier=chain_identifier,
+            channel_identifier=channel_identifier,
+            balance_hash=balance_hash,
+            nonce=nonce,
+            additional_hash=additional_hash,
+        )
     )
 
     return sign(privkey=privatekey, msg_hash=message_hash, v=v)
@@ -152,14 +154,16 @@ def sign_balance_proof_update_message(
     closing_signature: bytes,
     v: int = 27,
 ) -> bytes:
-    message_hash = hash_balance_proof_update_message(
-        token_network_address=token_network_address,
-        chain_identifier=chain_identifier,
-        channel_identifier=channel_identifier,
-        balance_hash=balance_hash,
-        nonce=nonce,
-        additional_hash=additional_hash,
-        closing_signature=closing_signature,
+    message_hash = eth_sign_hash_message(
+        pack_balance_proof_update_message(
+            token_network_address=token_network_address,
+            chain_identifier=chain_identifier,
+            channel_identifier=channel_identifier,
+            balance_hash=balance_hash,
+            nonce=nonce,
+            additional_hash=additional_hash,
+            closing_signature=closing_signature,
+        )
     )
 
     return sign(privkey=privatekey, msg_hash=message_hash, v=v)
@@ -176,14 +180,16 @@ def sign_cooperative_settle_message(
     participant2_balance: int,
     v: int = 27,
 ) -> bytes:
-    message_hash = hash_cooperative_settle_message(
-        token_network_address=token_network_address,
-        chain_identifier=chain_identifier,
-        channel_identifier=channel_identifier,
-        participant1_address=participant1_address,
-        participant1_balance=participant1_balance,
-        participant2_address=participant2_address,
-        participant2_balance=participant2_balance,
+    message_hash = eth_sign_hash_message(
+        pack_cooperative_settle_message(
+            token_network_address=token_network_address,
+            chain_identifier=chain_identifier,
+            channel_identifier=channel_identifier,
+            participant1_address=participant1_address,
+            participant1_balance=participant1_balance,
+            participant2_address=participant2_address,
+            participant2_balance=participant2_balance,
+        )
     )
 
     return sign(privkey=privatekey, msg_hash=message_hash, v=v)
@@ -199,13 +205,15 @@ def sign_withdraw_message(
     expiration_block: int,
     v: int = 27,
 ) -> bytes:
-    message_hash = hash_withdraw_message(
-        token_network_address=token_network_address,
-        chain_identifier=chain_identifier,
-        channel_identifier=channel_identifier,
-        participant=participant,
-        amount_to_withdraw=amount_to_withdraw,
-        expiration_block=expiration_block,
+    message_hash = eth_sign_hash_message(
+        pack_withdraw_message(
+            token_network_address=token_network_address,
+            chain_identifier=chain_identifier,
+            channel_identifier=channel_identifier,
+            participant=participant,
+            amount_to_withdraw=amount_to_withdraw,
+            expiration_block=expiration_block,
+        )
     )
 
     return sign(privkey=privatekey, msg_hash=message_hash, v=v)

--- a/raiden_contracts/utils/proofs.py
+++ b/raiden_contracts/utils/proofs.py
@@ -31,11 +31,12 @@ def pack_balance_proof(
     balance_hash: bytes,
     nonce: int,
     additional_hash: bytes,
+    msg_type: MessageTypeId = MessageTypeId.BALANCE_PROOF,
 ) -> bytes:
     return (
         Web3.toBytes(hexstr=token_network_address)
         + encode_single("uint256", chain_identifier)
-        + encode_single("uint256", MessageTypeId.BALANCE_PROOF)
+        + encode_single("uint256", msg_type)
         + encode_single("uint256", channel_identifier)
         + balance_hash
         + encode_single("uint256", nonce)
@@ -53,13 +54,15 @@ def pack_balance_proof_update_message(
     closing_signature: bytes,
 ) -> bytes:
     return (
-        Web3.toBytes(hexstr=token_network_address)
-        + encode_single("uint256", chain_identifier)
-        + encode_single("uint256", MessageTypeId.BALANCE_PROOF_UPDATE)
-        + encode_single("uint256", channel_identifier)
-        + balance_hash
-        + encode_single("uint256", nonce)
-        + additional_hash
+        pack_balance_proof(
+            token_network_address=token_network_address,
+            chain_identifier=chain_identifier,
+            channel_identifier=channel_identifier,
+            balance_hash=balance_hash,
+            nonce=nonce,
+            additional_hash=additional_hash,
+            msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        )
         + closing_signature
     )
 


### PR DESCRIPTION
The packing functions can be reused with the client's `Signer` objects,
which do their own hashing.

See #1041

I've prepare https://github.com/raiden-network/raiden/pull/4423 to update the raiden client to use these functions.