### PR TITLE
Rename balance_proof_update into balance_proof_countersign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Documents changes that result in:
 
 ## Unreleased
 
+- Rename `*balance_proof_update*` into `*balance_proof_countersign*`
+
 ## [0.29.0](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.29.0) - 2019-07-26
 
 - [#1143](https://github.com/raiden-network/raiden-contracts/pull/1143) Add ServiceRegistry.hasValidRegistration() function that returns whether a given address has a valid registration.

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -24,7 +24,7 @@ from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
 from raiden_contracts.utils.proofs import (
     hash_balance_data,
     sign_balance_proof,
-    sign_balance_proof_update_message,
+    sign_balance_proof_countersign_message,
     sign_cooperative_settle_message,
     sign_withdraw_message,
 )
@@ -674,7 +674,7 @@ def create_balance_proof_countersignature(
         _token_network = other_token_network or token_network
         private_key = get_private_key(participant)
 
-        non_closing_signature = sign_balance_proof_update_message(
+        non_closing_signature = sign_balance_proof_countersign_message(
             private_key,
             _token_network.address,
             int(_token_network.functions.chain_id().call()),
@@ -703,7 +703,7 @@ def create_close_signature_for_no_balance_proof(
         _token_network = other_token_network or token_network
         private_key = get_private_key(participant)
 
-        non_closing_signature = sign_balance_proof_update_message(
+        non_closing_signature = sign_balance_proof_countersign_message(
             private_key,
             _token_network.address,
             int(_token_network.functions.chain_id().call()),

--- a/raiden_contracts/utils/proofs.py
+++ b/raiden_contracts/utils/proofs.py
@@ -44,7 +44,7 @@ def pack_balance_proof(
     )
 
 
-def pack_balance_proof_update_message(
+def pack_balance_proof_countersign_message(
     token_network_address: HexAddress,
     chain_identifier: int,
     channel_identifier: int,
@@ -146,7 +146,7 @@ def sign_balance_proof(
     return sign(privkey=privatekey, msg_hash=message_hash, v=v)
 
 
-def sign_balance_proof_update_message(
+def sign_balance_proof_countersign_message(
     privatekey: str,
     token_network_address: HexAddress,
     chain_identifier: int,
@@ -158,7 +158,7 @@ def sign_balance_proof_update_message(
     v: int = 27,
 ) -> bytes:
     message_hash = eth_sign_hash_message(
-        pack_balance_proof_update_message(
+        pack_balance_proof_countersign_message(
             token_network_address=token_network_address,
             chain_identifier=chain_identifier,
             channel_identifier=channel_identifier,


### PR DESCRIPTION
The function was only for updateBalanceProof() method of TokenNetwork
but it's now also used for closeChannel() method.

The new name "countersign" suggests it's a second signature on a balance
proof, and it's what the function is about.