### PR TITLE
Document `make update_gas_costs`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all compile_contracts verify_contracts install lint isort black autopep8 format mypy clean release
+.PHONY: all compile_contracts verify_contracts install lint isort black autopep8 format mypy clean release update_gas_costs
 
 all: verify_contracts install
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ verify_contracts:
 	python setup.py verify_contracts
 
 update_gas_costs:
-	pytest raiden_contracts/tests/test_print_gas.py -k test_print_gas -s
+	pytest "raiden_contracts/tests/test_print_gas.py::test_print_gas" -s
 
 install:
 	pip install -r requirements.txt

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -124,7 +124,7 @@ Measure Gas Costs
 
 ::
 
-    pytest raiden_contracts/tests/test_print_gas.py
+    make update_gas_costs
 
 .. _create-new-dir
 


### PR DESCRIPTION
I was using `make update_gas_costs` and noticed that
* the feature was not documented in the release document
* it executed two tests instead of one.

So this PR fixes these points.