### PR TITLE
Deprecation switch can be turned on twice

### DIFF
--- a/raiden_contracts/tests/test_service_registry.py
+++ b/raiden_contracts/tests/test_service_registry.py
@@ -307,6 +307,16 @@ def test_deprecation_switch(
     service_registry.functions.setDeprecationSwitch().call_and_transact(
         {"from": CONTRACT_DEPLOYER_ADDRESS}
     )
+    # The controller can still change the parameter
+    new_duration = 90 * SECONDS_PER_DAY
+    service_registry.functions.changeParameters(
+        _price_bump_numerator=DEFAULT_BUMP_NUMERATOR,
+        _price_bump_denominator=DEFAULT_BUMP_DENOMINATOR,
+        _decay_constant=DEFAULT_DECAY_CONSTANT,
+        _min_price=DEFAULT_MIN_PRICE,
+        _registration_duration=new_duration,
+    ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+    assert service_registry.functions.registration_duration().call() == new_duration
 
 
 def test_deprecation_immediate_payout(

--- a/raiden_contracts/tests/test_service_registry.py
+++ b/raiden_contracts/tests/test_service_registry.py
@@ -303,6 +303,10 @@ def test_deprecation_switch(
     )
     with pytest.raises(TransactionFailed):
         service_registry.functions.deposit(SERVICE_DEPOSIT).call_and_transact({"from": A})
+    # The controller can deprecate the contract again
+    service_registry.functions.setDeprecationSwitch().call_and_transact(
+        {"from": CONTRACT_DEPLOYER_ADDRESS}
+    )
 
 
 def test_deprecation_immediate_payout(


### PR DESCRIPTION
but the second call has no effects.