### PR TITLE
Test calling an internal setPriceBumpParameters()

### DIFF
--- a/raiden_contracts/tests/test_service_registry.py
+++ b/raiden_contracts/tests/test_service_registry.py
@@ -5,6 +5,7 @@ from eth_tester.exceptions import TransactionFailed
 from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract import Contract, get_event_data
+from web3.exceptions import MismatchedABI
 
 from raiden_contracts.constants import (
     CONTRACT_DEPOSIT,
@@ -165,6 +166,14 @@ def test_changing_bump_numerator(service_registry: Contract) -> None:
         _registration_duration=DEFAULT_REGISTRATION_DURATION,
     ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
     assert service_registry.functions.price_bump_numerator().call() == DEFAULT_BUMP_NUMERATOR + 1
+
+
+def test_calling_internal_bump_paramter_change(service_registry: Contract) -> None:
+    """Calling an internal function setPriceBumpParameters() must fail"""
+    with pytest.raises(MismatchedABI):
+        service_registry.functions.setPriceBumpParameters(
+            DEFAULT_BUMP_NUMERATOR + 1, DEFAULT_BUMP_DENOMINATOR
+        ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
 
 
 def test_too_high_bump_numerator_fail(service_registry: Contract) -> None:


### PR DESCRIPTION
from out of the contract.

This commit is a part of #581.