### PR TITLE
Separate FAKE_ADDRESS and NOT_ADDRESS

### DIFF
--- a/raiden_contracts/tests/test_channel_deposit.py
+++ b/raiden_contracts/tests/test_channel_deposit.py
@@ -12,7 +12,7 @@ from raiden_contracts.tests.utils import (
     EMPTY_ADDITIONAL_HASH,
     EMPTY_BALANCE_HASH,
     EMPTY_SIGNATURE,
-    FAKE_ADDRESS,
+    NOT_ADDRESS,
     UINT256_MAX,
     ChannelValues,
 )
@@ -48,7 +48,7 @@ def test_deposit_channel_call(
         token_network.functions.setTotalDeposit(channel_identifier, "", deposit_A, B)
     # Validation failure with an odd-length string instead of an address
     with pytest.raises(ValidationError):
-        token_network.functions.setTotalDeposit(channel_identifier, FAKE_ADDRESS, deposit_A, B)
+        token_network.functions.setTotalDeposit(channel_identifier, NOT_ADDRESS, deposit_A, B)
     # Validation failure with the number zero instead of an address
     with pytest.raises(ValidationError):
         token_network.functions.setTotalDeposit(channel_identifier, 0x0, deposit_A, B)
@@ -57,7 +57,7 @@ def test_deposit_channel_call(
         token_network.functions.setTotalDeposit(channel_identifier, A, deposit_A, "")
     # Validation failure with an odd-length string instead of an address
     with pytest.raises(ValidationError):
-        token_network.functions.setTotalDeposit(channel_identifier, A, deposit_A, FAKE_ADDRESS)
+        token_network.functions.setTotalDeposit(channel_identifier, A, deposit_A, NOT_ADDRESS)
     # Validation failure with the number zero instead of an address
     with pytest.raises(ValidationError):
         token_network.functions.setTotalDeposit(channel_identifier, A, deposit_A, 0x0)

--- a/raiden_contracts/tests/test_channel_open.py
+++ b/raiden_contracts/tests/test_channel_open.py
@@ -20,9 +20,9 @@ from raiden_contracts.tests.utils import (
     EMPTY_ADDITIONAL_HASH,
     EMPTY_BALANCE_HASH,
     EMPTY_SIGNATURE,
-    FAKE_ADDRESS,
     LOCKSROOT_OF_NO_LOCKS,
     NONEXISTENT_LOCKSROOT,
+    NOT_ADDRESS,
 )
 from raiden_contracts.utils.events import check_channel_opened
 
@@ -48,7 +48,7 @@ def test_open_channel_call(token_network: Contract, get_accounts: Callable) -> N
 
     # Validation failure with an odd-length string instead of an address
     with pytest.raises(ValidationError):
-        token_network.functions.openChannel(FAKE_ADDRESS, B, settle_timeout)
+        token_network.functions.openChannel(NOT_ADDRESS, B, settle_timeout)
 
     # Validation failure with the number zero instead of an address
     with pytest.raises(ValidationError):
@@ -60,7 +60,7 @@ def test_open_channel_call(token_network: Contract, get_accounts: Callable) -> N
 
     # Validation failure with an odd-length string instead of an address
     with pytest.raises(ValidationError):
-        token_network.functions.openChannel(A, FAKE_ADDRESS, settle_timeout)
+        token_network.functions.openChannel(A, NOT_ADDRESS, settle_timeout)
 
     # Transaction failure with the zero address
     with pytest.raises(TransactionFailed):

--- a/raiden_contracts/tests/test_token_network.py
+++ b/raiden_contracts/tests/test_token_network.py
@@ -10,7 +10,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MAX,
     TEST_SETTLE_TIMEOUT_MIN,
 )
-from raiden_contracts.tests.utils.constants import FAKE_ADDRESS, UINT256_MAX
+from raiden_contracts.tests.utils.constants import NOT_ADDRESS, UINT256_MAX
 
 
 def test_constructor_call(
@@ -78,7 +78,7 @@ def test_constructor_call(
     with pytest.raises(TypeError):
         get_token_network(
             [
-                FAKE_ADDRESS,
+                NOT_ADDRESS,
                 secret_registry_contract.address,
                 chain_id,
                 settle_min,
@@ -135,7 +135,7 @@ def test_constructor_call(
         get_token_network(
             [
                 custom_token.address,
-                FAKE_ADDRESS,
+                NOT_ADDRESS,
                 chain_id,
                 settle_min,
                 settle_max,

--- a/raiden_contracts/tests/test_token_network_registry.py
+++ b/raiden_contracts/tests/test_token_network_registry.py
@@ -12,7 +12,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MAX,
     TEST_SETTLE_TIMEOUT_MIN,
 )
-from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS, FAKE_ADDRESS
+from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS, NOT_ADDRESS
 from raiden_contracts.utils.events import check_token_network_created
 
 
@@ -47,7 +47,7 @@ def test_constructor_call(
 
     # failure with an odd-length hex string instead of the SecretRegistry's address
     with pytest.raises(TypeError):
-        get_token_network_registry([FAKE_ADDRESS, chain_id, settle_min, settle_max, 1])
+        get_token_network_registry([NOT_ADDRESS, chain_id, settle_min, settle_max, 1])
 
     # failure with the empty string instead of a chain ID
     with pytest.raises(TypeError):
@@ -194,7 +194,7 @@ def test_create_erc20_token_network_call(
         )
     with pytest.raises(ValidationError):
         token_network_registry_contract.functions.createERC20TokenNetwork(
-            FAKE_ADDRESS, channel_participant_deposit_limit, token_network_deposit_limit
+            NOT_ADDRESS, channel_participant_deposit_limit, token_network_deposit_limit
         )
 
     # failures with addresses where no Token contract can be found

--- a/raiden_contracts/tests/utils/constants.py
+++ b/raiden_contracts/tests/utils/constants.py
@@ -5,7 +5,8 @@ from eth_utils.units import units
 from raiden_contracts.utils.signature import private_key_to_address
 
 UINT256_MAX = 2 ** 256 - 1
-FAKE_ADDRESS = "0x03432"
+NOT_ADDRESS = "0xaaa"
+FAKE_ADDRESS = "0x00112233445566778899aabbccddeeff00112233"
 EMPTY_BALANCE_HASH = b"\x00" * 32
 EMPTY_ADDITIONAL_HASH = b"\x00" * 32
 EMPTY_SIGNATURE = b"\x00" * 65


### PR DESCRIPTION
Before this commit, a string FAKE_ADDRESS was sometimes used
as a random address and sometimes as an oddly-sized string
that's not an address.  The real value of FAKE_ADDRESS was
an oddly-sized string that's not an address.

This commit separates this constant into two: FAKE_ADDRESS and
NOT_ADDRESS. FAKE_ADDRESS is a random address while NOT_ADDRESS
is an oddly-sized string that's not an address.

This closes #1166.