### PR TITLE
Complain when file does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Documents changes that result in:
 
 ## Unreleased
 
+- [#1213](https://github.com/raiden-network/raiden-contracts/pull/1213) etherscan_verify.py now fails when a source imports a nonexistent file.
+
 ## [0.31.0](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.31.0) - 2019-08-20
 
 - [#1163](https://github.com/raiden-network/raiden-contracts/pull/1163) MonitoringService.monitor() no longer works for service providers that are not registered in ServiceRegistry

--- a/raiden_contracts/tests/test_contract_joiner.py
+++ b/raiden_contracts/tests/test_contract_joiner.py
@@ -1,0 +1,18 @@
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+from raiden_contracts.utils.join_contracts import ContractJoiner
+
+
+def test_contract_joiner_with_non_existent_file() -> None:
+    """ Using ContractJoiner on a source importing a nonexistent file """
+    joiner = ContractJoiner()
+    source_with_missing_import = """
+        import "NonExistent.sol";
+    """
+    with NamedTemporaryFile() as source_file:
+        source_file.write(bytearray(source_with_missing_import, "ascii"))
+        source_file.flush()
+        with pytest.raises(FileNotFoundError):
+            joiner.join(open(source_file.name))

--- a/raiden_contracts/tests/test_contract_joiner.py
+++ b/raiden_contracts/tests/test_contract_joiner.py
@@ -21,8 +21,5 @@ def test_contract_joiner_with_non_existent_import() -> None:
 def test_contract_joiner_with_empty_file() -> None:
     """ Using ContractJoiner on an empty source """
     joiner = ContractJoiner()
-    empty_source = ""
     with NamedTemporaryFile() as source_file:
-        source_file.write(bytearray(empty_source, "ascii"))
-        source_file.flush()
         assert [] == joiner.join(open(source_file.name))

--- a/raiden_contracts/tests/test_contract_joiner.py
+++ b/raiden_contracts/tests/test_contract_joiner.py
@@ -5,7 +5,7 @@ import pytest
 from raiden_contracts.utils.join_contracts import ContractJoiner
 
 
-def test_contract_joiner_with_non_existent_file() -> None:
+def test_contract_joiner_with_non_existent_import() -> None:
     """ Using ContractJoiner on a source importing a nonexistent file """
     joiner = ContractJoiner()
     source_with_missing_import = """
@@ -16,3 +16,13 @@ def test_contract_joiner_with_non_existent_file() -> None:
         source_file.flush()
         with pytest.raises(FileNotFoundError):
             joiner.join(open(source_file.name))
+
+
+def test_contract_joiner_with_empty_file() -> None:
+    """ Using ContractJoiner on an empty source """
+    joiner = ContractJoiner()
+    empty_source = ""
+    with NamedTemporaryFile() as source_file:
+        source_file.write(bytearray(empty_source, "ascii"))
+        source_file.flush()
+        assert [] == joiner.join(open(source_file.name))

--- a/raiden_contracts/utils/join_contracts.py
+++ b/raiden_contracts/utils/join_contracts.py
@@ -63,7 +63,7 @@ class ContractJoiner:
                     next_file = next_file.replace(prefix, path)
             if next_file:
                 if not os.path.exists(next_file):
-                    raise IOError(f"File does not exist: {next_file}")
+                    raise FileNotFoundError(f"File does not exist: {next_file}")
                 with open(next_file) as next_contract:
                     out.extend(self.join(next_contract))
 

--- a/raiden_contracts/utils/join_contracts.py
+++ b/raiden_contracts/utils/join_contracts.py
@@ -61,11 +61,10 @@ class ContractJoiner:
             for prefix, path in self.import_map.items():
                 if next_file.startswith(prefix):
                     next_file = next_file.replace(prefix, path)
-            if next_file:
-                if not os.path.exists(next_file):
-                    raise FileNotFoundError(f"File does not exist: {next_file}")
-                with open(next_file) as next_contract:
-                    out.extend(self.join(next_contract))
+            if not os.path.exists(next_file):
+                raise FileNotFoundError(f"File does not exist: {next_file}")
+            with open(next_file) as next_contract:
+                out.extend(self.join(next_contract))
 
 
 @click.command()

--- a/raiden_contracts/utils/join_contracts.py
+++ b/raiden_contracts/utils/join_contracts.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import json
-import os
 import re
 import sys
 from typing import Dict, List, Set, TextIO
@@ -61,8 +60,6 @@ class ContractJoiner:
             for prefix, path in self.import_map.items():
                 if next_file.startswith(prefix):
                     next_file = next_file.replace(prefix, path)
-            if not os.path.exists(next_file):
-                raise FileNotFoundError(f"File does not exist: {next_file}")
             with open(next_file) as next_contract:
                 out.extend(self.join(next_contract))
 

--- a/raiden_contracts/utils/join_contracts.py
+++ b/raiden_contracts/utils/join_contracts.py
@@ -61,7 +61,9 @@ class ContractJoiner:
             for prefix, path in self.import_map.items():
                 if next_file.startswith(prefix):
                     next_file = next_file.replace(prefix, path)
-            if next_file and os.path.exists(next_file):
+            if next_file:
+                if not os.path.exists(next_file):
+                    raise IOError(f"File does not exist: {next_file}")
                 with open(next_file) as next_contract:
                     out.extend(self.join(next_contract))
 


### PR DESCRIPTION


### What this PR does

`join-contracts.py` raises an exception when a file does not exist.

### Why I'm making this PR

Before this commit, join-contracts.py silently skipped
non existing files.  The result is usually not useful
and might lead to nonpleasant surprises.

This closes #522.


### What's tricky about this PR (if any)

none.
----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.