### PR TITLE
Use _ instead of - in a file name

### DIFF
--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -65,7 +65,7 @@ api_of_chain_id = {
 
 
 def join_sources(source_module: DeploymentModule, contract_name: str) -> str:
-    """ Use join-contracts.py to concatenate all imported Solidity files.
+    """ Use join_contracts.py to concatenate all imported Solidity files.
 
     Args:
         source_module: a module name to look up contracts_source_path()
@@ -74,7 +74,7 @@ def join_sources(source_module: DeploymentModule, contract_name: str) -> str:
     joined_file = Path(__file__).parent.joinpath("joined.sol")
     remapping = {module: str(path) for module, path in contracts_source_path().items()}
     command = [
-        "./utils/join-contracts.py",
+        "./utils/join_contracts.py",
         "--import-map",
         json.dumps(remapping),
         str(

--- a/raiden_contracts/utils/join_contracts.py
+++ b/raiden_contracts/utils/join_contracts.py
@@ -17,7 +17,7 @@ resolving imports.
 example usage:
 
 $ cd raiden-contracts/raiden_contracts
-$ python ./utils/join-contracts.py ./contracts/TokenNetwork.sol joined.sol
+$ python ./utils/join_contracts.py ./contracts/TokenNetwork.sol joined.sol
 
 """
 


### PR DESCRIPTION
### What this PR does

This commit replaces a dash with an underscore in a name of a Python source file.

### Why I'm making this PR

It seems [1] Python sources should not be named with a dash, but
an underscore is tolerated.  

[1] http://google.github.io/styleguide/pyguide.html#316-naming

### What's tricky about this PR (if any)

I tried to make sure that all documents etc contain the new name instead of the old name.

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.