### PR TITLE
Add a missing space

### DIFF
--- a/raiden_contracts/deploy/contract_verifier.py
+++ b/raiden_contracts/deploy/contract_verifier.py
@@ -182,7 +182,7 @@ class ContractVerifier:
         if receipt["blockNumber"] != contracts[contract_name]["block_number"]:
             raise RuntimeError(
                 f'We have block_number {contracts[contract_name]["block_number"]} in the '
-                f'deployment info, but {receipt["blockNumber"]} in the transaction receipt'
+                f'deployment info, but {receipt["blockNumber"]} in the transaction receipt '
                 "from web3."
             )
         if receipt["gasUsed"] != contracts[contract_name]["gas_cost"]:


### PR DESCRIPTION
This fixes #1170.

### What this PR does

Adds a space between two words.

### Why I'm making this PR

The error message spans over multiple lines in the source code.
There was a missing space at the end of a line so the last word
"receipt" and the first word on the next line "from" collapsed
together into one word "receiptfrom".

### What's tricky about this PR (if any)

Nothing.

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.