### PR TITLE
deploy script with configurable settle timeouts

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -18,6 +18,8 @@ from web3.middleware import geth_poa_middleware
 from raiden_contracts.constants import (
     CONTRACT_CUSTOM_TOKEN,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
+    DEPLOY_SETTLE_TIMEOUT_MAX,
+    DEPLOY_SETTLE_TIMEOUT_MIN,
     EMPTY_ADDRESS,
 )
 from raiden_contracts.deploy.contract_deployer import ContractDeployer
@@ -161,6 +163,24 @@ def check_version_dependent_parameters(
     type=click.Path(exists=True),
     help="The deployment file from which SecretRegistry should be reused",
 )
+@click.option(
+    "--settle-timeout-max",
+    type=click.INT,
+    default=DEPLOY_SETTLE_TIMEOUT_MAX,
+    help=(
+        "The maximum allowed settle timeout for the channels opened with this "
+        "set of smart contracts"
+    ),
+)
+@click.option(
+    "--settle-timeout-min",
+    type=click.INT,
+    default=DEPLOY_SETTLE_TIMEOUT_MIN,
+    help=(
+        "The minimum allowed settle timeout for the channels opened with this "
+        "set of smart contracts"
+    ),
+)
 @click.pass_context
 def raiden(
     ctx: click.Context,
@@ -170,6 +190,8 @@ def raiden(
     gas_price: int,
     gas_limit: int,
     save_info: int,
+    settle_timeout_min: int,
+    settle_timeout_max: int,
     contracts_version: Optional[str],
     max_token_networks: Optional[int],
     secret_registry_from_deployment_file: Optional[str],
@@ -184,6 +206,8 @@ def raiden(
     deployed_contracts_info = deployer.deploy_raiden_contracts(
         max_num_of_token_networks=max_token_networks,
         reuse_secret_registry_from_deploy_file=secret_registry_from_deployment_path,
+        settle_timeout_min=settle_timeout_min,
+        settle_timeout_max=settle_timeout_max,
     )
     deployed_contracts = {
         contract_name: info["address"]

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -18,8 +18,6 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
     CONTRACTS_VERSION,
-    DEPLOY_SETTLE_TIMEOUT_MAX,
-    DEPLOY_SETTLE_TIMEOUT_MIN,
 )
 from raiden_contracts.contract_manager import CompiledContract, DeployedContract, DeployedContracts
 from raiden_contracts.contract_source_manager import ContractSourceManager, contracts_source_path
@@ -135,6 +133,8 @@ class ContractDeployer(ContractVerifier):
         self,
         max_num_of_token_networks: Optional[int],
         reuse_secret_registry_from_deploy_file: Optional[Path],
+        settle_timeout_min: int,
+        settle_timeout_max: int,
     ) -> DeployedContracts:
         """ Deploy all required raiden contracts and return a dict of contract_name:address
 
@@ -176,8 +176,8 @@ class ContractDeployer(ContractVerifier):
         token_network_registry_args = [
             secret_registry.address,
             deployed_contracts["chain_id"],
-            DEPLOY_SETTLE_TIMEOUT_MIN,
-            DEPLOY_SETTLE_TIMEOUT_MAX,
+            settle_timeout_min,
+            settle_timeout_max,
         ]
         if max_num_of_token_networks:
             token_network_registry_args.append(max_num_of_token_networks)

--- a/raiden_contracts/tests/deprecation_switch_testnet.py
+++ b/raiden_contracts/tests/deprecation_switch_testnet.py
@@ -10,6 +10,7 @@ from raiden_contracts.constants import (
     CONTRACT_CUSTOM_TOKEN,
     CONTRACT_TOKEN_NETWORK,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
+    DEPLOY_SETTLE_TIMEOUT_MAX,
     DEPLOY_SETTLE_TIMEOUT_MIN,
     MAX_ETH_CHANNEL_PARTICIPANT,
     MAX_ETH_TOKEN_NETWORK,
@@ -99,7 +100,10 @@ def deprecation_test_setup(
     token_network_deposit_limit: int,
 ) -> Tuple:
     deployed_contracts = deployer.deploy_raiden_contracts(
-        max_num_of_token_networks=1, reuse_secret_registry_from_deploy_file=None
+        max_num_of_token_networks=1,
+        reuse_secret_registry_from_deploy_file=None,
+        settle_timeout_min=DEPLOY_SETTLE_TIMEOUT_MIN,
+        settle_timeout_max=DEPLOY_SETTLE_TIMEOUT_MAX,
     )["contracts"]
 
     token_network_registry_abi = deployer.contract_manager.get_contract_abi(

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -24,6 +24,8 @@ from raiden_contracts.constants import (
     CONTRACT_SERVICE_REGISTRY,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
+    DEPLOY_SETTLE_TIMEOUT_MAX,
+    DEPLOY_SETTLE_TIMEOUT_MIN,
     EMPTY_ADDRESS,
 )
 from raiden_contracts.contract_manager import (
@@ -91,7 +93,10 @@ def deployer_0_4_0(web3: Web3) -> ContractDeployer:
 @pytest.fixture(scope="session")
 def deployed_raiden_info(deployer: ContractDeployer) -> DeployedContracts:
     return deployer.deploy_raiden_contracts(
-        max_num_of_token_networks=1, reuse_secret_registry_from_deploy_file=None
+        max_num_of_token_networks=1,
+        reuse_secret_registry_from_deploy_file=None,
+        settle_timeout_min=DEPLOY_SETTLE_TIMEOUT_MIN,
+        settle_timeout_max=DEPLOY_SETTLE_TIMEOUT_MAX,
     )
 
 
@@ -99,7 +104,10 @@ def deployed_raiden_info(deployer: ContractDeployer) -> DeployedContracts:
 @pytest.fixture(scope="session")
 def deployed_raiden_info2(deployer: ContractDeployer) -> DeployedContracts:
     return deployer.deploy_raiden_contracts(
-        max_num_of_token_networks=1, reuse_secret_registry_from_deploy_file=None
+        max_num_of_token_networks=1,
+        reuse_secret_registry_from_deploy_file=None,
+        settle_timeout_min=DEPLOY_SETTLE_TIMEOUT_MIN,
+        settle_timeout_max=DEPLOY_SETTLE_TIMEOUT_MAX,
     )
 
 
@@ -107,7 +115,10 @@ def deployed_raiden_info2(deployer: ContractDeployer) -> DeployedContracts:
 @pytest.fixture(scope="session")
 def deployed_raiden_info_0_4_0(deployer_0_4_0: ContractDeployer) -> DeployedContracts:
     return deployer_0_4_0.deploy_raiden_contracts(
-        max_num_of_token_networks=None, reuse_secret_registry_from_deploy_file=None
+        max_num_of_token_networks=None,
+        reuse_secret_registry_from_deploy_file=None,
+        settle_timeout_min=DEPLOY_SETTLE_TIMEOUT_MIN,
+        settle_timeout_max=DEPLOY_SETTLE_TIMEOUT_MAX,
     )
 
 
@@ -279,7 +290,12 @@ def test_deploy_script_raiden(
         web3=web3, private_key=get_random_privkey(), gas_limit=GAS_LIMIT, gas_price=1, wait=10
     )
     with pytest.raises(ValidationError):
-        deployer.deploy_raiden_contracts(1, reuse_secret_registry_from_deploy_file=None)
+        deployer.deploy_raiden_contracts(
+            1,
+            reuse_secret_registry_from_deploy_file=None,
+            settle_timeout_min=DEPLOY_SETTLE_TIMEOUT_MIN,
+            settle_timeout_max=DEPLOY_SETTLE_TIMEOUT_MAX,
+        )
 
 
 def test_deploy_raiden_reuse_secret_registry(
@@ -290,7 +306,10 @@ def test_deploy_raiden_reuse_secret_registry(
         previous_deployment_file.write(bytearray(json.dumps(deployed_raiden_info), "ascii"))
         previous_deployment_file.flush()
         new_deployment = deployer.deploy_raiden_contracts(
-            1, reuse_secret_registry_from_deploy_file=Path(previous_deployment_file.name)
+            1,
+            reuse_secret_registry_from_deploy_file=Path(previous_deployment_file.name),
+            settle_timeout_min=DEPLOY_SETTLE_TIMEOUT_MIN,
+            settle_timeout_max=DEPLOY_SETTLE_TIMEOUT_MAX,
         )
         assert (
             new_deployment["contracts"][CONTRACT_SECRET_REGISTRY]
@@ -819,7 +838,10 @@ def test_red_eyes_deployer(web3: Web3) -> None:
         contracts_version="0.4.0",
     )
     deployer.deploy_raiden_contracts(
-        max_num_of_token_networks=None, reuse_secret_registry_from_deploy_file=None
+        max_num_of_token_networks=None,
+        reuse_secret_registry_from_deploy_file=None,
+        settle_timeout_min=DEPLOY_SETTLE_TIMEOUT_MIN,
+        settle_timeout_max=DEPLOY_SETTLE_TIMEOUT_MAX,
     )
 
 


### PR DESCRIPTION
### What this PR does

Changes the deploy script to allow for configurable settlement timeouts

### Why I'm making this PR

The smart contracts deployed for the testnets have a settle timeout that is too high.

### What's tricky about this PR (if any)

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.