### PR TITLE
Test ServiceRegistry deployment with zero supply token

### DIFF
--- a/raiden_contracts/tests/test_service_registry.py
+++ b/raiden_contracts/tests/test_service_registry.py
@@ -384,6 +384,26 @@ def test_parameter_change_on_no_controller(service_registry_without_controller: 
     assert service_registry_without_controller.functions.min_price().call() == DEFAULT_MIN_PRICE
 
 
+def service_registry_with_zero_supply_token(
+    deploy_tester_contract: Callable, zero_supply_custom_token: Contract
+) -> None:
+    """Deployment of ServiceRegistry should fail with a token with zero supply"""
+    with pytest.raises(TransactionFailed, match="total supply zero"):
+        deploy_tester_contract(
+            CONTRACT_SERVICE_REGISTRY,
+            [
+                zero_supply_custom_token.address,
+                EMPTY_ADDRESS,
+                2 ** 90,
+                2 ** 40 - 1,
+                1,
+                2 ** 40 - 1,
+                DEFAULT_MIN_PRICE,
+                DEFAULT_REGISTRATION_DURATION,
+            ],
+        )
+
+
 def service_registry_with_high_numbers(
     deploy_tester_contract: Callable, custom_token: Contract
 ) -> Contract:


### PR DESCRIPTION
fails. This closes https://github.com/raiden-network/raiden-contracts/issues/581

### What this PR does

This PR adds a test about deploying a ServiceRegistry on a token with zero total supply.

### Why I'm making this PR

I came up with this test case when I was drafting https://github.com/raiden-network/raiden-contracts/issues/581 .  This is the last remaining test case in that issue.

### What's tricky about this PR (if any)

I copied and pasted many constructor arguments from a test below.  Perhaps that's a bad practice.

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.