### PR TITLE
Error on unknown contract names

### DIFF
--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -3,10 +3,11 @@ import pprint
 import subprocess
 from pathlib import Path
 from time import sleep
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import click
 import requests
+from click import Context
 from click.exceptions import BadParameter
 from eth_abi import encode_abi
 
@@ -27,7 +28,7 @@ from raiden_contracts.utils.type_aliases import ChainID
 CONTRACT_NAMES_SEPARATED = " | ".join([c.name for c in CONTRACT_LIST])
 
 
-def validate_contract_name(_ctx, _param, value):
+def validate_contract_name(_ctx: Context, _param: Any, value: Optional[str]) -> Optional[str]:
     if value is None:
         return None
     if value in {c.name for c in CONTRACT_LIST}:

--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -7,6 +7,7 @@ from typing import Dict, Optional
 
 import click
 import requests
+from click.exceptions import BadParameter
 from eth_abi import encode_abi
 
 from raiden_contracts.constants import CONTRACT_LIST, DeploymentModule
@@ -26,6 +27,14 @@ from raiden_contracts.utils.type_aliases import ChainID
 CONTRACT_NAMES_SEPARATED = " | ".join([c.name for c in CONTRACT_LIST])
 
 
+def validate_contract_name(_ctx, _param, value):
+    if value is None:
+        return None
+    if value in {c.name for c in CONTRACT_LIST}:
+        return value
+    raise BadParameter(f"unknown contract name {value}")
+
+
 @click.command()
 @click.option("--chain-id", default=3, help="Chain id. E.g. --chain-id 3")
 @click.option("--apikey", required=True, help="A valid Etherscan APIKEY is required.")
@@ -37,6 +46,7 @@ CONTRACT_NAMES_SEPARATED = " | ".join([c.name for c in CONTRACT_LIST])
     default=None,
     help=f"Contract name. Options: {CONTRACT_NAMES_SEPARATED}. "
     " Default is to submit the sources of all contracts.",
+    callback=validate_contract_name,
 )
 def etherscan_verify(
     chain_id: ChainID, apikey: str, guid: Optional[str], contract_name: Optional[str]

--- a/raiden_contracts/tests/test_etherscan_verify.py
+++ b/raiden_contracts/tests/test_etherscan_verify.py
@@ -260,13 +260,12 @@ def test_etherscan_verify_success_after_a_loop() -> None:
 
 def test_etherscan_verify_fail_unknown_contract() -> None:
     """ When invoked with an unknown contract name, etherscan_verify should error """
-    with requests_mock.Mocker() as m:
-        chain_id = 3
-        runner = CliRunner()
-        result = runner.invoke(
-            etherscan_verify,
-            ["--chain-id", str(chain_id), "--apikey", "API", "--contract-name", "Unknown"],
-        )
-        assert result.exit_code != 0
-        assert result.exception
-        assert "unknown contract name" in result.output
+    chain_id = 3
+    runner = CliRunner()
+    result = runner.invoke(
+        etherscan_verify,
+        ["--chain-id", str(chain_id), "--apikey", "API", "--contract-name", "Unknown"],
+    )
+    assert result.exit_code != 0
+    assert result.exception
+    assert "unknown contract name" in result.output

--- a/raiden_contracts/tests/test_etherscan_verify.py
+++ b/raiden_contracts/tests/test_etherscan_verify.py
@@ -150,7 +150,7 @@ def test_etherscan_verify_already_verified() -> None:
         runner = CliRunner()
         result = runner.invoke(
             etherscan_verify,
-            ["--chain-id", str(chain_id), "--apikey", "API", "--contract-name", "SedcretRegistry"],
+            ["--chain-id", str(chain_id), "--apikey", "API", "--contract-name", "SecretRegistry"],
         )
         assert result.exit_code == 0
 
@@ -269,4 +269,4 @@ def test_etherscan_verify_fail_unknown_contract() -> None:
         )
         assert result.exit_code != 0
         assert result.exception
-        assert "unknown contract name" in result.exception.message
+        assert "unknown contract name" in result.output

--- a/raiden_contracts/tests/test_etherscan_verify.py
+++ b/raiden_contracts/tests/test_etherscan_verify.py
@@ -256,3 +256,17 @@ def test_etherscan_verify_success_after_a_loop() -> None:
             ["--chain-id", str(chain_id), "--apikey", "API", "--contract-name", "SecretRegistry"],
         )
         assert result.exit_code == 0
+
+
+def test_etherscan_verify_fail_unknown_contract() -> None:
+    """ When invoked with an unknown contract name, etherscan_verify should error """
+    with requests_mock.Mocker() as m:
+        chain_id = 3
+        runner = CliRunner()
+        result = runner.invoke(
+            etherscan_verify,
+            ["--chain-id", str(chain_id), "--apikey", "API", "--contract-name", "Unknown"],
+        )
+        assert result.exit_code != 0
+        assert result.exception
+        assert "unknown contract name" in result.exception.message

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,3 +21,4 @@ isort
 pipdeptree
 eth-typing<2.0.0
 eth-abi<=1.2.2
+six>=1.12


### PR DESCRIPTION
### What this PR does

This PR modifies etherscan_verify so it raises an error on an unknown contract name.

### Why I'm making this PR

Before this PR the script silently succeeded while not doing anything.  This can be confusing when a user makes a typo.

### What's tricky about this PR (if any)

Nothing.

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.