### PR TITLE
Constructor computes checksums (so users don't need to initialize the object)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Documents changes that result in:
 
 ## Unreleased
 
+- [#1260](https://github.com/raiden-network/raiden-contracts/pull/1260) Simplify the usage of ContractSourceManager. Users don't need to call compute_checksums() to initialize the object.
+
 ## [0.32.0](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.32.0) - 2019-09-25
 
 - The minimum settlement window is now shorter (20 blocks) on test networks.

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -57,7 +57,6 @@ class ContractDeployer(ContractVerifier):
         # Only for current version, because this is the only one with source code
         if self.contracts_version in [None, CONTRACTS_VERSION]:
             contract_manager_source = ContractSourceManager(contracts_source_path())
-            contract_manager_source.checksum_contracts()
             contract_manager_source.verify_precompiled_checksums(self.precompiled_path)
         else:
             LOG.info("Skipped checks against the source code because it is not available.")

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -50,7 +50,6 @@ def test_verification_without_checksum() -> None:
 def test_verification_overall_checksum() -> None:
     """ Tamper with the overall checksum and see failures in verify_precompiled_checksums() """
     manager = ContractSourceManager(contracts_source_path())
-    manager.checksum_contracts()
     manager.verify_precompiled_checksums(contracts_precompiled_path())
 
     assert manager.overall_checksum
@@ -84,7 +83,6 @@ def test_verification_overall_checksum() -> None:
 def test_verification_contracts_checksums() -> None:
     """ Tamper with the contract checksums and see failures in verify_precompiled_checksums() """
     manager = ContractSourceManager(contracts_source_path())
-    manager.checksum_contracts()
     manager.verify_precompiled_checksums(contracts_precompiled_path())
 
     assert manager.contracts_checksums

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -40,13 +40,6 @@ def test_nonexistent_precompiled_path() -> None:
         ContractManager(contracts_precompiled_path(nonexistent_version))
 
 
-def test_verification_without_checksum() -> None:
-    """ Call ContractSourceManager.verify_precompiled_checksums() before computing the checksum """
-    manager = ContractSourceManager(contracts_source_path())
-    with pytest.raises(AttributeError):
-        manager.verify_precompiled_checksums(contracts_precompiled_path())
-
-
 def test_verification_overall_checksum() -> None:
     """ Tamper with the overall checksum and see failures in verify_precompiled_checksums() """
     manager = ContractSourceManager(contracts_source_path())

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ class VerifyContracts(Command):
             contracts_source_path,
         )
         manager = ContractSourceManager(contracts_source_path())
-        manager.checksum_contracts()
         manager.verify_precompiled_checksums(contracts_precompiled_path())
 
 


### PR DESCRIPTION
### What this PR does

This PR makes ContractSourceManager's constructor compute the checksums.  Before this PR, users had to initialize the object by calling `compute_checksums()` before calling some other methods.

### Why I'm making this PR

It's nicer when users don't need to care about the internal states of the class.

### What's tricky about this PR (if any)

I made sure that once initialized `contracts_checksums` and `overall_checksum` do not change.

----

Any reviewer can check these:

* [x] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [x] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [x] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [x] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [x] In Python, use keyword arguments
* [x] Squash unnecessary commits
* [x] Comment commits
* [x] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [x] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [x] The deployment script deploys the new contract.
    * [x] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [x] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [x] Document arguments of functions in natspec
    * [x] Care reentrancy problems
* [x] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.