### PR TITLE
Fix a typo "Parmas"

### DIFF
--- a/raiden_contracts/contract_source_manager.py
+++ b/raiden_contracts/contract_source_manager.py
@@ -26,7 +26,7 @@ class ContractSourceManager:
     """ ContractSourceManager knows how to compile contracts """
 
     def __init__(self, path: Dict[str, Path]) -> None:
-        """ Parmas: a dictionary of directories which contain solidity files to compile """
+        """ Params: path a dictionary of directories which contain solidity files to compile """
         if not isinstance(path, dict):
             raise TypeError("Wrong type of argument given for ContractSourceManager()")
         self.contracts_source_dirs = path

--- a/raiden_contracts/contract_source_manager.py
+++ b/raiden_contracts/contract_source_manager.py
@@ -26,7 +26,7 @@ class ContractSourceManager:
     """ ContractSourceManager knows how to compile contracts """
 
     def __init__(self, path: Dict[str, Path]) -> None:
-        """ Params: path a dictionary of directories which contain solidity files to compile """
+        """ Params: path: a dictionary of directories which contain solidity files to compile """
         if not isinstance(path, dict):
             raise TypeError("Wrong type of argument given for ContractSourceManager()")
         self.contracts_source_dirs = path

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,3 +21,4 @@ isort
 pipdeptree
 eth-typing<2.0.0
 eth-abi<=1.2.2
+six>=1.12


### PR DESCRIPTION
I don't know why but the word Parmas sounded delicious.
In fact it was about Params or parameters.

### What this PR does

This PR replaces a comment "Parmas" with "Params".

### Why I'm making this PR

I was looking at the file blankly when I saw the typo.

### What's tricky about this PR (if any)

Nothing.

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.