### PR TITLE
Fix autopep8 command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ black:
 	black $(BLACK_PARAMS)
 
 autopep8:
-	autopep8 raiden_contracts/
+	autopep8 --in-place --recursive raiden_contracts/
 
 format: autopep8 isort black
 

--- a/raiden_contracts/tests/test_channel_update_transfer.py
+++ b/raiden_contracts/tests/test_channel_update_transfer.py
@@ -723,7 +723,6 @@ def test_update_signature_on_invalid_arguments(
     create_balance_proof_countersignature: Callable,
     create_close_signature_for_no_balance_proof: Callable,
 ) -> None:
-
     """ Call updateNonClosingBalanceProof with signature on invalid argument fails """
     (A, B, C) = get_accounts(3)
     settle_timeout = TEST_SETTLE_TIMEOUT_MIN


### PR DESCRIPTION
Before this comment, `make format` showed
```
[Errno 21] Is a directory: 'raiden_contracts/'
```
This commit fixes the command.
`autopep8` needed `--in-place --recursive` options.

This closes https://github.com/raiden-network/raiden-contracts/issues/1165

### What this PR does

This PR changes `Makefile`. `autopep8` command now gets `--in-place --recursive` options.

### Why I'm making this PR

Before the PR, `make format` showed an error from `autopep8`.

### What's tricky about this PR (if any)

Nothing.

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.