### PR TITLE
Balance proof as a namedtuple instead of a tuple

### DIFF
--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -203,10 +203,16 @@ def close_and_update_channel(
             additional_hash2,
         )
         balance_proof_close_signature_1 = create_balance_proof_countersignature(
-            participant1, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_2
+            participant=participant1,
+            channel_identifier=channel_identifier,
+            msg_type=MessageTypeId.BALANCE_PROOF,
+            **balance_proof_2,
         )
         balance_proof_update_signature_2 = create_balance_proof_countersignature(
-            participant2, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_1
+            participant=participant2,
+            channel_identifier=channel_identifier,
+            msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+            **balance_proof_1,
         )
 
         token_network.functions.closeChannel(

--- a/raiden_contracts/tests/test_channel_close.py
+++ b/raiden_contracts/tests/test_channel_close.py
@@ -132,12 +132,12 @@ def test_close_wrong_signature(
         participant=A,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof,
+        **balance_proof._asdict(),
     )
 
     with pytest.raises(TransactionFailed):
         token_network.functions.closeChannel(
-            channel_identifier, B, A, *balance_proof.values(), closing_signature_A
+            channel_identifier, B, A, *balance_proof._asdict().values(), closing_signature_A
         ).call({"from": A})
 
 
@@ -237,7 +237,7 @@ def test_close_nonce_zero(
         participant=A,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof_B,
+        **balance_proof_B._asdict(),
     )
 
     (
@@ -256,7 +256,7 @@ def test_close_nonce_zero(
     ev_handler = event_handler(token_network)
 
     close_tx = token_network.functions.closeChannel(
-        channel_identifier, B, A, *balance_proof_B.values(), close_sig_A
+        channel_identifier, B, A, *balance_proof_B._asdict().values(), close_sig_A
     ).call_and_transact({"from": A})
 
     ev_handler.add(
@@ -266,7 +266,7 @@ def test_close_nonce_zero(
             channel_identifier=channel_identifier,
             closing_participant=A,
             nonce=0,
-            balance_hash=balance_proof_B["balance_hash"],
+            balance_hash=balance_proof_B.balance_hash,
         ),
     )
     ev_handler.check()
@@ -307,24 +307,24 @@ def test_close_first_argument_is_for_partner_transfer(
         participant=A,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof,
+        **balance_proof._asdict(),
     )
     closing_sig_B = create_balance_proof_countersignature(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof,
+        **balance_proof._asdict(),
     )
 
     # closeChannel fails, if the provided balance proof is from the same participant who closes
     with pytest.raises(TransactionFailed):
         token_network.functions.closeChannel(
-            channel_identifier, B, A, *balance_proof.values(), closing_sig_B
+            channel_identifier, B, A, *balance_proof._asdict().values(), closing_sig_B
         ).call({"from": B})
 
     # Else, closeChannel works with this balance proof
     token_network.functions.closeChannel(
-        channel_identifier, B, A, *balance_proof.values(), closing_sig_A
+        channel_identifier, B, A, *balance_proof._asdict().values(), closing_sig_A
     ).call_and_transact({"from": A})
 
 
@@ -492,11 +492,11 @@ def test_close_channel_state(
         participant=A,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof_B,
+        **balance_proof_B._asdict(),
     )
 
     txn_hash = token_network.functions.closeChannel(
-        channel_identifier, B, A, *balance_proof_B.values(), closing_sig_A
+        channel_identifier, B, A, *balance_proof_B._asdict().values(), closing_sig_A
     ).call_and_transact({"from": A})
 
     # Test that no balances have changed.
@@ -537,7 +537,7 @@ def test_close_channel_state(
         _,
     ) = token_network.functions.getChannelParticipantInfo(channel_identifier, B, A).call()
     assert B_is_the_closer is False
-    assert B_balance_hash == balance_proof_B["balance_hash"]
+    assert B_balance_hash == balance_proof_B.balance_hash
     assert B_nonce == vals_B.nonce
 
 
@@ -610,10 +610,10 @@ def test_close_replay_reopened_channel(
         participant=A,
         channel_identifier=channel_identifier1,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof_B,
+        **balance_proof_B._asdict(),
     )
     token_network.functions.closeChannel(
-        channel_identifier1, B, A, *balance_proof_B.values(), closing_sig_A
+        channel_identifier1, B, A, *balance_proof_B._asdict().values(), closing_sig_A
     ).call_and_transact({"from": A})
     web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
     token_network.functions.settleChannel(
@@ -635,7 +635,7 @@ def test_close_replay_reopened_channel(
     assert channel_identifier1 != channel_identifier2
     with pytest.raises(TransactionFailed):
         token_network.functions.closeChannel(
-            channel_identifier2, B, A, *balance_proof_B.values(), closing_sig_A
+            channel_identifier2, B, A, *balance_proof_B._asdict().values(), closing_sig_A
         ).call({"from": A})
 
     # Balance proof with correct channel_identifier must work
@@ -651,10 +651,10 @@ def test_close_replay_reopened_channel(
         participant=A,
         channel_identifier=channel_identifier2,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof_B2,
+        **balance_proof_B2._asdict(),
     )
     token_network.functions.closeChannel(
-        channel_identifier2, B, A, *balance_proof_B2.values(), closing_sig_A2
+        channel_identifier2, B, A, *balance_proof_B2._asdict().values(), closing_sig_A2
     ).call_and_transact({"from": A})
 
 
@@ -681,11 +681,11 @@ def test_close_channel_event(
         participant=A,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof,
+        **balance_proof._asdict(),
     )
 
     txn_hash = token_network.functions.closeChannel(
-        channel_identifier, B, A, *balance_proof.values(), close_sig
+        channel_identifier, B, A, *balance_proof._asdict().values(), close_sig
     ).call_and_transact({"from": A})
 
     ev_handler.add(
@@ -695,7 +695,7 @@ def test_close_channel_event(
             channel_identifier=channel_identifier,
             closing_participant=A,
             nonce=3,
-            balance_hash=balance_proof["balance_hash"],
+            balance_hash=balance_proof.balance_hash,
         ),
     )
     ev_handler.check()

--- a/raiden_contracts/tests/test_channel_close.py
+++ b/raiden_contracts/tests/test_channel_close.py
@@ -129,7 +129,10 @@ def test_close_wrong_signature(
         channel_identifier, C, transferred_amount, 0, nonce, locksroot
     )
     closing_signature_A = create_balance_proof_countersignature(
-        A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof
+        participant=A,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof,
     )
 
     with pytest.raises(TransactionFailed):
@@ -231,7 +234,10 @@ def test_close_nonce_zero(
         vals_B.locksroot,
     )
     close_sig_A = create_balance_proof_countersignature(
-        A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_B
+        participant=A,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof_B,
     )
 
     (
@@ -298,10 +304,16 @@ def test_close_first_argument_is_for_partner_transfer(
     # Create balance proofs
     balance_proof = create_balance_proof(channel_identifier, B)
     closing_sig_A = create_balance_proof_countersignature(
-        A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof
+        participant=A,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof,
     )
     closing_sig_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof,
     )
 
     # closeChannel fails, if the provided balance proof is from the same participant who closes
@@ -477,7 +489,10 @@ def test_close_channel_state(
         vals_B.locksroot,
     )
     closing_sig_A = create_balance_proof_countersignature(
-        A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_B
+        participant=A,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof_B,
     )
 
     txn_hash = token_network.functions.closeChannel(
@@ -592,7 +607,10 @@ def test_close_replay_reopened_channel(
         values_B.locksroot,
     )
     closing_sig_A = create_balance_proof_countersignature(
-        A, channel_identifier1, MessageTypeId.BALANCE_PROOF, **balance_proof_B
+        participant=A,
+        channel_identifier=channel_identifier1,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof_B,
     )
     token_network.functions.closeChannel(
         channel_identifier1, B, A, *balance_proof_B.values(), closing_sig_A
@@ -630,7 +648,10 @@ def test_close_replay_reopened_channel(
         values_B.locksroot,
     )
     closing_sig_A2 = create_balance_proof_countersignature(
-        A, channel_identifier2, MessageTypeId.BALANCE_PROOF, **balance_proof_B2
+        participant=A,
+        channel_identifier=channel_identifier2,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof_B2,
     )
     token_network.functions.closeChannel(
         channel_identifier2, B, A, *balance_proof_B2.values(), closing_sig_A2
@@ -657,7 +678,10 @@ def test_close_channel_event(
         channel_identifier, B, transferred_amount=5, locked_amount=0, nonce=3
     )
     close_sig = create_balance_proof_countersignature(
-        A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof
+        participant=A,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof,
     )
 
     txn_hash = token_network.functions.closeChannel(

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -193,10 +193,10 @@ def test_settle_single_direct_transfer_for_closing_party(
         participant=A,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof_B,
+        **balance_proof_B._asdict(),
     )
     token_network.functions.closeChannel(
-        channel_identifier, B, A, *balance_proof_B.values(), closing_sig_A
+        channel_identifier, B, A, *balance_proof_B._asdict().values(), closing_sig_A
     ).call_and_transact({"from": A})
 
     pre_balance_A = custom_token.functions.balanceOf(A).call()
@@ -279,10 +279,14 @@ def test_settle_single_direct_transfer_for_counterparty(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_A,
+        **balance_proof_A._asdict(),
     )
     token_network.functions.updateNonClosingBalanceProof(
-        channel_identifier, A, B, *balance_proof_A.values(), balance_proof_update_signature_B
+        channel_identifier,
+        A,
+        B,
+        *balance_proof_A._asdict().values(),
+        balance_proof_update_signature_B,
     ).call_and_transact({"from": B})
 
     pre_balance_A = custom_token.functions.balanceOf(A).call()
@@ -600,20 +604,24 @@ def test_settle_channel_event(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_A,
+        **balance_proof_A._asdict(),
     )
     close_sig_A = create_balance_proof_countersignature(
         participant=A,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof_B,
+        **balance_proof_B._asdict(),
     )
 
     token_network.functions.closeChannel(
-        channel_identifier, B, A, *balance_proof_B.values(), close_sig_A
+        channel_identifier, B, A, *balance_proof_B._asdict().values(), close_sig_A
     ).call_and_transact({"from": A})
     token_network.functions.updateNonClosingBalanceProof(
-        channel_identifier, A, B, *balance_proof_A.values(), balance_proof_update_signature_B
+        channel_identifier,
+        A,
+        B,
+        *balance_proof_A._asdict().values(),
+        balance_proof_update_signature_B,
     ).call_and_transact({"from": B})
 
     web3.testing.mine(settle_timeout + 1)

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -190,10 +190,10 @@ def test_settle_single_direct_transfer_for_closing_party(
         LOCKSROOT_OF_NO_LOCKS,
     )
     closing_sig_A = create_balance_proof_countersignature(
-        A, channel_identifier, MessageTypeId.BALANCE_PROOF, *balance_proof_B
+        A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_B
     )
     token_network.functions.closeChannel(
-        channel_identifier, B, A, *balance_proof_B, closing_sig_A
+        channel_identifier, B, A, *balance_proof_B.values(), closing_sig_A
     ).call_and_transact({"from": A})
 
     pre_balance_A = custom_token.functions.balanceOf(A).call()
@@ -273,10 +273,10 @@ def test_settle_single_direct_transfer_for_counterparty(
     )
 
     balance_proof_update_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, *balance_proof_A
+        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A
     )
     token_network.functions.updateNonClosingBalanceProof(
-        channel_identifier, A, B, *balance_proof_A, balance_proof_update_signature_B
+        channel_identifier, A, B, *balance_proof_A.values(), balance_proof_update_signature_B
     ).call_and_transact({"from": B})
 
     pre_balance_A = custom_token.functions.balanceOf(A).call()
@@ -591,17 +591,17 @@ def test_settle_channel_event(
     balance_proof_A = create_balance_proof(channel_identifier, A, 10, 0, 1, LOCKSROOT_OF_NO_LOCKS)
     balance_proof_B = create_balance_proof(channel_identifier, B, 5, 0, 3, LOCKSROOT_OF_NO_LOCKS)
     balance_proof_update_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, *balance_proof_A
+        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A
     )
     close_sig_A = create_balance_proof_countersignature(
-        A, channel_identifier, MessageTypeId.BALANCE_PROOF, *balance_proof_B
+        A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_B
     )
 
     token_network.functions.closeChannel(
-        channel_identifier, B, A, *balance_proof_B, close_sig_A
+        channel_identifier, B, A, *balance_proof_B.values(), close_sig_A
     ).call_and_transact({"from": A})
     token_network.functions.updateNonClosingBalanceProof(
-        channel_identifier, A, B, *balance_proof_A, balance_proof_update_signature_B
+        channel_identifier, A, B, *balance_proof_A.values(), balance_proof_update_signature_B
     ).call_and_transact({"from": B})
 
     web3.testing.mine(settle_timeout + 1)

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -190,7 +190,10 @@ def test_settle_single_direct_transfer_for_closing_party(
         LOCKSROOT_OF_NO_LOCKS,
     )
     closing_sig_A = create_balance_proof_countersignature(
-        A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_B
+        participant=A,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof_B,
     )
     token_network.functions.closeChannel(
         channel_identifier, B, A, *balance_proof_B.values(), closing_sig_A
@@ -273,7 +276,10 @@ def test_settle_single_direct_transfer_for_counterparty(
     )
 
     balance_proof_update_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_A,
     )
     token_network.functions.updateNonClosingBalanceProof(
         channel_identifier, A, B, *balance_proof_A.values(), balance_proof_update_signature_B
@@ -591,10 +597,16 @@ def test_settle_channel_event(
     balance_proof_A = create_balance_proof(channel_identifier, A, 10, 0, 1, LOCKSROOT_OF_NO_LOCKS)
     balance_proof_B = create_balance_proof(channel_identifier, B, 5, 0, 3, LOCKSROOT_OF_NO_LOCKS)
     balance_proof_update_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_A,
     )
     close_sig_A = create_balance_proof_countersignature(
-        A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_B
+        participant=A,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof_B,
     )
 
     token_network.functions.closeChannel(

--- a/raiden_contracts/tests/test_channel_update_transfer.py
+++ b/raiden_contracts/tests/test_channel_update_transfer.py
@@ -53,7 +53,7 @@ def test_update_call(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_A,
+        **balance_proof_A._asdict(),
     )
 
     # Failure with the zero address instead of A's address
@@ -62,7 +62,7 @@ def test_update_call(
             channel_identifier,
             EMPTY_ADDRESS,
             B,
-            *balance_proof_A.values(),
+            *balance_proof_A._asdict().values(),
             balance_proof_update_signature_B,
         ).call({"from": C})
 
@@ -72,14 +72,14 @@ def test_update_call(
             channel_identifier,
             A,
             EMPTY_ADDRESS,
-            *balance_proof_A.values(),
+            *balance_proof_A._asdict().values(),
             balance_proof_update_signature_B,
         ).call({"from": C})
 
     # Failure with the zero signature
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_A.values(), EMPTY_SIGNATURE
+            channel_identifier, A, B, *balance_proof_A._asdict().values(), EMPTY_SIGNATURE
         ).call({"from": C})
 
     # Failure with the empty balance hash
@@ -89,9 +89,9 @@ def test_update_call(
             A,
             B,
             EMPTY_BALANCE_HASH,
-            balance_proof_A["nonce"],
-            balance_proof_A["additional_hash"],
-            balance_proof_A["original_signature"],
+            balance_proof_A.nonce,
+            balance_proof_A.additional_hash,
+            balance_proof_A.original_signature,
             balance_proof_update_signature_B,
         ).call({"from": C})
 
@@ -101,10 +101,10 @@ def test_update_call(
             channel_identifier,
             A,
             B,
-            balance_proof_A["balance_hash"],
+            balance_proof_A.balance_hash,
             0,
-            balance_proof_A["additional_hash"],
-            balance_proof_A["original_signature"],
+            balance_proof_A.additional_hash,
+            balance_proof_A.original_signature,
             balance_proof_update_signature_B,
         ).call({"from": C})
 
@@ -114,9 +114,9 @@ def test_update_call(
             channel_identifier,
             A,
             B,
-            balance_proof_A["balance_hash"],
-            balance_proof_A["nonce"],
-            balance_proof_A["additional_hash"],
+            balance_proof_A.balance_hash,
+            balance_proof_A.nonce,
+            balance_proof_A.additional_hash,
             EMPTY_SIGNATURE,
             balance_proof_update_signature_B,
         ).call({"from": C})
@@ -126,10 +126,10 @@ def test_update_call(
         channel_identifier,
         A,
         B,
-        balance_proof_A["balance_hash"],
-        balance_proof_A["nonce"],
-        balance_proof_A["additional_hash"],
-        balance_proof_A["original_signature"],
+        balance_proof_A.balance_hash,
+        balance_proof_A.nonce,
+        balance_proof_A.additional_hash,
+        balance_proof_A.original_signature,
         balance_proof_update_signature_B,
     ).call_and_transact({"from": C})
 
@@ -155,12 +155,16 @@ def test_update_nonexistent_fail(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_A,
+        **balance_proof_A._asdict(),
     )
 
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_A.values(), balance_proof_update_signature_B
+            channel_identifier,
+            A,
+            B,
+            *balance_proof_A._asdict().values(),
+            balance_proof_update_signature_B,
         ).call({"from": C})
 
 
@@ -182,7 +186,7 @@ def test_update_notclosed_fail(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_A,
+        **balance_proof_A._asdict(),
     )
 
     (settle_block_number, state) = token_network.functions.getChannelInfo(
@@ -193,7 +197,11 @@ def test_update_notclosed_fail(
 
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_A.values(), balance_proof_update_signature_B
+            channel_identifier,
+            A,
+            B,
+            *balance_proof_A._asdict().values(),
+            balance_proof_update_signature_B,
         ).call({"from": C})
 
 
@@ -217,36 +225,44 @@ def test_update_wrong_nonce_fail(
         participant=A,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof_B,
+        **balance_proof_B._asdict(),
     )
     balance_proof_update_signature_B = create_balance_proof_countersignature(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_A,
+        **balance_proof_A._asdict(),
     )
     txn_hash1 = token_network.functions.closeChannel(
-        channel_identifier, B, A, *balance_proof_B.values(), closing_sig_A
+        channel_identifier, B, A, *balance_proof_B._asdict().values(), closing_sig_A
     ).call_and_transact({"from": A})
 
     token_network.functions.updateNonClosingBalanceProof(
-        channel_identifier, A, B, *balance_proof_A.values(), balance_proof_update_signature_B
+        channel_identifier,
+        A,
+        B,
+        *balance_proof_A._asdict().values(),
+        balance_proof_update_signature_B,
     ).call_and_transact({"from": Delegate})
 
     # updateNonClosingBalanceProof should fail for the same nonce as provided previously
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_A.values(), balance_proof_update_signature_B
+            channel_identifier,
+            A,
+            B,
+            *balance_proof_A._asdict().values(),
+            balance_proof_update_signature_B,
         ).call({"from": Delegate})
     balance_proof_A_same_nonce = create_balance_proof(
-        channel_identifier, A, 12, 2, balance_proof_A["nonce"], fake_bytes(32, "03")
+        channel_identifier, A, 12, 2, balance_proof_A.nonce, fake_bytes(32, "03")
     )
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
             channel_identifier,
             A,
             B,
-            *balance_proof_A_same_nonce.values(),
+            *balance_proof_A_same_nonce._asdict().values(),
             balance_proof_update_signature_B,
         ).call({"from": Delegate})
 
@@ -258,14 +274,14 @@ def test_update_wrong_nonce_fail(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_A_lower_nonce,
+        **balance_proof_A_lower_nonce._asdict(),
     )
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
             channel_identifier,
             A,
             B,
-            *balance_proof_A_lower_nonce.values(),
+            *balance_proof_A_lower_nonce._asdict().values(),
             balance_proof_update_signature_B,
         ).call({"from": A})
 
@@ -297,13 +313,13 @@ def test_update_wrong_signatures(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_A,
+        **balance_proof_A._asdict(),
     )
     balance_proof_update_signature_B_fake = create_balance_proof_countersignature(
         participant=C,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_A,
+        **balance_proof_A._asdict(),
     )
 
     # Close the channel so updateNonClosingBalanceProof() is possible
@@ -324,7 +340,7 @@ def test_update_wrong_signatures(
             channel_identifier,
             A,
             B,
-            *balance_proof_A_fake.values(),
+            *balance_proof_A_fake._asdict().values(),
             balance_proof_update_signature_B,
         ).call({"from": C})
     with pytest.raises(TransactionFailed):
@@ -332,13 +348,17 @@ def test_update_wrong_signatures(
             channel_identifier,
             A,
             B,
-            *balance_proof_A.values(),
+            *balance_proof_A._asdict().values(),
             balance_proof_update_signature_B_fake,
         ).call({"from": C})
 
     # See a success to make sure that the above failures are not spurious
     token_network.functions.updateNonClosingBalanceProof(
-        channel_identifier, A, B, *balance_proof_A.values(), balance_proof_update_signature_B
+        channel_identifier,
+        A,
+        B,
+        *balance_proof_A._asdict().values(),
+        balance_proof_update_signature_B,
     ).call_and_transact({"from": C})
 
 
@@ -366,17 +386,17 @@ def test_update_channel_state(
         participant=A,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof_B,
+        **balance_proof_B._asdict(),
     )
     balance_proof_update_signature_B = create_balance_proof_countersignature(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_A,
+        **balance_proof_A._asdict(),
     )
 
     txn_hash1 = token_network.functions.closeChannel(
-        channel_identifier, B, A, *balance_proof_B.values(), closing_sig_A
+        channel_identifier, B, A, *balance_proof_B._asdict().values(), closing_sig_A
     ).call_and_transact({"from": A})
 
     pre_eth_balance_A = web3.eth.getBalance(A)
@@ -389,7 +409,11 @@ def test_update_channel_state(
     pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
     txn_hash = token_network.functions.updateNonClosingBalanceProof(
-        channel_identifier, A, B, *balance_proof_A.values(), balance_proof_update_signature_B
+        channel_identifier,
+        A,
+        B,
+        *balance_proof_A._asdict().values(),
+        balance_proof_update_signature_B,
     ).call_and_transact({"from": Delegate})
 
     # Test that no balances have changed.
@@ -425,7 +449,7 @@ def test_update_channel_fail_no_offchain_transfers(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_A,
+        **balance_proof_A._asdict(),
     )
 
     closing_sig = create_close_signature_for_no_balance_proof(A, channel_identifier)
@@ -454,7 +478,11 @@ def test_update_channel_fail_no_offchain_transfers(
 
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_A.values(), balance_proof_update_signature_B
+            channel_identifier,
+            A,
+            B,
+            *balance_proof_A._asdict().values(),
+            balance_proof_update_signature_B,
         ).call({"from": B})
 
 
@@ -479,21 +507,25 @@ def test_update_not_allowed_after_settlement_period(
         participant=A,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof_B,
+        **balance_proof_B._asdict(),
     )
     balance_proof_update_signature_B = create_balance_proof_countersignature(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_A,
+        **balance_proof_A._asdict(),
     )
     token_network.functions.closeChannel(
-        channel_identifier, B, A, *balance_proof_B.values(), closing_sig_A
+        channel_identifier, B, A, *balance_proof_B._asdict().values(), closing_sig_A
     ).call_and_transact({"from": A})
     web3.testing.mine(settle_timeout + 1)
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_A.values(), balance_proof_update_signature_B
+            channel_identifier,
+            A,
+            B,
+            *balance_proof_A._asdict().values(),
+            balance_proof_update_signature_B,
         ).call({"from": A})
 
 
@@ -518,7 +550,7 @@ def test_update_not_allowed_for_the_closing_address(
         participant=A,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof_B_0,
+        **balance_proof_B_0._asdict(),
     )
 
     # Later balance proof, higher transferred amount, higher nonce
@@ -529,26 +561,38 @@ def test_update_not_allowed_for_the_closing_address(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_B_1,
+        **balance_proof_B_1._asdict(),
     )
 
     # A closes with the first balance proof
     token_network.functions.closeChannel(
-        channel_identifier, B, A, *balance_proof_B_0.values(), closing_sig_A_0
+        channel_identifier, B, A, *balance_proof_B_0._asdict().values(), closing_sig_A_0
     ).call_and_transact({"from": A})
 
     # Someone wants to update with later balance proof - not possible
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_B_1.values(), balance_proof_update_signature_B
+            channel_identifier,
+            A,
+            B,
+            *balance_proof_B_1._asdict().values(),
+            balance_proof_update_signature_B,
         ).call({"from": A})
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_B_1.values(), balance_proof_update_signature_B
+            channel_identifier,
+            A,
+            B,
+            *balance_proof_B_1._asdict().values(),
+            balance_proof_update_signature_B,
         ).call({"from": B})
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_B_1.values(), balance_proof_update_signature_B
+            channel_identifier,
+            A,
+            B,
+            *balance_proof_B_1._asdict().values(),
+            balance_proof_update_signature_B,
         ).call({"from": M})
 
 
@@ -587,12 +631,17 @@ def test_update_invalid_balance_proof_arguments(
 
     #  Create valid balance_proof
     balance_proof_valid = balance_proof(
-        *create_balance_proof(channel_identifier, A, 10, 0, 2, fake_bytes(32, "02")).values()
+        *create_balance_proof(channel_identifier, A, 10, 0, 2, fake_bytes(32, "02"))
+        ._asdict()
+        .values()
     )
 
     # And a valid nonclosing_signature
     valid_balance_proof_update_signature = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, *balance_proof_valid
+        B,
+        channel_identifier,
+        MessageTypeId.BALANCE_PROOF_UPDATE,
+        *balance_proof_valid._asdict().values(),
     )
 
     #  We test invalid balance proof arguments with valid signatures
@@ -607,7 +656,9 @@ def test_update_invalid_balance_proof_arguments(
             2,
             fake_bytes(32, "02"),
             other_token_network=token_network_test_utils,
-        ).values()
+        )
+        ._asdict()
+        .values()
     )
 
     signature_invalid_token_network = create_balance_proof_countersignature(
@@ -625,13 +676,15 @@ def test_update_invalid_balance_proof_arguments(
             channel_identifier,
             A,
             B,
-            *balance_proof_invalid_token_network,
+            *balance_proof_invalid_token_network._asdict().values(),
             signature_invalid_token_network,
         ).call({"from": B})
 
     #  Create balance_proof for invalid channel participant
     balance_proof_invalid_channel_participant = balance_proof(
-        *create_balance_proof(channel_identifier, C, 10, 0, 2, fake_bytes(32, "02")).values()
+        *create_balance_proof(channel_identifier, C, 10, 0, 2, fake_bytes(32, "02"))
+        ._asdict()
+        .values()
     )
 
     signature_invalid_channel_participant = create_balance_proof_countersignature(
@@ -648,13 +701,15 @@ def test_update_invalid_balance_proof_arguments(
             channel_identifier,
             A,
             B,
-            *balance_proof_invalid_channel_participant,
+            *balance_proof_invalid_channel_participant._asdict().values(),
             signature_invalid_channel_participant,
         ).call({"from": B})
 
     #  Create balance_proof for invalid channel identifier
     balance_proof_invalid_channel_identifier = balance_proof(
-        *create_balance_proof(channel_identifier + 1, A, 10, 0, 2, fake_bytes(32, "02")).values()
+        *create_balance_proof(channel_identifier + 1, A, 10, 0, 2, fake_bytes(32, "02"))
+        ._asdict()
+        .values()
     )
 
     signature_invalid_channel_identifier = create_balance_proof_countersignature(
@@ -671,7 +726,7 @@ def test_update_invalid_balance_proof_arguments(
             channel_identifier,
             A,
             B,
-            *balance_proof_invalid_channel_identifier,
+            *balance_proof_invalid_channel_identifier._asdict().values(),
             signature_invalid_channel_identifier,
         ).call({"from": B})
 
@@ -765,7 +820,11 @@ def test_update_invalid_balance_proof_arguments(
     # Call with same balance_proof and signature on valid arguments still works
 
     token_network.functions.updateNonClosingBalanceProof(
-        channel_identifier, A, B, *balance_proof_valid, valid_balance_proof_update_signature
+        channel_identifier,
+        A,
+        B,
+        *balance_proof_valid._asdict().values(),
+        valid_balance_proof_update_signature,
     ).call_and_transact({"from": B})
 
 
@@ -806,19 +865,25 @@ def test_update_signature_on_invalid_arguments(
     balance_proof_valid = balance_proof(
         *create_balance_proof(
             channel_identifier, A, 10, 0, 2, fake_bytes(32, "02"), fake_bytes(32, "02")
-        ).values()
+        )
+        ._asdict()
+        .values()
     )
 
     signature_invalid_token_network_address = create_balance_proof_countersignature(
         B,
         channel_identifier,
         MessageTypeId.BALANCE_PROOF_UPDATE,
-        *balance_proof_valid,
+        *balance_proof_valid._asdict().values(),
         other_token_network=token_network_test_utils,  # invalid token_network_address
     )
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_valid, signature_invalid_token_network_address
+            channel_identifier,
+            A,
+            B,
+            *balance_proof_valid._asdict().values(),
+            signature_invalid_token_network_address,
         ).call({"from": B})
 
     signature_invalid_participant = create_balance_proof_countersignature(
@@ -832,7 +897,11 @@ def test_update_signature_on_invalid_arguments(
     )
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_valid, signature_invalid_participant
+            channel_identifier,
+            A,
+            B,
+            *balance_proof_valid._asdict().values(),
+            signature_invalid_participant,
         ).call({"from": B})
 
     signature_invalid_channel_identifier = create_balance_proof_countersignature(
@@ -846,7 +915,11 @@ def test_update_signature_on_invalid_arguments(
     )
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_valid, signature_invalid_channel_identifier
+            channel_identifier,
+            A,
+            B,
+            *balance_proof_valid._asdict().values(),
+            signature_invalid_channel_identifier,
         ).call({"from": B})
 
     signature_invalid_balance_hash = create_balance_proof_countersignature(
@@ -860,7 +933,11 @@ def test_update_signature_on_invalid_arguments(
     )
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_valid, signature_invalid_balance_hash
+            channel_identifier,
+            A,
+            B,
+            *balance_proof_valid._asdict().values(),
+            signature_invalid_balance_hash,
         ).call({"from": B})
 
     signature_invalid_nonce = create_balance_proof_countersignature(
@@ -874,7 +951,11 @@ def test_update_signature_on_invalid_arguments(
     )
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_valid, signature_invalid_nonce
+            channel_identifier,
+            A,
+            B,
+            *balance_proof_valid._asdict().values(),
+            signature_invalid_nonce,
         ).call({"from": B})
 
     signature_invalid_additional_hash = create_balance_proof_countersignature(
@@ -888,7 +969,11 @@ def test_update_signature_on_invalid_arguments(
     )
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_valid, signature_invalid_additional_hash
+            channel_identifier,
+            A,
+            B,
+            *balance_proof_valid._asdict().values(),
+            signature_invalid_additional_hash,
         ).call({"from": B})
 
     signature_invalid_closing_signature = create_balance_proof_countersignature(
@@ -902,15 +987,26 @@ def test_update_signature_on_invalid_arguments(
     )
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_valid, signature_invalid_closing_signature
+            channel_identifier,
+            A,
+            B,
+            *balance_proof_valid._asdict().values(),
+            signature_invalid_closing_signature,
         ).call({"from": B})
 
     # Call with same balance_proof and signature on valid arguments works
     balance_proof_update_signature = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, *balance_proof_valid
+        B,
+        channel_identifier,
+        MessageTypeId.BALANCE_PROOF_UPDATE,
+        *balance_proof_valid._asdict().values(),
     )
     token_network.functions.updateNonClosingBalanceProof(
-        channel_identifier, A, B, *balance_proof_valid, balance_proof_update_signature
+        channel_identifier,
+        A,
+        B,
+        *balance_proof_valid._asdict().values(),
+        balance_proof_update_signature,
     ).call_and_transact({"from": B})
 
 
@@ -944,7 +1040,7 @@ def test_update_replay_reopened_channel(
         participant=A,
         channel_identifier=channel_identifier1,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_B,
+        **balance_proof_B._asdict(),
     )
 
     closing_sig = create_close_signature_for_no_balance_proof(B, channel_identifier1)
@@ -960,7 +1056,11 @@ def test_update_replay_reopened_channel(
     ).call_and_transact({"from": B})
 
     token_network.functions.updateNonClosingBalanceProof(
-        channel_identifier1, B, A, *balance_proof_B.values(), balance_proof_update_signature_A
+        channel_identifier1,
+        B,
+        A,
+        *balance_proof_B._asdict().values(),
+        balance_proof_update_signature_A,
     ).call_and_transact({"from": A})
 
     web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
@@ -979,7 +1079,11 @@ def test_update_replay_reopened_channel(
     # Make sure we cannot update balance proofs after settleChannel is called
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier1, B, A, *balance_proof_B.values(), balance_proof_update_signature_A
+            channel_identifier1,
+            B,
+            A,
+            *balance_proof_B._asdict().values(),
+            balance_proof_update_signature_A,
         ).call({"from": A})
 
     # Reopen the channel and make sure we cannot use the old balance proof
@@ -1000,7 +1104,11 @@ def test_update_replay_reopened_channel(
     assert channel_identifier1 != channel_identifier2
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier2, B, A, *balance_proof_B.values(), balance_proof_update_signature_A
+            channel_identifier2,
+            B,
+            A,
+            *balance_proof_B._asdict().values(),
+            balance_proof_update_signature_A,
         ).call({"from": A})
 
     # Correct channel_identifier must work
@@ -1016,11 +1124,15 @@ def test_update_replay_reopened_channel(
         participant=A,
         channel_identifier=channel_identifier2,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_B2,
+        **balance_proof_B2._asdict(),
     )
 
     token_network.functions.updateNonClosingBalanceProof(
-        channel_identifier2, B, A, *balance_proof_B2.values(), balance_proof_update_signature_A2
+        channel_identifier2,
+        B,
+        A,
+        *balance_proof_B2._asdict().values(),
+        balance_proof_update_signature_A2,
     ).call_and_transact({"from": A})
 
 
@@ -1047,27 +1159,31 @@ def test_update_channel_event(
         participant=A,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof_B,
+        **balance_proof_B._asdict(),
     )
     balance_proof_A = create_balance_proof(channel_identifier, A, 2, 0, 1)
     balance_proof_update_signature_B = create_balance_proof_countersignature(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_A,
+        **balance_proof_A._asdict(),
     )
 
     token_network.functions.closeChannel(
-        channel_identifier, B, A, *balance_proof_B.values(), closing_sig_A
+        channel_identifier, B, A, *balance_proof_B._asdict().values(), closing_sig_A
     ).call_and_transact({"from": A})
     txn_hash = token_network.functions.updateNonClosingBalanceProof(
-        channel_identifier, A, B, *balance_proof_A.values(), balance_proof_update_signature_B
+        channel_identifier,
+        A,
+        B,
+        *balance_proof_A._asdict().values(),
+        balance_proof_update_signature_B,
     ).call_and_transact({"from": B})
 
     ev_handler.add(
         txn_hash,
         ChannelEvent.BALANCE_PROOF_UPDATED,
-        check_transfer_updated(channel_identifier, A, 1, balance_proof_A["balance_hash"]),
+        check_transfer_updated(channel_identifier, A, 1, balance_proof_A.balance_hash),
     )
     ev_handler.check()
 
@@ -1077,15 +1193,19 @@ def test_update_channel_event(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_A2,
+        **balance_proof_A2._asdict(),
     )
     txn_hash = token_network.functions.updateNonClosingBalanceProof(
-        channel_identifier, A, B, *balance_proof_A2.values(), balance_proof_update_signature_B2
+        channel_identifier,
+        A,
+        B,
+        *balance_proof_A2._asdict().values(),
+        balance_proof_update_signature_B2,
     ).call_and_transact({"from": B})
 
     ev_handler.add(
         txn_hash,
         ChannelEvent.BALANCE_PROOF_UPDATED,
-        check_transfer_updated(channel_identifier, A, 2, balance_proof_A2["balance_hash"]),
+        check_transfer_updated(channel_identifier, A, 2, balance_proof_A2.balance_hash),
     )
     ev_handler.check()

--- a/raiden_contracts/tests/test_channel_update_transfer.py
+++ b/raiden_contracts/tests/test_channel_update_transfer.py
@@ -50,7 +50,10 @@ def test_update_call(
 
     balance_proof_A = create_balance_proof(channel_identifier, A, 10, 0, 5, fake_bytes(32, "02"))
     balance_proof_update_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_A,
     )
 
     # Failure with the zero address instead of A's address
@@ -149,7 +152,10 @@ def test_update_nonexistent_fail(
 
     balance_proof_A = create_balance_proof(channel_identifier, A, 10, 0, 5, fake_bytes(32, "02"))
     balance_proof_update_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_A,
     )
 
     with pytest.raises(TransactionFailed):
@@ -173,7 +179,10 @@ def test_update_notclosed_fail(
 
     balance_proof_A = create_balance_proof(channel_identifier, A, 10, 0, 5, fake_bytes(32, "02"))
     balance_proof_update_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_A,
     )
 
     (settle_block_number, state) = token_network.functions.getChannelInfo(
@@ -205,10 +214,16 @@ def test_update_wrong_nonce_fail(
     balance_proof_A = create_balance_proof(channel_identifier, A, 10, 0, 5, fake_bytes(32, "02"))
     balance_proof_B = create_balance_proof(channel_identifier, B, 5, 0, 3, fake_bytes(32, "02"))
     closing_sig_A = create_balance_proof_countersignature(
-        A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_B
+        participant=A,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof_B,
     )
     balance_proof_update_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_A,
     )
     txn_hash1 = token_network.functions.closeChannel(
         channel_identifier, B, A, *balance_proof_B.values(), closing_sig_A
@@ -240,7 +255,10 @@ def test_update_wrong_nonce_fail(
     )
 
     balance_proof_update_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A_lower_nonce
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_A_lower_nonce,
     )
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
@@ -276,10 +294,16 @@ def test_update_wrong_signatures(
     )
 
     balance_proof_update_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_A,
     )
     balance_proof_update_signature_B_fake = create_balance_proof_countersignature(
-        C, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A
+        participant=C,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_A,
     )
 
     # Close the channel so updateNonClosingBalanceProof() is possible
@@ -339,10 +363,16 @@ def test_update_channel_state(
     balance_proof_A = create_balance_proof(channel_identifier, A, 10, 0, 5, fake_bytes(32, "02"))
     balance_proof_B = create_balance_proof(channel_identifier, B, 5, 0, 3, fake_bytes(32, "02"))
     closing_sig_A = create_balance_proof_countersignature(
-        A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_B
+        participant=A,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof_B,
     )
     balance_proof_update_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_A,
     )
 
     txn_hash1 = token_network.functions.closeChannel(
@@ -392,7 +422,10 @@ def test_update_channel_fail_no_offchain_transfers(
     channel_identifier = create_channel(A, B)[0]
     balance_proof_A = create_balance_proof(channel_identifier, A, 0, 0, 0)
     balance_proof_update_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_A,
     )
 
     closing_sig = create_close_signature_for_no_balance_proof(A, channel_identifier)
@@ -443,10 +476,16 @@ def test_update_not_allowed_after_settlement_period(
     balance_proof_A = create_balance_proof(channel_identifier, A, 10, 0, 5, fake_bytes(32, "02"))
     balance_proof_B = create_balance_proof(channel_identifier, B, 5, 0, 3, fake_bytes(32, "02"))
     closing_sig_A = create_balance_proof_countersignature(
-        A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_B
+        participant=A,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof_B,
     )
     balance_proof_update_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_A,
     )
     token_network.functions.closeChannel(
         channel_identifier, B, A, *balance_proof_B.values(), closing_sig_A
@@ -476,7 +515,10 @@ def test_update_not_allowed_for_the_closing_address(
     # Some balance proof from B
     balance_proof_B_0 = create_balance_proof(channel_identifier, B, 5, 0, 3, fake_bytes(32, "02"))
     closing_sig_A_0 = create_balance_proof_countersignature(
-        A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_B_0
+        participant=A,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof_B_0,
     )
 
     # Later balance proof, higher transferred amount, higher nonce
@@ -484,7 +526,10 @@ def test_update_not_allowed_for_the_closing_address(
 
     # B's signature on the update message is valid
     balance_proof_update_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_B_1
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_B_1,
     )
 
     # A closes with the first balance proof
@@ -896,7 +941,10 @@ def test_update_replay_reopened_channel(
         values_B.locksroot,
     )
     balance_proof_update_signature_A = create_balance_proof_countersignature(
-        A, channel_identifier1, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_B
+        participant=A,
+        channel_identifier=channel_identifier1,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_B,
     )
 
     closing_sig = create_close_signature_for_no_balance_proof(B, channel_identifier1)
@@ -965,7 +1013,10 @@ def test_update_replay_reopened_channel(
         values_B.locksroot,
     )
     balance_proof_update_signature_A2 = create_balance_proof_countersignature(
-        A, channel_identifier2, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_B2
+        participant=A,
+        channel_identifier=channel_identifier2,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_B2,
     )
 
     token_network.functions.updateNonClosingBalanceProof(
@@ -993,11 +1044,17 @@ def test_update_channel_event(
     channel_deposit(channel_identifier, B, deposit_B, A)
     balance_proof_B = create_balance_proof(channel_identifier, B, 5, 0, 3)
     closing_sig_A = create_balance_proof_countersignature(
-        A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_B
+        participant=A,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof_B,
     )
     balance_proof_A = create_balance_proof(channel_identifier, A, 2, 0, 1)
     balance_proof_update_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_A,
     )
 
     token_network.functions.closeChannel(
@@ -1017,7 +1074,10 @@ def test_update_channel_event(
     # Test event for second balance proof update
     balance_proof_A2 = create_balance_proof(channel_identifier, A, 4, 0, 2)
     balance_proof_update_signature_B2 = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A2
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_A2,
     )
     txn_hash = token_network.functions.updateNonClosingBalanceProof(
         channel_identifier, A, B, *balance_proof_A2.values(), balance_proof_update_signature_B2

--- a/raiden_contracts/tests/test_monitoring_service.py
+++ b/raiden_contracts/tests/test_monitoring_service.py
@@ -63,10 +63,10 @@ def setup_monitor_data(
 
         # Add signatures by non_closing_participant
         closing_signature_A = create_balance_proof_countersignature(
-            A, channel_identifier, MessageTypeId.BALANCE_PROOF, *balance_proof_A
+            A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_A
         )
         non_closing_signature_B = create_balance_proof_countersignature(
-            B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, *balance_proof_B
+            B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_B
         )
         reward_proof_signature = sign_reward_proof(
             privatekey=get_private_key(B),
@@ -80,7 +80,7 @@ def setup_monitor_data(
 
         # close channel
         token_network.functions.closeChannel(
-            channel_identifier, B, A, *balance_proof_A, closing_signature_A
+            channel_identifier, B, A, *balance_proof_A.values(), closing_signature_A
         ).call_and_transact({"from": A})
 
         # calculate when this MS is allowed to monitor
@@ -142,7 +142,7 @@ def test_claimReward_with_settle_call(
     txn_hash = monitoring_service_external.functions.monitor(
         A,
         B,
-        *monitor_data["balance_proof_B"],
+        *monitor_data["balance_proof_B"].values(),
         monitor_data["non_closing_signature"],
         REWARD_AMOUNT,
         token_network.address,
@@ -209,7 +209,7 @@ def test_monitor(
         txn_hash = monitoring_service_external.functions.monitor(
             A,
             B,
-            *monitor_data["balance_proof_B"],
+            *monitor_data["balance_proof_B"].values(),
             monitor_data["non_closing_signature"],
             REWARD_AMOUNT + 1,
             token_network.address,
@@ -222,7 +222,7 @@ def test_monitor(
         txn_hash = monitoring_service_external.functions.monitor(
             A,
             B,
-            *monitor_data["balance_proof_B"],
+            *monitor_data["balance_proof_B"].values(),
             monitor_data["non_closing_signature"],
             REWARD_AMOUNT,
             token_network.address,
@@ -236,7 +236,7 @@ def test_monitor(
     txn_hash = monitoring_service_external.functions.monitor(
         A,
         B,
-        *monitor_data["balance_proof_B"],
+        *monitor_data["balance_proof_B"].values(),
         monitor_data["non_closing_signature"],
         REWARD_AMOUNT,
         token_network.address,
@@ -252,7 +252,7 @@ def test_monitor(
             token_network_address=token_network.address,
             channel_identifier=monitor_data["channel_identifier"],
             reward_amount=REWARD_AMOUNT,
-            nonce=monitor_data["balance_proof_B"][1],
+            nonce=monitor_data["balance_proof_B"]["nonce"],
             ms_address=ms_address,
             raiden_node_address=B,
         ),
@@ -276,7 +276,7 @@ def test_monitor_by_unregistered_service(
         monitoring_service_external.functions.monitor(
             A,
             B,
-            *monitor_data["balance_proof_B"],
+            *monitor_data["balance_proof_B"].values(),
             monitor_data["non_closing_signature"],
             REWARD_AMOUNT,
             token_network.address,
@@ -287,7 +287,7 @@ def test_monitor_by_unregistered_service(
     monitoring_service_external.functions.monitor(
         A,
         B,
-        *monitor_data["balance_proof_B"],
+        *monitor_data["balance_proof_B"].values(),
         monitor_data["non_closing_signature"],
         REWARD_AMOUNT,
         token_network.address,
@@ -315,7 +315,7 @@ def test_monitor_on_wrong_token_network_registry(
         monitoring_service_external.functions.monitor(
             A,
             B,
-            *monitor_data["balance_proof_B"],
+            *monitor_data["balance_proof_B"].values(),
             monitor_data["non_closing_signature"],
             REWARD_AMOUNT,
             token_network_in_another_token_network_registry.address,

--- a/raiden_contracts/tests/test_monitoring_service.py
+++ b/raiden_contracts/tests/test_monitoring_service.py
@@ -66,13 +66,13 @@ def setup_monitor_data(
             participant=A,
             channel_identifier=channel_identifier,
             msg_type=MessageTypeId.BALANCE_PROOF,
-            **balance_proof_A,
+            **balance_proof_A._asdict(),
         )
         non_closing_signature_B = create_balance_proof_countersignature(
             participant=B,
             channel_identifier=channel_identifier,
             msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-            **balance_proof_B,
+            **balance_proof_B._asdict(),
         )
         reward_proof_signature = sign_reward_proof(
             privatekey=get_private_key(B),
@@ -86,7 +86,7 @@ def setup_monitor_data(
 
         # close channel
         token_network.functions.closeChannel(
-            channel_identifier, B, A, *balance_proof_A.values(), closing_signature_A
+            channel_identifier, B, A, *balance_proof_A._asdict().values(), closing_signature_A
         ).call_and_transact({"from": A})
 
         # calculate when this MS is allowed to monitor
@@ -148,7 +148,7 @@ def test_claimReward_with_settle_call(
     txn_hash = monitoring_service_external.functions.monitor(
         A,
         B,
-        *monitor_data["balance_proof_B"].values(),
+        *monitor_data["balance_proof_B"]._asdict().values(),
         monitor_data["non_closing_signature"],
         REWARD_AMOUNT,
         token_network.address,
@@ -215,7 +215,7 @@ def test_monitor(
         txn_hash = monitoring_service_external.functions.monitor(
             A,
             B,
-            *monitor_data["balance_proof_B"].values(),
+            *monitor_data["balance_proof_B"]._asdict().values(),
             monitor_data["non_closing_signature"],
             REWARD_AMOUNT + 1,
             token_network.address,
@@ -228,7 +228,7 @@ def test_monitor(
         txn_hash = monitoring_service_external.functions.monitor(
             A,
             B,
-            *monitor_data["balance_proof_B"].values(),
+            *monitor_data["balance_proof_B"]._asdict().values(),
             monitor_data["non_closing_signature"],
             REWARD_AMOUNT,
             token_network.address,
@@ -242,7 +242,7 @@ def test_monitor(
     txn_hash = monitoring_service_external.functions.monitor(
         A,
         B,
-        *monitor_data["balance_proof_B"].values(),
+        *monitor_data["balance_proof_B"]._asdict().values(),
         monitor_data["non_closing_signature"],
         REWARD_AMOUNT,
         token_network.address,
@@ -258,7 +258,7 @@ def test_monitor(
             token_network_address=token_network.address,
             channel_identifier=monitor_data["channel_identifier"],
             reward_amount=REWARD_AMOUNT,
-            nonce=monitor_data["balance_proof_B"]["nonce"],
+            nonce=monitor_data["balance_proof_B"].nonce,
             ms_address=ms_address,
             raiden_node_address=B,
         ),
@@ -282,7 +282,7 @@ def test_monitor_by_unregistered_service(
         monitoring_service_external.functions.monitor(
             A,
             B,
-            *monitor_data["balance_proof_B"].values(),
+            *monitor_data["balance_proof_B"]._asdict().values(),
             monitor_data["non_closing_signature"],
             REWARD_AMOUNT,
             token_network.address,
@@ -293,7 +293,7 @@ def test_monitor_by_unregistered_service(
     monitoring_service_external.functions.monitor(
         A,
         B,
-        *monitor_data["balance_proof_B"].values(),
+        *monitor_data["balance_proof_B"]._asdict().values(),
         monitor_data["non_closing_signature"],
         REWARD_AMOUNT,
         token_network.address,
@@ -321,7 +321,7 @@ def test_monitor_on_wrong_token_network_registry(
         monitoring_service_external.functions.monitor(
             A,
             B,
-            *monitor_data["balance_proof_B"].values(),
+            *monitor_data["balance_proof_B"]._asdict().values(),
             monitor_data["non_closing_signature"],
             REWARD_AMOUNT,
             token_network_in_another_token_network_registry.address,

--- a/raiden_contracts/tests/test_monitoring_service.py
+++ b/raiden_contracts/tests/test_monitoring_service.py
@@ -63,10 +63,16 @@ def setup_monitor_data(
 
         # Add signatures by non_closing_participant
         closing_signature_A = create_balance_proof_countersignature(
-            A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_A
+            participant=A,
+            channel_identifier=channel_identifier,
+            msg_type=MessageTypeId.BALANCE_PROOF,
+            **balance_proof_A,
         )
         non_closing_signature_B = create_balance_proof_countersignature(
-            B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_B
+            participant=B,
+            channel_identifier=channel_identifier,
+            msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+            **balance_proof_B,
         )
         reward_proof_signature = sign_reward_proof(
             privatekey=get_private_key(B),

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -178,11 +178,17 @@ def print_gas_channel_cycle(
         channel_identifier, A, 10, locked_amount1, 5, locksroot1
     )
     balance_proof_update_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_A
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_A,
     )
     balance_proof_B = create_balance_proof(channel_identifier, B, 5, locked_amount2, 3, locksroot2)
     closing_sig_A = create_balance_proof_countersignature(
-        A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_B
+        participant=A,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof_B,
     )
 
     for lock in pending_transfers_tree1.unlockable:
@@ -269,11 +275,17 @@ def print_gas_monitoring_service(
     # create balance and reward proofs
     balance_proof_A = create_balance_proof(channel_identifier, B, transferred_amount=10, nonce=1)
     closing_sig_A = create_balance_proof_countersignature(
-        A, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_A
+        participant=A,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof_A,
     )
     balance_proof_B = create_balance_proof(channel_identifier, A, transferred_amount=20, nonce=2)
     non_closing_signature_B = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_B
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_B,
     )
     reward_proof_signature = sign_reward_proof(
         privatekey=get_private_key(B),

--- a/raiden_contracts/tests/unit/test_recover_from_signature.py
+++ b/raiden_contracts/tests/unit/test_recover_from_signature.py
@@ -33,15 +33,15 @@ def test_verify(
     channel_identifier = create_channel(A, B)[0]
 
     balance_proof_A = create_balance_proof(channel_identifier, A, 2, 0, 3)
-    signature = balance_proof_A[3]
+    signature = balance_proof_A["original_signature"]
     balance_proof_hash = eth_sign_hash_message(
         pack_balance_proof(
             token_network_address=token_network.address,
             chain_identifier=int(web3.version.network),
             channel_identifier=channel_identifier,
-            balance_hash=balance_proof_A[0],
-            nonce=balance_proof_A[1],
-            additional_hash=balance_proof_A[2],
+            balance_hash=balance_proof_A["balance_hash"],
+            nonce=balance_proof_A["nonce"],
+            additional_hash=balance_proof_A["additional_hash"],
             msg_type=MessageTypeId.BALANCE_PROOF,
         )
     )
@@ -49,15 +49,15 @@ def test_verify(
     assert address == A
 
     balance_proof_B = create_balance_proof(channel_identifier, B, 0, 0, 0)
-    signature = balance_proof_B[3]
+    signature = balance_proof_B["original_signature"]
     balance_proof_hash = eth_sign_hash_message(
         pack_balance_proof(
             token_network_address=token_network.address,
             chain_identifier=int(web3.version.network),
             channel_identifier=channel_identifier,
-            balance_hash=balance_proof_B[0],
-            nonce=balance_proof_B[1],
-            additional_hash=balance_proof_B[2],
+            balance_hash=balance_proof_B["balance_hash"],
+            nonce=balance_proof_B["nonce"],
+            additional_hash=balance_proof_B["additional_hash"],
             msg_type=MessageTypeId.BALANCE_PROOF,
         )
     )
@@ -99,7 +99,7 @@ def test_ecrecover_output(
     (A, B) = get_accounts(2)
     channel_identifier = create_channel(A, B)[0]
     balance_proof_A = create_balance_proof(channel_identifier, A, 2, 0, 3)
-    signature = balance_proof_A[3]
+    signature = balance_proof_A["original_signature"]
     r = signature[:32]
     s = signature[32:64]
     v = signature[64:]
@@ -108,9 +108,9 @@ def test_ecrecover_output(
             token_network_address=token_network.address,
             chain_identifier=int(web3.version.network),
             channel_identifier=channel_identifier,
-            balance_hash=balance_proof_A[0],
-            nonce=balance_proof_A[1],
-            additional_hash=balance_proof_A[2],
+            balance_hash=balance_proof_A["balance_hash"],
+            nonce=balance_proof_A["nonce"],
+            additional_hash=balance_proof_A["additional_hash"],
             msg_type=MessageTypeId.BALANCE_PROOF,
         )
     )

--- a/raiden_contracts/tests/unit/test_recover_from_signature.py
+++ b/raiden_contracts/tests/unit/test_recover_from_signature.py
@@ -33,15 +33,15 @@ def test_verify(
     channel_identifier = create_channel(A, B)[0]
 
     balance_proof_A = create_balance_proof(channel_identifier, A, 2, 0, 3)
-    signature = balance_proof_A["original_signature"]
+    signature = balance_proof_A.original_signature
     balance_proof_hash = eth_sign_hash_message(
         pack_balance_proof(
             token_network_address=token_network.address,
             chain_identifier=int(web3.version.network),
             channel_identifier=channel_identifier,
-            balance_hash=balance_proof_A["balance_hash"],
-            nonce=balance_proof_A["nonce"],
-            additional_hash=balance_proof_A["additional_hash"],
+            balance_hash=balance_proof_A.balance_hash,
+            nonce=balance_proof_A.nonce,
+            additional_hash=balance_proof_A.additional_hash,
             msg_type=MessageTypeId.BALANCE_PROOF,
         )
     )
@@ -49,15 +49,15 @@ def test_verify(
     assert address == A
 
     balance_proof_B = create_balance_proof(channel_identifier, B, 0, 0, 0)
-    signature = balance_proof_B["original_signature"]
+    signature = balance_proof_B.original_signature
     balance_proof_hash = eth_sign_hash_message(
         pack_balance_proof(
             token_network_address=token_network.address,
             chain_identifier=int(web3.version.network),
             channel_identifier=channel_identifier,
-            balance_hash=balance_proof_B["balance_hash"],
-            nonce=balance_proof_B["nonce"],
-            additional_hash=balance_proof_B["additional_hash"],
+            balance_hash=balance_proof_B.balance_hash,
+            nonce=balance_proof_B.nonce,
+            additional_hash=balance_proof_B.additional_hash,
             msg_type=MessageTypeId.BALANCE_PROOF,
         )
     )
@@ -99,7 +99,7 @@ def test_ecrecover_output(
     (A, B) = get_accounts(2)
     channel_identifier = create_channel(A, B)[0]
     balance_proof_A = create_balance_proof(channel_identifier, A, 2, 0, 3)
-    signature = balance_proof_A["original_signature"]
+    signature = balance_proof_A.original_signature
     r = signature[:32]
     s = signature[32:64]
     v = signature[64:]
@@ -108,9 +108,9 @@ def test_ecrecover_output(
             token_network_address=token_network.address,
             chain_identifier=int(web3.version.network),
             channel_identifier=channel_identifier,
-            balance_hash=balance_proof_A["balance_hash"],
-            nonce=balance_proof_A["nonce"],
-            additional_hash=balance_proof_A["additional_hash"],
+            balance_hash=balance_proof_A.balance_hash,
+            nonce=balance_proof_A.nonce,
+            additional_hash=balance_proof_A.additional_hash,
             msg_type=MessageTypeId.BALANCE_PROOF,
         )
     )

--- a/raiden_contracts/tests/unit/test_unit_signatures.py
+++ b/raiden_contracts/tests/unit/test_unit_signatures.py
@@ -91,21 +91,21 @@ def test_recover_address_from_balance_proof(
     assert (
         A
         == token_network_test_signatures.functions.recoverAddressFromBalanceProofPublic(
-            channel_identifier, *balance_proof.values()
+            channel_identifier, *balance_proof._asdict().values()
         ).call()
     )
 
     assert (
         B
         == token_network_test_signatures.functions.recoverAddressFromBalanceProofPublic(
-            channel_identifier, *balance_proof_other_signer.values()
+            channel_identifier, *balance_proof_other_signer._asdict().values()
         ).call()
     )
 
     assert (
         A
         != token_network_test_signatures.functions.recoverAddressFromBalanceProofPublic(
-            channel_identifier, *balance_proof_wrong_token_network.values()
+            channel_identifier, *balance_proof_wrong_token_network._asdict().values()
         ).call()
     )
 
@@ -134,7 +134,7 @@ def test_recover_address_from_balance_proof_update(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof,
+        **balance_proof._asdict(),
         other_token_network=other_token_network,
     )
 
@@ -142,7 +142,7 @@ def test_recover_address_from_balance_proof_update(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof,
+        **balance_proof._asdict(),
     )
 
     balance_proof_signed_B = create_balance_proof(
@@ -152,7 +152,7 @@ def test_recover_address_from_balance_proof_update(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        **balance_proof_signed_B,
+        **balance_proof_signed_B._asdict(),
     )
 
     assert (
@@ -160,7 +160,7 @@ def test_recover_address_from_balance_proof_update(
         == other_token_network.functions.recoverAddressFromBalanceProofCounterSignaturePublic(
             MessageTypeId.BALANCE_PROOF_UPDATE,
             channel_identifier,
-            *balance_proof.values(),
+            *balance_proof._asdict().values(),
             balance_proof_update_signature,
         ).call()
     )
@@ -170,7 +170,7 @@ def test_recover_address_from_balance_proof_update(
         != other_token_network.functions.recoverAddressFromBalanceProofCounterSignaturePublic(
             MessageTypeId.BALANCE_PROOF_UPDATE,
             channel_identifier,
-            *balance_proof.values(),
+            *balance_proof._asdict().values(),
             sig_wrong_token_network,
         ).call()
     )
@@ -180,7 +180,7 @@ def test_recover_address_from_balance_proof_update(
         != other_token_network.functions.recoverAddressFromBalanceProofCounterSignaturePublic(
             MessageTypeId.BALANCE_PROOF_UPDATE,
             channel_identifier,
-            *balance_proof.values(),
+            *balance_proof._asdict().values(),
             balance_proof_update_signature_wrong_signer,
         ).call()
     )
@@ -210,7 +210,7 @@ def test_recover_address_from_balance_proof_close(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof,
+        **balance_proof._asdict(),
         other_token_network=other_token_network,
     )
 
@@ -218,7 +218,7 @@ def test_recover_address_from_balance_proof_close(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof,
+        **balance_proof._asdict(),
     )
 
     balance_proof_signed_B = create_balance_proof(
@@ -228,7 +228,7 @@ def test_recover_address_from_balance_proof_close(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF,
-        **balance_proof_signed_B,
+        **balance_proof_signed_B._asdict(),
     )
 
     assert (
@@ -236,7 +236,7 @@ def test_recover_address_from_balance_proof_close(
         == other_token_network.functions.recoverAddressFromBalanceProofCounterSignaturePublic(
             MessageTypeId.BALANCE_PROOF,
             channel_identifier,
-            *balance_proof.values(),
+            *balance_proof._asdict().values(),
             balance_proof_update_signature,
         ).call()
     )
@@ -246,7 +246,7 @@ def test_recover_address_from_balance_proof_close(
         != other_token_network.functions.recoverAddressFromBalanceProofCounterSignaturePublic(
             MessageTypeId.BALANCE_PROOF,
             channel_identifier,
-            *balance_proof.values(),
+            *balance_proof._asdict().values(),
             sig_wrong_token_network,
         ).call()
     )
@@ -256,7 +256,7 @@ def test_recover_address_from_balance_proof_close(
         != other_token_network.functions.recoverAddressFromBalanceProofCounterSignaturePublic(
             MessageTypeId.BALANCE_PROOF,
             channel_identifier,
-            *balance_proof.values(),
+            *balance_proof._asdict().values(),
             balance_proof_update_signature_wrong_signer,
         ).call()
     )

--- a/raiden_contracts/tests/unit/test_unit_signatures.py
+++ b/raiden_contracts/tests/unit/test_unit_signatures.py
@@ -134,22 +134,25 @@ def test_recover_address_from_balance_proof_update(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        balance_hash=balance_proof["balance_hash"],
-        nonce=balance_proof["nonce"],
-        additional_hash=balance_proof["additional_hash"],
-        original_signature=balance_proof["original_signature"],
+        **balance_proof,
         other_token_network=other_token_network,
     )
 
     sig_wrong_token_network = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof,
     )
 
     balance_proof_signed_B = create_balance_proof(
         channel_identifier, B, other_token_network=other_token_network
     )
     balance_proof_update_signature_wrong_signer = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_signed_B
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        **balance_proof_signed_B,
     )
 
     assert (
@@ -204,22 +207,28 @@ def test_recover_address_from_balance_proof_close(
         channel_identifier, A, other_token_network=other_token_network
     )
     balance_proof_update_signature = create_balance_proof_countersignature(
-        B,
-        channel_identifier,
-        MessageTypeId.BALANCE_PROOF,
-        *balance_proof.values(),
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof,
         other_token_network=other_token_network,
     )
 
     sig_wrong_token_network = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof,
     )
 
     balance_proof_signed_B = create_balance_proof(
         channel_identifier, B, other_token_network=other_token_network
     )
     balance_proof_update_signature_wrong_signer = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_signed_B
+        participant=B,
+        channel_identifier=channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
+        **balance_proof_signed_B,
     )
 
     assert (

--- a/raiden_contracts/tests/unit/test_unit_signatures.py
+++ b/raiden_contracts/tests/unit/test_unit_signatures.py
@@ -91,21 +91,21 @@ def test_recover_address_from_balance_proof(
     assert (
         A
         == token_network_test_signatures.functions.recoverAddressFromBalanceProofPublic(
-            channel_identifier, *balance_proof
+            channel_identifier, *balance_proof.values()
         ).call()
     )
 
     assert (
         B
         == token_network_test_signatures.functions.recoverAddressFromBalanceProofPublic(
-            channel_identifier, *balance_proof_other_signer
+            channel_identifier, *balance_proof_other_signer.values()
         ).call()
     )
 
     assert (
         A
         != token_network_test_signatures.functions.recoverAddressFromBalanceProofPublic(
-            channel_identifier, *balance_proof_wrong_token_network
+            channel_identifier, *balance_proof_wrong_token_network.values()
         ).call()
     )
 
@@ -134,22 +134,22 @@ def test_recover_address_from_balance_proof_update(
         participant=B,
         channel_identifier=channel_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
-        balance_hash=balance_proof[0],
-        nonce=balance_proof[1],
-        additional_hash=balance_proof[2],
-        original_signature=balance_proof[3],
+        balance_hash=balance_proof["balance_hash"],
+        nonce=balance_proof["nonce"],
+        additional_hash=balance_proof["additional_hash"],
+        original_signature=balance_proof["original_signature"],
         other_token_network=other_token_network,
     )
 
     sig_wrong_token_network = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, *balance_proof
+        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof
     )
 
     balance_proof_signed_B = create_balance_proof(
         channel_identifier, B, other_token_network=other_token_network
     )
     balance_proof_update_signature_wrong_signer = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, *balance_proof_signed_B
+        B, channel_identifier, MessageTypeId.BALANCE_PROOF_UPDATE, **balance_proof_signed_B
     )
 
     assert (
@@ -157,7 +157,7 @@ def test_recover_address_from_balance_proof_update(
         == other_token_network.functions.recoverAddressFromBalanceProofCounterSignaturePublic(
             MessageTypeId.BALANCE_PROOF_UPDATE,
             channel_identifier,
-            *balance_proof,
+            *balance_proof.values(),
             balance_proof_update_signature,
         ).call()
     )
@@ -167,7 +167,7 @@ def test_recover_address_from_balance_proof_update(
         != other_token_network.functions.recoverAddressFromBalanceProofCounterSignaturePublic(
             MessageTypeId.BALANCE_PROOF_UPDATE,
             channel_identifier,
-            *balance_proof,
+            *balance_proof.values(),
             sig_wrong_token_network,
         ).call()
     )
@@ -177,7 +177,7 @@ def test_recover_address_from_balance_proof_update(
         != other_token_network.functions.recoverAddressFromBalanceProofCounterSignaturePublic(
             MessageTypeId.BALANCE_PROOF_UPDATE,
             channel_identifier,
-            *balance_proof,
+            *balance_proof.values(),
             balance_proof_update_signature_wrong_signer,
         ).call()
     )
@@ -207,19 +207,19 @@ def test_recover_address_from_balance_proof_close(
         B,
         channel_identifier,
         MessageTypeId.BALANCE_PROOF,
-        *balance_proof,
+        *balance_proof.values(),
         other_token_network=other_token_network,
     )
 
     sig_wrong_token_network = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF, *balance_proof
+        B, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof
     )
 
     balance_proof_signed_B = create_balance_proof(
         channel_identifier, B, other_token_network=other_token_network
     )
     balance_proof_update_signature_wrong_signer = create_balance_proof_countersignature(
-        B, channel_identifier, MessageTypeId.BALANCE_PROOF, *balance_proof_signed_B
+        B, channel_identifier, MessageTypeId.BALANCE_PROOF, **balance_proof_signed_B
     )
 
     assert (
@@ -227,7 +227,7 @@ def test_recover_address_from_balance_proof_close(
         == other_token_network.functions.recoverAddressFromBalanceProofCounterSignaturePublic(
             MessageTypeId.BALANCE_PROOF,
             channel_identifier,
-            *balance_proof,
+            *balance_proof.values(),
             balance_proof_update_signature,
         ).call()
     )
@@ -237,7 +237,7 @@ def test_recover_address_from_balance_proof_close(
         != other_token_network.functions.recoverAddressFromBalanceProofCounterSignaturePublic(
             MessageTypeId.BALANCE_PROOF,
             channel_identifier,
-            *balance_proof,
+            *balance_proof.values(),
             sig_wrong_token_network,
         ).call()
     )
@@ -247,7 +247,7 @@ def test_recover_address_from_balance_proof_close(
         != other_token_network.functions.recoverAddressFromBalanceProofCounterSignaturePublic(
             MessageTypeId.BALANCE_PROOF,
             channel_identifier,
-            *balance_proof,
+            *balance_proof.values(),
             balance_proof_update_signature_wrong_signer,
         ).call()
     )

--- a/raiden_contracts/tests/utils/constants.py
+++ b/raiden_contracts/tests/utils/constants.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+from typing import NamedTuple
 
 from eth_utils.units import units
 
@@ -32,3 +33,10 @@ class TestLockIndex(IntEnum):
     AMOUNT = 1
     SECRETHASH = 2
     SECRET = 3
+
+
+class OnchainBalanceProof(NamedTuple):
+    balance_hash: bytes
+    nonce: int
+    additional_hash: bytes
+    original_signature: bytes


### PR DESCRIPTION
### What this PR does

This PR changes `create_balance_proof()`s return value from a tuple to a dictionary.

### Why I'm making this PR

* accessing tuple elements like `balance_proof[0]` `balance_proof[3]` was less readable than `balance_proof["balance_hash"]`.
* in order to use `**balance_proof` in other function calls, `balance_proof` has to be a dictionary.

### What's tricky about this PR (if any)

The fields of the dictionary have the same name as the parameters of `create_balance_proof_countersignature()`.

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.