### PR TITLE
Deploy contracts with kwargs

### DIFF
--- a/raiden_contracts/tests/fixtures/contracts.py
+++ b/raiden_contracts/tests/fixtures/contracts.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, List, Optional
+from typing import Callable, Dict, List
 
 import pytest
 from eth_tester.exceptions import TransactionFailed
@@ -20,10 +20,10 @@ def deploy_tester_contract(
     """Returns a function that can be used to deploy a named contract,
     using conract manager to compile the bytecode and get the ABI"""
 
-    def f(contract_name: str, args: Optional[List] = None) -> Contract:
+    def f(contract_name: str, **kwargs: Dict) -> Contract:
         json_contract = contracts_manager.get_contract(contract_name)
         contract = deploy_contract(
-            web3, CONTRACT_DEPLOYER_ADDRESS, json_contract["abi"], json_contract["bin"], args
+            web3, CONTRACT_DEPLOYER_ADDRESS, json_contract["abi"], json_contract["bin"], **kwargs
         )
         return contract
 
@@ -35,13 +35,11 @@ def deploy_contract_txhash() -> Callable[..., str]:
     """Returns a function that deploys a compiled contract, returning a txhash"""
 
     def fn(
-        web3: Web3, deployer_address: HexAddress, abi: List, bytecode: str, args: Optional[List]
+        web3: Web3, deployer_address: HexAddress, abi: List, bytecode: str, **kwargs: Dict
     ) -> str:
-        if args is None:
-            args = []
         contract = web3.eth.contract(abi=abi, bytecode=bytecode)
         # Failure does not fire an exception.  Check the receipt for status.
-        return contract.constructor(*args).transact({"from": deployer_address})
+        return contract.constructor(**kwargs).transact({"from": deployer_address})
 
     return fn
 
@@ -51,10 +49,10 @@ def deploy_contract(deploy_contract_txhash: Callable) -> Callable:
     """Returns a function that deploys a compiled contract"""
 
     def fn(
-        web3: Web3, deployer_address: HexAddress, abi: List, bytecode: str, args: List
+        web3: Web3, deployer_address: HexAddress, abi: List, bytecode: str, **kwargs: Dict
     ) -> Contract:
         contract = web3.eth.contract(abi=abi, bytecode=bytecode)
-        txhash = deploy_contract_txhash(web3, deployer_address, abi, bytecode, args)
+        txhash = deploy_contract_txhash(web3, deployer_address, abi, bytecode, **kwargs)
         contract_address = web3.eth.getTransactionReceipt(txhash).contractAddress
         web3.testing.mine(1)
 
@@ -73,10 +71,10 @@ def deploy_tester_contract_txhash(
     """Returns a function that can be used to deploy a named contract,
     but returning txhash only"""
 
-    def f(contract_name: str, args: Optional[List] = None) -> str:
+    def f(contract_name: str, **kwargs: Dict) -> str:
         json_contract = contracts_manager.get_contract(contract_name)
         txhash = deploy_contract_txhash(
-            web3, CONTRACT_DEPLOYER_ADDRESS, json_contract["abi"], json_contract["bin"], args
+            web3, CONTRACT_DEPLOYER_ADDRESS, json_contract["abi"], json_contract["bin"], **kwargs
         )
         return txhash
 

--- a/raiden_contracts/tests/fixtures/deposit_fixtures.py
+++ b/raiden_contracts/tests/fixtures/deposit_fixtures.py
@@ -1,4 +1,4 @@
-from typing import Callable, List
+from typing import Callable, Dict
 
 import pytest
 from web3.contract import Contract
@@ -10,7 +10,7 @@ from raiden_contracts.constants import CONTRACT_DEPOSIT
 def get_deposit_contract(deploy_tester_contract: Callable) -> Callable:
     """Deploy a Deposit contract with the given arguments"""
 
-    def get(arguments: List) -> Contract:
-        return deploy_tester_contract(CONTRACT_DEPOSIT, arguments)
+    def get(**arguments: Dict) -> Contract:
+        return deploy_tester_contract(CONTRACT_DEPOSIT, **arguments)
 
     return get

--- a/raiden_contracts/tests/fixtures/monitoring_service.py
+++ b/raiden_contracts/tests/fixtures/monitoring_service.py
@@ -14,12 +14,10 @@ def monitoring_service_external(
 ) -> Contract:
     return deploy_tester_contract(
         CONTRACT_MONITORING_SERVICE,
-        [
-            custom_token.address,
-            service_registry.address,
-            uninitialized_user_deposit_contract.address,
-            token_network_registry_contract.address,
-        ],
+        _token_address=custom_token.address,
+        _service_registry_address=service_registry.address,
+        _udc_address=uninitialized_user_deposit_contract.address,
+        _token_network_registry_address=token_network_registry_contract.address,
     )
 
 
@@ -33,10 +31,8 @@ def monitoring_service_internals(
 ) -> Contract:
     return deploy_tester_contract(
         "MonitoringServiceInternalsTest",
-        [
-            custom_token.address,
-            service_registry.address,
-            uninitialized_user_deposit_contract.address,
-            token_network_registry_contract.address,
-        ],
+        _token_address=custom_token.address,
+        _service_registry_address=service_registry.address,
+        _udc_address=uninitialized_user_deposit_contract.address,
+        _token_network_registry_address=token_network_registry_contract.address,
     )

--- a/raiden_contracts/tests/fixtures/one_to_n.py
+++ b/raiden_contracts/tests/fixtures/one_to_n.py
@@ -19,7 +19,9 @@ def one_to_n_contract(
     chain_id = int(web3.version.network)
     return deploy_tester_contract(
         CONTRACT_ONE_TO_N,
-        [uninitialized_user_deposit_contract.address, chain_id, service_registry.address],
+        _deposit_contract=uninitialized_user_deposit_contract.address,
+        _chain_id=chain_id,
+        _service_registry_contract=service_registry.address,
     )
 
 
@@ -33,7 +35,9 @@ def one_to_n_internals(
     chain_id = int(web3.version.network)
     return deploy_tester_contract(
         "OneToNInternalsTest",
-        [uninitialized_user_deposit_contract.address, chain_id, service_registry.address],
+        _deposit_contract=uninitialized_user_deposit_contract.address,
+        _chain_id=chain_id,
+        _service_registry_contract=service_registry.address,
     )
 
 

--- a/raiden_contracts/tests/fixtures/service_registry_fixtures.py
+++ b/raiden_contracts/tests/fixtures/service_registry_fixtures.py
@@ -18,16 +18,14 @@ from raiden_contracts.tests.utils import (
 def service_registry(deploy_tester_contract: Callable, custom_token: Contract) -> Contract:
     return deploy_tester_contract(
         CONTRACT_SERVICE_REGISTRY,
-        [
-            custom_token.address,
-            CONTRACT_DEPLOYER_ADDRESS,
-            int(3000e18),
-            DEFAULT_BUMP_NUMERATOR,
-            DEFAULT_BUMP_DENOMINATOR,
-            DEFAULT_DECAY_CONSTANT,
-            DEFAULT_MIN_PRICE,
-            DEFAULT_REGISTRATION_DURATION,
-        ],
+        _token_for_registration=custom_token.address,
+        _controller=CONTRACT_DEPLOYER_ADDRESS,
+        _initial_price=int(3000e18),
+        _price_bump_numerator=DEFAULT_BUMP_NUMERATOR,
+        _price_bump_denominator=DEFAULT_BUMP_DENOMINATOR,
+        _decay_constant=DEFAULT_DECAY_CONSTANT,
+        _min_price=DEFAULT_MIN_PRICE,
+        _registration_duration=DEFAULT_REGISTRATION_DURATION,
     )
 
 
@@ -37,14 +35,12 @@ def service_registry_without_controller(
 ) -> Contract:
     return deploy_tester_contract(
         CONTRACT_SERVICE_REGISTRY,
-        [
-            custom_token.address,
-            EMPTY_ADDRESS,
-            3000 * (10 ** 18),
-            DEFAULT_BUMP_NUMERATOR,
-            DEFAULT_BUMP_DENOMINATOR,
-            DEFAULT_DECAY_CONSTANT,
-            DEFAULT_MIN_PRICE,
-            DEFAULT_REGISTRATION_DURATION,
-        ],
+        _token_for_registration=custom_token.address,
+        _controller=EMPTY_ADDRESS,
+        _initial_price=3000 * (10 ** 18),
+        _price_bump_numerator=DEFAULT_BUMP_NUMERATOR,
+        _price_bump_denominator=DEFAULT_BUMP_DENOMINATOR,
+        _decay_constant=DEFAULT_DECAY_CONSTANT,
+        _min_price=DEFAULT_MIN_PRICE,
+        _registration_duration=DEFAULT_REGISTRATION_DURATION,
     )

--- a/raiden_contracts/tests/fixtures/test_contracts.py
+++ b/raiden_contracts/tests/fixtures/test_contracts.py
@@ -35,13 +35,11 @@ def token_network_test_signatures(
 ) -> Contract:
     return deploy_tester_contract(
         "TokenNetworkSignatureTest",
-        [
-            custom_token.address,
-            secret_registry_contract.address,
-            int(web3.version.network),
-            TEST_SETTLE_TIMEOUT_MIN,
-            TEST_SETTLE_TIMEOUT_MAX,
-        ],
+        _token_address=custom_token.address,
+        _secret_registry=secret_registry_contract.address,
+        _chain_id=int(web3.version.network),
+        _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+        _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
     )
 
 
@@ -54,11 +52,9 @@ def token_network_test_utils(
 ) -> Contract:
     return deploy_tester_contract(
         "TokenNetworkUtilsTest",
-        [
-            custom_token.address,
-            secret_registry_contract.address,
-            int(web3.version.network),
-            TEST_SETTLE_TIMEOUT_MIN,
-            TEST_SETTLE_TIMEOUT_MAX,
-        ],
+        _token_address=custom_token.address,
+        _secret_registry=secret_registry_contract.address,
+        _chain_id=int(web3.version.network),
+        _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+        _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
     )

--- a/raiden_contracts/tests/fixtures/token.py
+++ b/raiden_contracts/tests/fixtures/token.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Tuple
+from typing import Callable, Dict
 
 import pytest
 from web3.contract import Contract
@@ -9,16 +9,21 @@ CUSTOM_TOKEN_TOTAL_SUPPLY = 10 ** 26
 
 
 @pytest.fixture(scope="session")
-def token_args() -> Tuple:
-    return (CUSTOM_TOKEN_TOTAL_SUPPLY, 18, CONTRACT_CUSTOM_TOKEN, "TKN")
+def token_args() -> Dict:
+    return {
+        "initial_supply": CUSTOM_TOKEN_TOTAL_SUPPLY,
+        "decimal_units": 18,
+        "token_name": CONTRACT_CUSTOM_TOKEN,
+        "token_symbol": "TKN",
+    }
 
 
 @pytest.fixture(scope="session")
-def custom_token_factory(deploy_tester_contract: Callable, token_args: List) -> Callable:
+def custom_token_factory(deploy_tester_contract: Callable, token_args: Dict) -> Callable:
     """A function that deploys a CustomToken contract"""
 
     def f() -> Contract:
-        return deploy_tester_contract(CONTRACT_CUSTOM_TOKEN, token_args)
+        return deploy_tester_contract(CONTRACT_CUSTOM_TOKEN, **token_args)
 
     return f
 
@@ -36,21 +41,22 @@ def zero_supply_custom_token(deploy_tester_contract: Callable) -> Contract:
 
 
 @pytest.fixture()
-def human_standard_token(deploy_token_contract: Callable, token_args: List) -> Contract:
+def human_standard_token(deploy_token_contract: Callable, token_args: Dict) -> Contract:
     """Deploy HumanStandardToken contract"""
-    return deploy_token_contract(*token_args)
+    return deploy_token_contract(
+        _initialAmount=token_args["initial_supply"],
+        _decimalUnits=token_args["decimal_units"],
+        _tokenName=token_args["token_name"],
+        _tokenSymbol=token_args["token_symbol"],
+    )
 
 
 @pytest.fixture
 def deploy_token_contract(deploy_tester_contract: Contract) -> Callable:
     """Returns a function that deploys a generic HumanStandardToken contract"""
 
-    def f(initial_amount: int, decimals: int, token_name: str, token_symbol: str) -> Contract:
-        assert initial_amount > 0
-        assert decimals > 0
-        return deploy_tester_contract(
-            CONTRACT_HUMAN_STANDARD_TOKEN, [initial_amount, decimals, token_name, token_symbol]
-        )
+    def f(**args: Dict) -> Contract:
+        return deploy_tester_contract(CONTRACT_HUMAN_STANDARD_TOKEN, **args)
 
     return f
 

--- a/raiden_contracts/tests/fixtures/token_network_fixtures.py
+++ b/raiden_contracts/tests/fixtures/token_network_fixtures.py
@@ -1,4 +1,4 @@
-from typing import Callable, List
+from typing import Callable, Dict
 
 import pytest
 from eth_typing import HexAddress
@@ -24,8 +24,8 @@ snapshot_before_token_network = None
 def get_token_network(deploy_tester_contract: Callable) -> Callable:
     """Deploy a token network as a separate contract (registry is not used)"""
 
-    def get(arguments: List) -> Contract:
-        return deploy_tester_contract(CONTRACT_TOKEN_NETWORK, arguments)
+    def get(**arguments: Dict) -> Contract:
+        return deploy_tester_contract(CONTRACT_TOKEN_NETWORK, **arguments)
 
     return get
 
@@ -142,14 +142,12 @@ def token_network_external(
     token_network_deposit_limit: int,
 ) -> Contract:
     return get_token_network(
-        [
-            custom_token.address,
-            secret_registry_contract.address,
-            int(web3.version.network),
-            TEST_SETTLE_TIMEOUT_MIN,
-            TEST_SETTLE_TIMEOUT_MAX,
-            CONTRACT_DEPLOYER_ADDRESS,
-            channel_participant_deposit_limit,
-            token_network_deposit_limit,
-        ]
+        _token_address=custom_token.address,
+        _secret_registry=secret_registry_contract.address,
+        _chain_id=int(web3.version.network),
+        _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+        _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
+        _deprecation_executor=CONTRACT_DEPLOYER_ADDRESS,
+        _channel_participant_deposit_limit=channel_participant_deposit_limit,
+        _token_network_deposit_limit=token_network_deposit_limit,
     )

--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Collection, List
+from typing import Callable, Dict
 
 import pytest
 from eth_typing import HexAddress
@@ -20,8 +20,8 @@ from raiden_contracts.utils.transaction import check_successful_tx
 
 @pytest.fixture()
 def get_token_network_registry(deploy_tester_contract: Contract) -> Callable:
-    def get(arguments: Collection[Any]) -> Contract:
-        return deploy_tester_contract(CONTRACT_TOKEN_NETWORK_REGISTRY, arguments)
+    def get(**arguments: Dict) -> Contract:
+        return deploy_tester_contract(CONTRACT_TOKEN_NETWORK_REGISTRY, **arguments)
 
     return get
 
@@ -29,35 +29,35 @@ def get_token_network_registry(deploy_tester_contract: Contract) -> Callable:
 @pytest.fixture(scope="session")
 def token_network_registry_constructor_args(
     web3: Web3, secret_registry_contract: Contract
-) -> List:
-    return [
-        secret_registry_contract.address,
-        int(web3.version.network),
-        TEST_SETTLE_TIMEOUT_MIN,
-        TEST_SETTLE_TIMEOUT_MAX,
-        1,
-    ]
+) -> Dict:
+    return {
+        "_secret_registry_address": secret_registry_contract.address,
+        "_chain_id": int(web3.version.network),
+        "_settlement_timeout_min": TEST_SETTLE_TIMEOUT_MIN,
+        "_settlement_timeout_max": TEST_SETTLE_TIMEOUT_MAX,
+        "_max_token_networks": 1,
+    }
 
 
 @pytest.fixture(scope="session")
 def token_network_registry_contract(
-    deploy_tester_contract: Callable, token_network_registry_constructor_args: List
+    deploy_tester_contract: Callable, token_network_registry_constructor_args: Dict
 ) -> Contract:
     """Deployed TokenNetworkRegistry contract"""
     return deploy_tester_contract(
-        CONTRACT_TOKEN_NETWORK_REGISTRY, token_network_registry_constructor_args
+        CONTRACT_TOKEN_NETWORK_REGISTRY, **token_network_registry_constructor_args
     )
 
 
 @pytest.fixture(scope="session")
 def token_network_registry_contract2(
-    deploy_tester_contract: Callable, token_network_registry_constructor_args: List
+    deploy_tester_contract: Callable, token_network_registry_constructor_args: Dict
 ) -> Contract:
     """Another deployed TokenNetworkRegistry contract
 
     to which service payment contracts should not collaborate."""
     return deploy_tester_contract(
-        CONTRACT_TOKEN_NETWORK_REGISTRY, token_network_registry_constructor_args
+        CONTRACT_TOKEN_NETWORK_REGISTRY, **token_network_registry_constructor_args
     )
 
 

--- a/raiden_contracts/tests/fixtures/user_deposit.py
+++ b/raiden_contracts/tests/fixtures/user_deposit.py
@@ -18,7 +18,9 @@ def uninitialized_user_deposit_contract(
     deploy_tester_contract: Callable, custom_token: Contract, user_deposit_whole_balance_limit: int
 ) -> Contract:
     return deploy_tester_contract(
-        CONTRACT_USER_DEPOSIT, [custom_token.address, user_deposit_whole_balance_limit]
+        CONTRACT_USER_DEPOSIT,
+        _token_address=custom_token.address,
+        _whole_balance_limit=user_deposit_whole_balance_limit,
     )
 
 
@@ -38,7 +40,9 @@ def user_deposit_contract(
 def udc_transfer_contract(
     deploy_tester_contract: Callable, uninitialized_user_deposit_contract: Contract
 ) -> Contract:
-    return deploy_tester_contract("UDCTransfer", [uninitialized_user_deposit_contract.address])
+    return deploy_tester_contract(
+        "UDCTransfer", udc_address=uninitialized_user_deposit_contract.address
+    )
 
 
 @pytest.fixture

--- a/raiden_contracts/tests/test_contract_limits.py
+++ b/raiden_contracts/tests/test_contract_limits.py
@@ -25,13 +25,11 @@ def test_register_three_but_not_four(
 ) -> None:
     """ Check that TokenNetworkRegistry observes the max number of tokens """
     token_network_registry = get_token_network_registry(
-        [
-            secret_registry_contract.address,
-            int(web3.version.network),
-            TEST_SETTLE_TIMEOUT_MIN,
-            TEST_SETTLE_TIMEOUT_MAX,
-            3,
-        ]
+        _secret_registry_address=secret_registry_contract.address,
+        _chain_id=int(web3.version.network),
+        _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+        _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
+        _max_token_networks=3,
     )
     assert token_network_registry.functions.max_token_networks().call() == 3
     token0 = custom_token_factory()

--- a/raiden_contracts/tests/test_deprecation_switch.py
+++ b/raiden_contracts/tests/test_deprecation_switch.py
@@ -47,13 +47,11 @@ def test_deprecation_executor(
         deprecation_executor,
         json_contract["abi"],
         json_contract["bin"],
-        [
-            secret_registry_contract.address,
-            int(web3.version.network),
-            TEST_SETTLE_TIMEOUT_MIN,
-            TEST_SETTLE_TIMEOUT_MAX,
-            1,
-        ],
+        _secret_registry_address=secret_registry_contract.address,
+        _chain_id=int(web3.version.network),
+        _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+        _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
+        _max_token_networks=1,
     )
 
     # Make sure deployer is deprecation_executor

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -72,13 +72,11 @@ def print_gas_token_network_registry(
     """ Abusing pytest to print the deployment gas cost of TokenNetworkRegistry """
     txhash = deploy_tester_contract_txhash(
         CONTRACT_TOKEN_NETWORK_REGISTRY,
-        [
-            secret_registry_contract.address,
-            int(web3.version.network),
-            TEST_SETTLE_TIMEOUT_MIN,
-            TEST_SETTLE_TIMEOUT_MAX,
-            10,
-        ],
+        _secret_registry_address=secret_registry_contract.address,
+        _chain_id=int(web3.version.network),
+        _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+        _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
+        _max_token_networks=10,
     )
     print_gas(txhash, CONTRACT_TOKEN_NETWORK_REGISTRY + " DEPLOYMENT")
 
@@ -98,16 +96,14 @@ def print_gas_token_network_deployment(
     deprecation_executor = get_accounts(1)[0]
     txhash = deploy_tester_contract_txhash(
         CONTRACT_TOKEN_NETWORK,
-        [
-            custom_token.address,
-            secret_registry_contract.address,
-            int(web3.version.network),
-            TEST_SETTLE_TIMEOUT_MIN,
-            TEST_SETTLE_TIMEOUT_MAX,
-            deprecation_executor,
-            channel_participant_deposit_limit,
-            token_network_deposit_limit,
-        ],
+        _token_address=custom_token.address,
+        _secret_registry=secret_registry_contract.address,
+        _chain_id=int(web3.version.network),
+        _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+        _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
+        _deprecation_executor=deprecation_executor,
+        _channel_participant_deposit_limit=channel_participant_deposit_limit,
+        _token_network_deposit_limit=token_network_deposit_limit,
     )
     print_gas(txhash, CONTRACT_TOKEN_NETWORK + " DEPLOYMENT")
 
@@ -119,10 +115,10 @@ def print_gas_token_network_create(
     get_token_network_registry: Callable,
     channel_participant_deposit_limit: int,
     token_network_deposit_limit: int,
-    token_network_registry_constructor_args: List,
+    token_network_registry_constructor_args: Dict,
 ) -> None:
     """ Abusing pytest to print gas cost of TokenNetworkRegistry's createERC20TokenNetwork() """
-    registry = get_token_network_registry(token_network_registry_constructor_args)
+    registry = get_token_network_registry(**token_network_registry_constructor_args)
     txn_hash = registry.functions.createERC20TokenNetwork(
         custom_token.address, channel_participant_deposit_limit, token_network_deposit_limit
     ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})

--- a/raiden_contracts/tests/test_service_registry.py
+++ b/raiden_contracts/tests/test_service_registry.py
@@ -33,7 +33,9 @@ def test_deposit_contract(
     """Deposit contract with zero-deadline should release the deposit immediately"""
     (A,) = get_accounts(1)
     custom_token.functions.mint(100).call_and_transact({"from": A})
-    depo = get_deposit_contract([custom_token.address, 0, A, A])
+    depo = get_deposit_contract(
+        _token=custom_token.address, _release_at=0, _withdrawer=A, _service_registry=A
+    )
     custom_token.functions.transfer(depo.address, 100).call_and_transact({"from": A})
     assert custom_token.functions.balanceOf(A).call() == 0
     assert custom_token.functions.balanceOf(depo.address).call() == 100
@@ -48,7 +50,9 @@ def test_deposit_contract_too_early_withdraw(
     """Deposit contract with some deadline should not release the deposit immediately"""
     (A,) = get_accounts(1)
     custom_token.functions.mint(100).call_and_transact({"from": A})
-    depo = get_deposit_contract([custom_token.address, UINT256_MAX, A, A])
+    depo = get_deposit_contract(
+        _token=custom_token.address, _release_at=UINT256_MAX, _withdrawer=A, _service_registry=A
+    )
     custom_token.functions.transfer(depo.address, 100).call_and_transact({"from": A})
     assert custom_token.functions.balanceOf(A).call() == 0
     assert custom_token.functions.balanceOf(depo.address).call() == 100
@@ -474,14 +478,12 @@ def test_deploying_service_registry_with_denominator_zero(
     with pytest.raises(TransactionFailed, match="deployment failed"):
         deploy_tester_contract(
             CONTRACT_SERVICE_REGISTRY,
-            [
-                custom_token.address,
-                CONTRACT_DEPLOYER_ADDRESS,
-                int(3000e18),
-                DEFAULT_BUMP_NUMERATOR,
-                0,  # instead of DEFAULT_BUMP_DENOMINATOR
-                DEFAULT_DECAY_CONSTANT,
-                DEFAULT_MIN_PRICE,
-                DEFAULT_REGISTRATION_DURATION,
-            ],
+            _token_for_registration=custom_token.address,
+            _controller=CONTRACT_DEPLOYER_ADDRESS,
+            _initial_price=int(3000e18),
+            _price_bump_numerator=DEFAULT_BUMP_NUMERATOR,
+            _price_bump_denominator=0,  # instead of DEFAULT_BUMP_DENOMINATOR
+            _decay_constant=DEFAULT_DECAY_CONSTANT,
+            _min_price=DEFAULT_MIN_PRICE,
+            _registration_duration=DEFAULT_REGISTRATION_DURATION,
         )

--- a/raiden_contracts/tests/test_token_network.py
+++ b/raiden_contracts/tests/test_token_network.py
@@ -232,190 +232,164 @@ def test_constructor_call(
     # failures with Ethereum addresses that don't contain a Token contract
     with pytest.raises(TransactionFailed):
         get_token_network(
-            [
-                EMPTY_ADDRESS,
-                secret_registry_contract.address,
-                chain_id,
-                TEST_SETTLE_TIMEOUT_MIN,
-                TEST_SETTLE_TIMEOUT_MAX,
-                deprecation_executor,
-                channel_participant_deposit_limit,
-                token_network_deposit_limit,
-            ]
+            _token_address=EMPTY_ADDRESS,
+            _secret_registry=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+            _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
+            _deprecation_executor=deprecation_executor,
+            _channel_participant_deposit_limit=channel_participant_deposit_limit,
+            _token_network_deposit_limit=token_network_deposit_limit,
         )
     with pytest.raises(TransactionFailed):
         get_token_network(
-            [
-                A,
-                secret_registry_contract.address,
-                chain_id,
-                TEST_SETTLE_TIMEOUT_MIN,
-                TEST_SETTLE_TIMEOUT_MAX,
-                deprecation_executor,
-                channel_participant_deposit_limit,
-                token_network_deposit_limit,
-            ]
+            _token_address=A,
+            _secret_registry=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+            _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
+            _deprecation_executor=deprecation_executor,
+            _channel_participant_deposit_limit=channel_participant_deposit_limit,
+            _token_network_deposit_limit=token_network_deposit_limit,
         )
     with pytest.raises(TransactionFailed):
         get_token_network(
-            [
-                secret_registry_contract.address,
-                secret_registry_contract.address,
-                chain_id,
-                TEST_SETTLE_TIMEOUT_MIN,
-                TEST_SETTLE_TIMEOUT_MAX,
-                deprecation_executor,
-                channel_participant_deposit_limit,
-                token_network_deposit_limit,
-            ]
+            _token_address=secret_registry_contract.address,
+            _secret_registry=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+            _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
+            _deprecation_executor=deprecation_executor,
+            _channel_participant_deposit_limit=channel_participant_deposit_limit,
+            _token_network_deposit_limit=token_network_deposit_limit,
         )
 
     # failures with Ethereum addresses that don't contain the SecretRegistry contract
     with pytest.raises(TransactionFailed):
         get_token_network(
-            [
-                custom_token.address,
-                EMPTY_ADDRESS,
-                chain_id,
-                TEST_SETTLE_TIMEOUT_MIN,
-                TEST_SETTLE_TIMEOUT_MAX,
-                deprecation_executor,
-                channel_participant_deposit_limit,
-                token_network_deposit_limit,
-            ]
+            _token_address=custom_token.address,
+            _secret_registry=EMPTY_ADDRESS,
+            _chain_id=chain_id,
+            _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+            _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
+            _deprecation_executor=deprecation_executor,
+            _channel_participant_deposit_limit=channel_participant_deposit_limit,
+            _token_network_deposit_limit=token_network_deposit_limit,
         )
     with pytest.raises(TransactionFailed):
         get_token_network(
-            [
-                custom_token.address,
-                A,
-                chain_id,
-                TEST_SETTLE_TIMEOUT_MIN,
-                TEST_SETTLE_TIMEOUT_MAX,
-                deprecation_executor,
-                channel_participant_deposit_limit,
-                token_network_deposit_limit,
-            ]
+            _token_address=custom_token.address,
+            _secret_registry=A,
+            _chain_id=chain_id,
+            _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+            _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
+            _deprecation_executor=deprecation_executor,
+            _channel_participant_deposit_limit=channel_participant_deposit_limit,
+            _token_network_deposit_limit=token_network_deposit_limit,
         )
 
     # failure with chain_id zero
     with pytest.raises(TransactionFailed):
         get_token_network(
-            [
-                custom_token.address,
-                secret_registry_contract.address,
-                0,
-                TEST_SETTLE_TIMEOUT_MIN,
-                TEST_SETTLE_TIMEOUT_MAX,
-                deprecation_executor,
-                channel_participant_deposit_limit,
-                token_network_deposit_limit,
-            ]
+            _token_address=custom_token.address,
+            _secret_registry=secret_registry_contract.address,
+            _chain_id=0,
+            _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+            _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
+            _deprecation_executor=deprecation_executor,
+            _channel_participant_deposit_limit=channel_participant_deposit_limit,
+            _token_network_deposit_limit=token_network_deposit_limit,
         )
 
     # failure with a timeout min and max swapped
     with pytest.raises(TransactionFailed):
         get_token_network(
-            [
-                custom_token.address,
-                secret_registry_contract.address,
-                chain_id,
-                TEST_SETTLE_TIMEOUT_MAX,
-                TEST_SETTLE_TIMEOUT_MIN,
-                deprecation_executor,
-                channel_participant_deposit_limit,
-                token_network_deposit_limit,
-            ]
+            _token_address=custom_token.address,
+            _secret_registry=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MAX,
+            _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MIN,
+            _deprecation_executor=deprecation_executor,
+            _channel_participant_deposit_limit=channel_participant_deposit_limit,
+            _token_network_deposit_limit=token_network_deposit_limit,
         )
 
     # failure with settle_timeout_min being zero
     with pytest.raises(TransactionFailed):
         get_token_network(
-            [
-                custom_token.address,
-                secret_registry_contract.address,
-                chain_id,
-                0,
-                TEST_SETTLE_TIMEOUT_MIN,
-                deprecation_executor,
-                channel_participant_deposit_limit,
-                token_network_deposit_limit,
-            ]
+            _token_address=custom_token.address,
+            _secret_registry=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min=0,
+            _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MIN,
+            _deprecation_executor=deprecation_executor,
+            _channel_participant_deposit_limit=channel_participant_deposit_limit,
+            _token_network_deposit_limit=token_network_deposit_limit,
         )
 
     # failure with settle_timeout_max being zero
     with pytest.raises(TransactionFailed):
         get_token_network(
-            [
-                custom_token.address,
-                secret_registry_contract.address,
-                chain_id,
-                TEST_SETTLE_TIMEOUT_MIN,
-                0,
-                deprecation_executor,
-                channel_participant_deposit_limit,
-                token_network_deposit_limit,
-            ]
+            _token_address=custom_token.address,
+            _secret_registry=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+            _settlement_timeout_max=0,
+            _deprecation_executor=deprecation_executor,
+            _channel_participant_deposit_limit=channel_participant_deposit_limit,
+            _token_network_deposit_limit=token_network_deposit_limit,
         )
 
     # failure with channel_participant_deposit_limit being zero
     with pytest.raises(TransactionFailed):
         get_token_network(
-            [
-                custom_token.address,
-                secret_registry_contract.address,
-                chain_id,
-                TEST_SETTLE_TIMEOUT_MIN,
-                TEST_SETTLE_TIMEOUT_MAX,
-                deprecation_executor,
-                0,
-                token_network_deposit_limit,
-            ]
+            _token_address=custom_token.address,
+            _secret_registry=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+            _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
+            _deprecation_executor=deprecation_executor,
+            _channel_participant_deposit_limit=0,
+            _token_network_deposit_limit=token_network_deposit_limit,
         )
 
     # failure with both limits being zero
     with pytest.raises(TransactionFailed):
         get_token_network(
-            [
-                custom_token.address,
-                secret_registry_contract.address,
-                chain_id,
-                TEST_SETTLE_TIMEOUT_MIN,
-                TEST_SETTLE_TIMEOUT_MAX,
-                deprecation_executor,
-                0,
-                0,
-            ]
+            _token_address=custom_token.address,
+            _secret_registry=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+            _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
+            _deprecation_executor=deprecation_executor,
+            _channel_participant_deposit_limit=0,
+            _token_network_deposit_limit=0,
         )
 
     # failure with channel_participant_deposit_limit being bigger than
     # token_network_deposit_limit.
     with pytest.raises(TransactionFailed):
         get_token_network(
-            [
-                custom_token.address,
-                secret_registry_contract.address,
-                chain_id,
-                TEST_SETTLE_TIMEOUT_MIN,
-                TEST_SETTLE_TIMEOUT_MAX,
-                deprecation_executor,
-                token_network_deposit_limit,
-                channel_participant_deposit_limit,
-            ]
+            _token_address=custom_token.address,
+            _secret_registry=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+            _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
+            _deprecation_executor=deprecation_executor,
+            _channel_participant_deposit_limit=token_network_deposit_limit,
+            _token_network_deposit_limit=channel_participant_deposit_limit,
         )
 
     # see a success to make sure that the above failures are meaningful
     get_token_network(
-        [
-            custom_token.address,
-            secret_registry_contract.address,
-            chain_id,
-            TEST_SETTLE_TIMEOUT_MIN,
-            TEST_SETTLE_TIMEOUT_MAX,
-            deprecation_executor,
-            channel_participant_deposit_limit,
-            token_network_deposit_limit,
-        ]
+        _token_address=custom_token.address,
+        _secret_registry=secret_registry_contract.address,
+        _chain_id=chain_id,
+        _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+        _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
+        _deprecation_executor=deprecation_executor,
+        _channel_participant_deposit_limit=channel_participant_deposit_limit,
+        _token_network_deposit_limit=token_network_deposit_limit,
     )
 
 

--- a/raiden_contracts/tests/test_token_network_registry.py
+++ b/raiden_contracts/tests/test_token_network_registry.py
@@ -31,46 +31,86 @@ def test_constructor_call(
 
     # failure with no arguments
     with pytest.raises(TypeError):
-        get_token_network_registry([])
+        get_token_network_registry()
 
     # failure with an int instead of the SecretRegistry's address
     with pytest.raises(TypeError):
-        get_token_network_registry([3, chain_id, settle_min, settle_max, 1])
+        get_token_network_registry(
+            _secret_registry_address=3,
+            _chain_id=chain_id,
+            _settlement_timeout_min=settle_min,
+            _settlement_timeout_max=settle_max,
+            _max_token_networks=1,
+        )
 
     # failure with zero instead of the SecretRegistry's address
     with pytest.raises(TypeError):
-        get_token_network_registry([0, chain_id, settle_min, settle_max, 1])
+        get_token_network_registry(
+            _secret_registry_address=0,
+            _chain_id=chain_id,
+            _settlement_timeout_min=settle_min,
+            _settlement_timeout_max=settle_max,
+            _max_token_networks=1,
+        )
 
     # failure with the empty string instead of the SecretRegistry's address
     with pytest.raises(TypeError):
-        get_token_network_registry(["", chain_id, settle_min, settle_max, 1])
+        get_token_network_registry(
+            _secret_registry_address="",
+            _chain_id=chain_id,
+            _settlement_timeout_min=settle_min,
+            _settlement_timeout_max=settle_max,
+            _max_token_networks=1,
+        )
 
     # failure with an odd-length hex string instead of the SecretRegistry's address
     with pytest.raises(TypeError):
-        get_token_network_registry([NOT_ADDRESS, chain_id, settle_min, settle_max, 1])
+        get_token_network_registry(
+            _secret_registry_address=NOT_ADDRESS,
+            _chain_id=chain_id,
+            _settlement_timeout_min=settle_min,
+            _settlement_timeout_max=settle_max,
+            _max_token_networks=1,
+        )
 
     # failure with the empty string instead of a chain ID
     with pytest.raises(TypeError):
         get_token_network_registry(
-            [secret_registry_contract.address, "", settle_min, settle_max, 1]
+            _secret_registry_address=secret_registry_contract.address,
+            _chain_id="",
+            _settlement_timeout_min=settle_min,
+            _settlement_timeout_max=settle_max,
+            _max_token_networks=1,
         )
 
     # failure with a string instead of a chain ID
     with pytest.raises(TypeError):
         get_token_network_registry(
-            [secret_registry_contract.address, "1", settle_min, settle_max, 1]
+            _secret_registry_address=secret_registry_contract.address,
+            _chain_id="1",
+            _settlement_timeout_min=settle_min,
+            _settlement_timeout_max=settle_max,
+            _max_token_networks=1,
         )
 
     # failure with a negative integer instead of a chain ID
     with pytest.raises(TypeError):
         get_token_network_registry(
-            [secret_registry_contract.address, -3, settle_min, settle_max, 1]
+            _secret_registry_address=secret_registry_contract.address,
+            _chain_id=-3,
+            _settlement_timeout_min=settle_min,
+            _settlement_timeout_max=settle_max,
+            _max_token_networks=1,
         )
 
     # failure with chain ID zero
     with pytest.raises(TransactionFailed):
         get_token_network_registry(
-            [secret_registry_contract.address, 0, settle_min, settle_max, 1]
+            _secret_registry_address=secret_registry_contract.address,
+            _chain_id=0,
+            _settlement_timeout_min=settle_min,
+            _settlement_timeout_max=settle_max,
+            _max_token_networks=1,
         )
 
     # failure with strings instead of the minimal challenge period
@@ -89,50 +129,123 @@ def test_constructor_call(
 
     # failure with strings instead of the max challenge period
     with pytest.raises(TypeError):
-        get_token_network_registry([secret_registry_contract.address, chain_id, settle_min, "", 1])
-    with pytest.raises(TypeError):
         get_token_network_registry(
-            [secret_registry_contract.address, chain_id, "settle_min, 1", 1]
+            _secret_registry_address=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min=settle_min,
+            _settlement_timeout_max="",
+            _max_token_networks=1,
         )
     with pytest.raises(TypeError):
-        get_token_network_registry([secret_registry_contract.address, chain_id, settle_min, -3, 1])
+        get_token_network_registry(
+            _secret_registry_address=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min="settle_min,1",
+            _max_token_networks=1,
+        )
+    with pytest.raises(TypeError):
+        get_token_network_registry(
+            _secret_registry_address=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min=settle_min,
+            _settlement_timeout_max=-3,
+            _max_token_networks=1,
+        )
 
     # failure with Ethereum accounts that doesn't look like a SecretRegistry
     with pytest.raises(TransactionFailed):
-        get_token_network_registry([EMPTY_ADDRESS, chain_id, settle_min, settle_max, 1])
+        get_token_network_registry(
+            _secret_registry_address=EMPTY_ADDRESS,
+            _chain_id=chain_id,
+            _settlement_timeout_min=settle_min,
+            _settlement_timeout_max=settle_max,
+            _max_token_networks=1,
+        )
     with pytest.raises(TransactionFailed):
-        get_token_network_registry([A, chain_id, settle_min, settle_max, 1])
+        get_token_network_registry(
+            _secret_registry_address=A,
+            _chain_id=chain_id,
+            _settlement_timeout_min=settle_min,
+            _settlement_timeout_max=settle_max,
+            _max_token_networks=1,
+        )
 
     # failures with chain_id zero
     with pytest.raises(TransactionFailed):
-        get_token_network_registry([secret_registry_contract.address, 0, 0, settle_max, 1])
-    with pytest.raises(TransactionFailed):
-        get_token_network_registry([secret_registry_contract.address, 0, settle_min, 0, 1])
+        get_token_network_registry(
+            _secret_registry_address=secret_registry_contract.address,
+            _chain_id=0,
+            _settlement_timeout_min=0,
+            _settlement_timeout_max=settle_max,
+            _max_token_networks=1,
+        )
     with pytest.raises(TransactionFailed):
         get_token_network_registry(
-            [secret_registry_contract.address, 0, settle_max, settle_min, 1]
+            _secret_registry_address=secret_registry_contract.address,
+            _chain_id=0,
+            _settlement_timeout_min=settle_min,
+            _settlement_timeout_max=0,
+            _max_token_networks=1,
+        )
+    with pytest.raises(TransactionFailed):
+        get_token_network_registry(
+            _secret_registry_address=secret_registry_contract.address,
+            _chain_id=0,
+            _settlement_timeout_min=settle_max,
+            _settlement_timeout_max=settle_min,
+            _max_token_networks=1,
         )
 
     # failures with nonsense challenge periods
     with pytest.raises(TransactionFailed):
-        get_token_network_registry([secret_registry_contract.address, chain_id, 0, settle_max, 1])
-    with pytest.raises(TransactionFailed):
-        get_token_network_registry([secret_registry_contract.address, chain_id, settle_min, 0, 1])
+        get_token_network_registry(
+            _secret_registry_address=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min=0,
+            _settlement_timeout_max=settle_max,
+            _max_token_networks=1,
+        )
     with pytest.raises(TransactionFailed):
         get_token_network_registry(
-            [secret_registry_contract.address, chain_id, settle_max, settle_min, 1]
+            _secret_registry_address=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min=settle_min,
+            _settlement_timeout_max=0,
+            _max_token_networks=1,
+        )
+    with pytest.raises(TransactionFailed):
+        get_token_network_registry(
+            _secret_registry_address=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min=settle_max,
+            _settlement_timeout_max=settle_min,
+            _max_token_networks=1,
         )
 
     # failures with nonsense token number limits
     with pytest.raises(TransactionFailed):
-        get_token_network_registry([secret_registry_contract.address, chain_id, 0, settle_max, 0])
+        get_token_network_registry(
+            _secret_registry_address=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min=0,
+            _settlement_timeout_max=settle_max,
+            _max_token_networks=0,
+        )
     with pytest.raises(TypeError):
         get_token_network_registry(
-            [secret_registry_contract.address, chain_id, 0, settle_max, "limit"]
+            _secret_registry_address=secret_registry_contract.address,
+            _chain_id=chain_id,
+            _settlement_timeout_min=0,
+            _settlement_timeout_max=settle_max,
+            _max_token_networks="limit",
         )
 
     get_token_network_registry(
-        [secret_registry_contract.address, chain_id, settle_min, settle_max, 1]
+        _secret_registry_address=secret_registry_contract.address,
+        _chain_id=chain_id,
+        _settlement_timeout_min=settle_min,
+        _settlement_timeout_max=settle_max,
+        _max_token_networks=1,
     )
 
 
@@ -145,13 +258,11 @@ def test_constructor_call_state(
     chain_id = int(web3.version.network)
 
     registry = get_token_network_registry(
-        [
-            secret_registry_contract.address,
-            chain_id,
-            TEST_SETTLE_TIMEOUT_MIN,
-            TEST_SETTLE_TIMEOUT_MAX,
-            30,
-        ]
+        _secret_registry_address=secret_registry_contract.address,
+        _chain_id=chain_id,
+        _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
+        _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
+        _max_token_networks=30,
     )
     assert secret_registry_contract.address == registry.functions.secret_registry_address().call()
     assert chain_id == registry.functions.chain_id().call()

--- a/raiden_contracts/tests/utils/channel.py
+++ b/raiden_contracts/tests/utils/channel.py
@@ -329,8 +329,12 @@ def get_unlocked_amount(secret_registry: Contract, packed_locks: bytes) -> int:
 
 
 def get_participants_hash(A: HexAddress, B: HexAddress) -> bytes:
-    A = to_canonical_address(A)
-    B = to_canonical_address(B)
-    if A == B:
+    A_canonical = to_canonical_address(A)
+    B_canonical = to_canonical_address(B)
+    if A_canonical == B_canonical:
         raise ValueError("get_participants_hash got the same address twice")
-    return keccak(A + B) if A < B else keccak(B + A)
+    return (
+        keccak(A_canonical + B_canonical)
+        if A_canonical < B_canonical
+        else keccak(B_canonical + A_canonical)
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = C812, C813, C815, C819, E203, E731, E402, W503
+ignore = C812, C813, C815, C816, C819, E203, E731, E402, W503
 max-line-length = 99
 
 [pep8]


### PR DESCRIPTION
This fixes #1210.

### What this PR does

This commit forces these arguments to be provided as kwargs.

### Why I'm making this PR

Some smart contracts' constructors take many arguments,
so it's easy to mistake an argument for another.

### What's tricky about this PR (if any)

Nothing.

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.