### PR TITLE
Add entries in checklist on require() and assert()

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -76,7 +76,7 @@ Bump Smart Contracts Version
   * ``CONTRACTS_VERSION`` https://github.com/raiden-network/raiden-contracts/blob/9fd2124eb648a629aee886f37ade5e502431371f/raiden_contracts/constants.py#L4
   * This string will be filled in the contract templates.
 * We are currently at a ``0.*`` version. Our first ``major`` bump will be made when a stable, not-limited version will be released on the main net.
-* ``minor`` bumps (for now) are made for contract ABI changes.
+* ``minor`` bumps (for now) are made for contract ABI changes. An added or removed ``require()`` or ``assert()`` counts as ABI changes.
 * ``patch`` bumps are made for any fix that does not touch the ABI.
 
 .. _deploy-contracts:

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -30,6 +30,10 @@ Any reviewer can check these:
 * Solidity specific conventions
     * [ ] Document arguments of functions in natspec
     * [ ] Care reentrancy problems
+    * if the PR adds or removes `require()` or `assert()`
+        * [ ] add an entry in Changelog
+        * [ ] open an issue in the client, light client, service repos so the change is reflected there
+        * Just adding a message in `require()` doesn't require these steps.
 * [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`
 
 And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.


### PR DESCRIPTION
This fixes #1218.

### What this PR does

This PR describes what to do with additional `require()`s.

### Why I'm making this PR

Because in many occasions, new `require()` was added but
that was not reflected in the smart contract proxies in
the Raiden node codebase.

### What's tricky about this PR (if any)

Nothing.

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.