### PR TITLE
Copy mypy configs from `raiden`

### DIFF
--- a/raiden_contracts/tests/unit/test_recover_from_signature.py
+++ b/raiden_contracts/tests/unit/test_recover_from_signature.py
@@ -182,7 +182,7 @@ def test_sign_not_32_bytes(get_private_key: Callable, get_accounts: Callable) ->
     A = get_accounts(1)[0]
     privatekey = get_private_key(A)
     with pytest.raises(ValueError):
-        sign(privatekey, bytes("a" * 31, "ascii"), v=27)  # type: ignore
+        sign(privatekey, bytes("a" * 31, "ascii"), v=27)
 
 
 def test_sign_privatekey_not_string(get_private_key: Callable, get_accounts: Callable) -> None:
@@ -198,4 +198,4 @@ def test_sign_wrong_v(get_private_key: Callable, get_accounts: Callable) -> None
     A = get_accounts(1)[0]
     privatekey = get_private_key(A)
     with pytest.raises(ValueError):
-        sign(privatekey, bytes("a" * 32, "ascii"), v=22)  # type: ignore
+        sign(privatekey, bytes("a" * 32, "ascii"), v=22)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,5 +28,8 @@ default_section=THIRDPARTY
 combine_as_imports=1
 
 [mypy]
+check_untyped_defs = True
 disallow_untyped_defs = True
 ignore_missing_imports = True
+warn_unused_configs = True
+warn_unused_ignores = True


### PR DESCRIPTION
### What this PR does

This PR copies `mypy` configuration from `raiden` repository.

### Why I'm making this PR

It's better to use the same configurations in `raiden` repo and here.

### What's tricky about this PR (if any)

Nothing.

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
    * if the PR adds or removes `require()` or `assert()`
        * [ ] add an entry in Changelog
        * [ ] open an issue in the client, light client, service repos so the change is reflected there
        * Just adding a message in `require()` doesn't require these steps.
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.