### PR TITLE
Withdraw fails for empty contract or too early try

### DIFF
--- a/raiden_contracts/tests/test_service_registry.py
+++ b/raiden_contracts/tests/test_service_registry.py
@@ -56,8 +56,12 @@ def test_deposit_contract_without_service_registry_code(
     custom_token.functions.transfer(depo.address, 100).call_and_transact({"from": A})
     assert custom_token.functions.balanceOf(A).call() == 0
     assert custom_token.functions.balanceOf(depo.address).call() == 100
-    with pytest.raises(TransactionFailed):
+    # The call fails because an empty account doesn't return a boolean.
+    # In this case, the message of the TransactionFailed exception is ''.
+    with pytest.raises(TransactionFailed) as ex:
         depo.functions.withdraw(A).call_and_transact({"from": A})
+    assert str(ex.value) == "b''"
+
     assert custom_token.functions.balanceOf(A).call() == 0
     assert custom_token.functions.balanceOf(depo.address).call() == 100
 


### PR DESCRIPTION
so there have to be two tests.

This fixes #1268.

### What this PR does

This PR copies a test into two. The test was failing for a wrong reason.

The first copy is renamed so it shows why it fails (because ServiceRegistry has no code).

The second copy is edited so that it fails for the originally intended reason. In the second copy I added the `match="..."` so the reason of the failure is clearer.

### Why I'm making this PR

Because the test was failing for a wrong reason #1268.

### What's tricky about this PR (if any)

Nothing.

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
    * if the PR adds or removes `require()` or `assert()`
        * [ ] add an entry in Changelog
        * [ ] open an issue in the client, light client, service repos so the change is reflected there
        * Just adding a message in `require()` doesn't require these steps.
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.