### PR TITLE
Call check_channel_closed with kwargs

### DIFF
--- a/raiden_contracts/tests/test_channel_close.py
+++ b/raiden_contracts/tests/test_channel_close.py
@@ -256,7 +256,12 @@ def test_close_nonce_zero(
     ev_handler.add(
         close_tx,
         ChannelEvent.CLOSED,
-        check_channel_closed(channel_identifier, A, 0, balance_proof_B[0]),
+        check_channel_closed(
+            channel_identifier=channel_identifier,
+            closing_participant=A,
+            nonce=0,
+            balance_hash=balance_proof_B[0],
+        ),
     )
     ev_handler.check()
 
@@ -551,7 +556,12 @@ def test_close_channel_event_no_offchain_transfers(
     ev_handler.add(
         txn_hash,
         ChannelEvent.CLOSED,
-        check_channel_closed(channel_identifier, A, 0, EMPTY_BALANCE_HASH),
+        check_channel_closed(
+            channel_identifier=channel_identifier,
+            closing_participant=A,
+            nonce=0,
+            balance_hash=EMPTY_BALANCE_HASH,
+        ),
     )
     ev_handler.check()
 
@@ -657,6 +667,11 @@ def test_close_channel_event(
     ev_handler.add(
         txn_hash,
         ChannelEvent.CLOSED,
-        check_channel_closed(channel_identifier, A, 3, balance_proof[0]),
+        check_channel_closed(
+            channel_identifier=channel_identifier,
+            closing_participant=A,
+            nonce=3,
+            balance_hash=balance_proof[0],
+        ),
     )
     ev_handler.check()


### PR DESCRIPTION
This fixes #1271.

### What this PR does

Turn all calls of `check_channel_closed()` into kwarg calls.

### Why I'm making this PR

kwargs are easier to understand.

### What's tricky about this PR (if any)

Nothing.

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
    * if the PR adds or removes `require()` or `assert()`
        * [ ] add an entry in Changelog
        * [ ] open an issue in the client, light client, service repos so the change is reflected there
        * Just adding a message in `require()` doesn't require these steps.
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.