### PR TITLE
Simplify gas price logic

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import click
-from click import BadParameter, Context, Option, Parameter
+from click import BadParameter, Context, IntRange, Option, Parameter
 from eth_typing.evm import ChecksumAddress, HexAddress
 from eth_utils import is_address, to_checksum_address
 from web3 import HTTPProvider, Web3
@@ -67,7 +67,7 @@ def common_options(func: Callable) -> Callable:
         help="Address of the Ethereum RPC provider",
     )
     @click.option("--wait", default=300, help="Max tx wait time in s.")
-    @click.option("--gas-price", default=5, type=int, help="Gas price to use in gwei")
+    @click.option("--gas-price", default=5, type=IntRange(min=1), help="Gas price to use in gwei")
     @click.option("--gas-limit", default=5_500_000)
     @click.option(
         "--contracts-version",

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -39,7 +39,7 @@ class ContractDeployer(ContractVerifier):
         web3: Web3,
         private_key: str,
         gas_limit: int,
-        gas_price: int = 1,
+        gas_price: int,
         wait: int = 10,
         contracts_version: Optional[str] = None,
     ):
@@ -48,8 +48,7 @@ class ContractDeployer(ContractVerifier):
         self.wait = wait
         self.owner = private_key_to_address(private_key)
         self.transaction = {"from": self.owner, "gas": gas_limit}
-        if gas_price != 0:
-            self.transaction["gasPrice"] = gas_price * int(units["gwei"])
+        self.transaction["gasPrice"] = gas_price * int(units["gwei"])
 
         self.web3.middleware_stack.add(construct_sign_and_send_raw_middleware(private_key))
 


### PR DESCRIPTION
Before this commit, if the user specifies `--gas-price 0`, that
caused the Ethereum node to choose the gas price.  That was
counterintuitive, and this feature was not documented.

This commit removes this possibility.

This fixes #1284.

### What this PR does

This commit removes
* the undocumented feature of `ContractDeployer` that lets the Ethereum node choose the gas price, when 0 was specified as the gas price.
* the default gas price value in `ContractDeployer`.

### Why I'm making this PR

These features were not documented and were never used. The scripts should just fail in these weird cases rather than try to find something reasonable on its own.

### What's tricky about this PR (if any)

Nothing.

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
    * if the PR adds or removes `require()` or `assert()`
        * [ ] add an entry in Changelog
        * [ ] open an issue in the client, light client, service repos so the change is reflected there
        * Just adding a message in `require()` doesn't require these steps.
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.