### PR TITLE
Better error message for missing command argument

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -285,7 +285,7 @@ def raiden(
 @click.option("--save-info/--no-save-info", default=True, help="Save deployment info to a file.")
 @click.option(
     "--token-network-registry-address",
-    default=None,
+    required=True,
     callback=validate_address,
     help="Address of TokenNetworkRegistry that MS contract looks at",
 )

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -28,6 +28,7 @@ from raiden_contracts.utils.transaction import check_successful_tx
 from raiden_contracts.utils.versions import (
     contracts_version_expects_deposit_limits,
     contracts_version_has_initial_service_deposit,
+    contracts_version_monitoring_service_takes_token_network_registry,
 )
 
 LOG = getLogger(__name__)
@@ -321,6 +322,10 @@ class ContractDeployer(ContractVerifier):
             self.contract_manager.contracts_version
         ):
             raise RuntimeError("Deployment of older service contracts is not suppported.")
+        if not contracts_version_monitoring_service_takes_token_network_registry(
+            self.contract_manager.contracts_version
+        ):
+            raise RuntimeError("Deployment of older service contracts is not supported.")
 
         chain_id = int(self.web3.version.network)
         deployed_contracts: DeployedContracts = {

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -27,7 +27,6 @@ from raiden_contracts.utils.signature import private_key_to_address
 from raiden_contracts.utils.transaction import check_successful_tx
 from raiden_contracts.utils.versions import (
     contracts_version_expects_deposit_limits,
-    contracts_version_has_initial_service_deposit,
     contracts_version_monitoring_service_takes_token_network_registry,
 )
 
@@ -318,14 +317,10 @@ class ContractDeployer(ContractVerifier):
         token_network_registry_address: HexAddress,
     ) -> DeployedContracts:
         """Deploy 3rd party service contracts"""
-        if not contracts_version_has_initial_service_deposit(
-            self.contract_manager.contracts_version
-        ):
-            raise RuntimeError("Deployment of older service contracts is not suppported.")
         if not contracts_version_monitoring_service_takes_token_network_registry(
             self.contract_manager.contracts_version
         ):
-            raise RuntimeError("Deployment of older service contracts is not supported.")
+            raise RuntimeError("Deployment of older service contracts is not suppported.")
 
         chain_id = int(self.web3.version.network)
         deployed_contracts: DeployedContracts = {

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -90,6 +90,18 @@ def deployer_0_4_0(web3: Web3) -> ContractDeployer:
     )
 
 
+@pytest.fixture(scope="session")
+def deployer_0_21_0(web3: Web3) -> ContractDeployer:
+    return ContractDeployer(
+        web3=web3,
+        private_key=FAUCET_PRIVATE_KEY,
+        gas_limit=GAS_LIMIT,
+        gas_price=1,
+        wait=10,
+        contracts_version="0.21.0",
+    )
+
+
 @pytest.mark.slow
 @pytest.fixture(scope="session")
 def deployed_raiden_info(deployer: ContractDeployer) -> DeployedContracts:
@@ -161,6 +173,50 @@ def deployed_service_info(
         registration_duration=180 * SECONDS_PER_DAY,
         token_network_registry_address=token_network_registry_contract.address,
     )
+
+
+@pytest.mark.slow
+@pytest.fixture(scope="session")
+def test_deploy_service_0_4_0(
+    deployer_0_4_0: ContractDeployer,
+    token_address: HexAddress,
+    token_network_registry_contract: Contract,
+) -> None:
+    with pytest.raises(RuntimeError, match="older service contracts is not supported"):
+        deployer_0_4_0.deploy_service_contracts(
+            token_address=token_address,
+            user_deposit_whole_balance_limit=DEPOSIT_LIMIT,
+            service_registry_controller=CONTRACT_DEPLOYER_ADDRESS,
+            initial_service_deposit_price=SERVICE_DEPOSIT // 2,
+            service_deposit_bump_numerator=6,
+            service_deposit_bump_denominator=5,
+            decay_constant=200 * SECONDS_PER_DAY,
+            min_price=1000,
+            registration_duration=180 * SECONDS_PER_DAY,
+            token_network_registry_address=token_network_registry_contract.address,
+        )
+
+
+@pytest.mark.slow
+@pytest.fixture(scope="session")
+def test_deploy_service_0_21_0(
+    deployer_0_21_0: ContractDeployer,
+    token_address: HexAddress,
+    token_network_registry_contract: Contract,
+) -> None:
+    with pytest.raises(RuntimeError, match="older service contracts is not supported"):
+        deployer_0_21_0.deploy_service_contracts(
+            token_address=token_address,
+            user_deposit_whole_balance_limit=DEPOSIT_LIMIT,
+            service_registry_controller=CONTRACT_DEPLOYER_ADDRESS,
+            initial_service_deposit_price=SERVICE_DEPOSIT // 2,
+            service_deposit_bump_numerator=6,
+            service_deposit_bump_denominator=5,
+            decay_constant=200 * SECONDS_PER_DAY,
+            min_price=1000,
+            registration_duration=180 * SECONDS_PER_DAY,
+            token_network_registry_address=token_network_registry_contract.address,
+        )
 
 
 @pytest.mark.parametrize(

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -1112,7 +1112,10 @@ def test_deploy_raiden_save_info_false(
 
 
 def deploy_services_arguments(
-    privkey: str, save_info: Optional[bool], service_registry_controller: Optional[HexAddress]
+    privkey: str,
+    save_info: Optional[bool],
+    service_registry_controller: Optional[HexAddress],
+    token_network_registry_address: HexAddress,
 ) -> List:
     if save_info is None:
         arguments: List = []
@@ -1143,6 +1146,8 @@ def deploy_services_arguments(
         1000,
         "--service-registration-duration",
         180 * SECONDS_PER_DAY,
+        "--token-network-registry-address",
+        token_network_registry_address,
     ]
     return arguments
 
@@ -1166,7 +1171,10 @@ def test_deploy_services(
             result = runner.invoke(
                 services,
                 deploy_services_arguments(
-                    privkey=privkey_file.name, save_info=None, service_registry_controller=None
+                    privkey=privkey_file.name,
+                    save_info=None,
+                    service_registry_controller=None,
+                    token_network_registry_address=FAKE_ADDRESS,
                 ),
             )
             assert result.exception is None
@@ -1194,7 +1202,10 @@ def test_deploy_services_with_controller(
             result = runner.invoke(
                 services,
                 deploy_services_arguments(
-                    privkey=privkey_file.name, save_info=None, service_registry_controller=signer
+                    privkey=privkey_file.name,
+                    save_info=None,
+                    service_registry_controller=signer,
+                    token_network_registry_address=FAKE_ADDRESS,
                 ),
             )
             assert result.exception is None
@@ -1222,7 +1233,10 @@ def test_deploy_services_save_info_false(
             result = runner.invoke(
                 services,
                 deploy_services_arguments(
-                    privkey=privkey_file.name, save_info=False, service_registry_controller=None
+                    privkey=privkey_file.name,
+                    save_info=False,
+                    service_registry_controller=None,
+                    token_network_registry_address=FAKE_ADDRESS,
                 ),
             )
             assert result.exception is None

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -48,6 +48,7 @@ from raiden_contracts.deploy.__main__ import (
 from raiden_contracts.deploy.contract_deployer import (
     contracts_version_expects_deposit_limits,
     contracts_version_has_initial_service_deposit,
+    contracts_version_monitoring_service_takes_token_network_registry,
 )
 from raiden_contracts.deploy.contract_verifier import (
     _verify_monitoring_service_deployment,
@@ -177,6 +178,27 @@ def test_contracts_version_with_max_token_networks(
     version: Optional[str], expectation: bool
 ) -> None:
     assert contracts_version_with_max_token_networks(version) == expectation
+
+
+@pytest.mark.parametrize(
+    "version,expectation",
+    [
+        ("0.3.0", False),
+        ("0.3._", False),
+        ("0.4.0", False),
+        ("0.8.0", False),
+        ("0.8.0_unlimited", False),
+        ("0.22.0", False),
+        ("0.23.0", True),
+        (None, True),
+    ],
+)
+def test_contracts_version_monitoring_service_takes_token_network_registry(
+    version: Optional[str], expectation: bool
+) -> None:
+    assert (
+        contracts_version_monitoring_service_takes_token_network_registry(version) == expectation
+    )
 
 
 @pytest.mark.slow

--- a/raiden_contracts/utils/versions.py
+++ b/raiden_contracts/utils/versions.py
@@ -44,3 +44,20 @@ def contracts_version_has_initial_service_deposit(version: Optional[str]) -> boo
     if version == "0.8.0_unlimited":
         return False
     return compare(version, "0.18.0") > 0
+
+
+def contracts_version_monitoring_service_takes_token_network_registry(
+    version: Optional[str]
+) -> bool:
+    """ Returns true if the contracts_version's MonitoringService contracts
+
+    expects a TokenNetworkRegistry address as a constructor argument.
+    """
+    if version is None:
+        # stock version in `data`
+        return True
+    if version == "0.3._":
+        return False
+    if version == "0.8.0_unlimited":
+        return False
+    return compare(version, "0.22.0") > 0


### PR DESCRIPTION
This fixes #1168.

### What this PR does

This PR makes `click` complain when `--token-network-registry-address` is missing in the service contract deployment command.

### Why I'm making this PR

When --token-network-registry-address was missing, the
deployment script showed a mysterious error
```
TypeError: One or more arguments could not be encoded to the necessary ABI type.  Expected types are: address, address, address, address
```

### What's tricky about this PR (if any)

Older service contracts didn't need this value. The script didn't work for these old versions.  So I made the script complain explicitly when the user wants to deploy these older versions.

----

Any reviewer can check these:

* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.