### PR TITLE
Change the versioning scheme for contracts_version

### DIFF
--- a/.bumpversion_contracts.cfg
+++ b/.bumpversion_contracts.cfg
@@ -1,8 +1,0 @@
-[bumpversion]
-current_version = 0.25.2
-commit = True
-tag = False
-
-[bumpversion:file:raiden_contracts/constants.py]
-serialize = CONTRACTS_VERSION = "{major}.{minor}.{patch}"
-

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -66,18 +66,11 @@ We **DO** need to manually check whether source code changes have been done sinc
 Bump Smart Contracts Version
 ----------------------------
 
-::
-
-    bumpversion --config-file ./.bumpversion_contracts.cfg [PART]
-
-``[PART]`` can be ``major``, ``minor``, ``patch``.
-
-* The script changes the version located here:
+* Edit the version located here:
   * ``CONTRACTS_VERSION`` https://github.com/raiden-network/raiden-contracts/blob/9fd2124eb648a629aee886f37ade5e502431371f/raiden_contracts/constants.py#L4
-  * This string will be filled in the contract templates.
 * We are currently at a ``0.*`` version. Our first ``major`` bump will be made when a stable, not-limited version will be released on the main net.
-* ``minor`` bumps (for now) are made for contract ABI changes. An added or removed ``require()`` or ``assert()`` counts as ABI changes.
-* ``patch`` bumps are made for any fix that does not touch the ABI.
+* ``minor`` bumps are made for any contract changes. A modified comment counts as a contract change. The new version should match the next package version.
+* ``patch`` bumps are never used.
 
 .. _deploy-contracts:
 
@@ -157,7 +150,7 @@ Before bumping the package version, ``git add`` the deployment data at ``data/de
 * The script changes the version located here:
   * ``VERSION`` https://github.com/raiden-network/raiden-contracts/blob/9fd2124eb648a629aee886f37ade5e502431371f/setup.py#L15
 * We are currently at a ``0.*`` version. Our first ``major`` bump will be made when a stable, not-limited version will be released on the main net.
-* for now, ``minor`` bumps are done if ``minor`` or ``patch`` smart contract bumps are done or when we introduce backwards incompatible changes to package deliverables (e.g. changing variable names or helper functions).
+* for now, ``minor`` bumps are done if contracts_version changes.
 * ``patch`` bumps are made for any other fix
 
 This command triggers a commit and a local tag is created. A PR must be made with the commit changes.


### PR DESCRIPTION
as proposed in https://github.com/raiden-network/raiden-contracts/issues/584#issuecomment-544935108

### What this PR does

This PR
* modifies `RELEASE.md` so it describes the new versioning scheme
* removes a `bumpversion` configuration that won't be used.

### Why I'm making this PR

Having two distant version numbers is confusing.  Some people are totally confused about the version numbers.  Some others deny that the current scheme is too hard for human beings, but I've seen enough confusion.

### What's tricky about this PR (if any)

We are here slightly abusing `semver` because after this PR, `minor` means "contract changes" and `patch` means "Python script changes".

As far as we are in `0.x.y` range, the Semantic Versioning permits anything at any moment.

----

Any reviewer can check these:

* [x] Squash unnecessary commits
* [x] Comment commits

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.