### PR TITLE
Separate _verify_single_precompiled_checksum()

### DIFF
--- a/raiden_contracts/contract_source_manager.py
+++ b/raiden_contracts/contract_source_manager.py
@@ -197,3 +197,10 @@ def _verify_single_precompiled_checksum(
             f"checksum of {contract_name} does not match. got {precompiled_checksum} != "
             "expected {expected_checksum}"
         )
+
+
+def verify_single_precompiled_checksum_on_nonexistent_contract_name() -> None:
+    """ A functiohn for testing the case where the contract name is not found """
+    _verify_single_precompiled_checksum(
+        checked_checksums={}, contract_name="a", expected_checksum="abc"
+    )

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -22,6 +22,7 @@ from raiden_contracts.contract_source_manager import (
     ContractSourceManager,
     ContractSourceManagerVerificationError,
     contracts_source_path,
+    verify_single_precompiled_checksum_on_nonexistent_contract_name,
 )
 
 
@@ -256,3 +257,8 @@ def test_contract_source_manager_constructor_with_wrong_type() -> None:
     """ ConstructSourceManager's constructor raises TypeError on a wrong kind of argument """
     with pytest.raises(TypeError):
         ContractSourceManager(None)  # type: ignore
+
+
+def test_verify_single_precompiled_cyhecksum_on_nonexistent_contract_name() -> None:
+    with pytest.raises(ContractSourceManagerVerificationError, match="No checksum for"):
+        verify_single_precompiled_checksum_on_nonexistent_contract_name()

--- a/raiden_contracts/tests/test_deploy_data.py
+++ b/raiden_contracts/tests/test_deploy_data.py
@@ -180,7 +180,7 @@ def test_verify_existent_deployment(token_network_registry_contract: Contract) -
 
 
 def test_verify_existent_deployment_with_wrong_code(
-    token_network_registry_contract: Contract
+    token_network_registry_contract: Contract,
 ) -> None:
     """ Test verify_deployed_contracts_in_filesystem() with an existent deployment data
 

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -1362,7 +1362,7 @@ def test_verify_script(mock_verify: MagicMock) -> None:
 
 
 def test_verify_monitoring_service_deployment_with_wrong_first_constructor_arg(
-    token_network_registry_contract: Contract
+    token_network_registry_contract: Contract,
 ) -> None:
     mock_token = MagicMock()
     mock_token.call.return_value = EMPTY_ADDRESS
@@ -1380,7 +1380,7 @@ def test_verify_monitoring_service_deployment_with_wrong_first_constructor_arg(
 
 
 def test_verify_monitoring_service_deployment_with_wrong_onchain_token_address(
-    token_network_registry_contract: Contract
+    token_network_registry_contract: Contract,
 ) -> None:
     mock_token = MagicMock()
     mock_token.call.return_value = EMPTY_ADDRESS

--- a/raiden_contracts/utils/versions.py
+++ b/raiden_contracts/utils/versions.py
@@ -47,7 +47,7 @@ def contracts_version_has_initial_service_deposit(version: Optional[str]) -> boo
 
 
 def contracts_version_monitoring_service_takes_token_network_registry(
-    version: Optional[str]
+    version: Optional[str],
 ) -> bool:
     """ Returns true if the contracts_version's MonitoringService contracts
 


### PR DESCRIPTION
This commit separates a function that checks one entry of
contracts.json.  This eases the implementation of #1257.

### What this PR does

This is a pure refactoring that separates away a subroutine.

Before this PR, ContractSourceManager didn't have a function that checks a single entry of `contracrts.json`.  There was only `verify_precompiled_checksums()` that checks all entries of `contracts.json`.  This PR separates `_verify_single_precompiled_checksum()` that checks a single entry of `contracts.json`.

### Why I'm making this PR

After this PR, I want to expose a feature to check a single `contracts.json` entry.  That will be useful for [checking whether or not SecretRegistry's sources have changed](https://github.com/raiden-network/raiden-contracts/issues/1208#issuecomment-537490029).

### What's tricky about this PR (if any)

I had to take a moment to name the arguments of the new function.

----

Any reviewer can check these:

* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `python_variable`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.