### PR TITLE
Fix the source code check on CONTRACTS_VERSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Documents changes that result in:
 
 ## Unreleased
 
+- [#1313](https://github.com/raiden-network/raiden-contracts/pull/1313) fix deployment using --contracts-version CONTRACT_VERSION, even when ``data`` and ``data_CONTRACTS_VERSION`` contain different sources.
 - [#1299](https://github.com/raiden-network/raiden-contracts/pull/1299) fix consistency of data_0.25.2
 
 ## [0.33.2](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.33.2) - 2019-10-17

--- a/raiden_contracts/contract_source_manager.py
+++ b/raiden_contracts/contract_source_manager.py
@@ -3,12 +3,12 @@ import hashlib
 import json
 from os import chdir
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 from solc import compile_files
 
 from raiden_contracts.constants import PRECOMPILED_DATA_FIELDS, DeploymentModule
-from raiden_contracts.contract_manager import ContractManager
+from raiden_contracts.contract_manager import ContractManager, contracts_data_path
 
 _BASE = Path(__file__).parent
 
@@ -144,15 +144,16 @@ class ContractSourceManager:
         return (checksums, overall_checksum)
 
 
-def contracts_source_path() -> Dict[str, Path]:
-    return contracts_source_path_with_stem(Path("data/source"))
+def contracts_source_path(contracts_version: Optional[str]) -> Dict[str, Path]:
+    data = contracts_data_path(contracts_version)
+    return contracts_source_path_with_stem(data.joinpath("source"))
 
 
 def contracts_source_path_of_deployment_module(module: DeploymentModule) -> Path:
     if module == DeploymentModule.RAIDEN:
-        return contracts_source_path()["raiden"]
+        return contracts_source_path(contracts_version=None)["raiden"]
     elif module == DeploymentModule.SERVICES:
-        return contracts_source_path()["services"]
+        return contracts_source_path(contracts_version=None)["services"]
     else:
         raise ValueError(f"No source known for module {module}")
 

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -55,7 +55,9 @@ class ContractDeployer(ContractVerifier):
         # Check that the precompiled data matches the source code
         # Only for current version, because this is the only one with source code
         if self.contracts_version in [None, CONTRACTS_VERSION]:
-            contract_manager_source = ContractSourceManager(contracts_source_path())
+            contract_manager_source = ContractSourceManager(
+                contracts_source_path(contracts_version=contracts_version)
+            )
             contract_manager_source.verify_precompiled_checksums(self.precompiled_path)
         else:
             LOG.info("Skipped checks against the source code because it is not available.")

--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -83,7 +83,9 @@ def join_sources(source_module: DeploymentModule, contract_name: str) -> str:
         contract_name: 'TokenNetworkRegistry', 'SecretRegistry' etc.
     """
     joined_file = Path(__file__).parent.joinpath("joined.sol")
-    remapping = {module: str(path) for module, path in contracts_source_path().items()}
+    remapping = {
+        module: str(path) for module, path in contracts_source_path(contracts_version=None).items()
+    }
     command = [
         "./utils/join_contracts.py",
         "--import-map",

--- a/raiden_contracts/tests/fixtures/base/contract_manager.py
+++ b/raiden_contracts/tests/fixtures/base/contract_manager.py
@@ -9,7 +9,7 @@ from raiden_contracts.contract_source_manager import ContractSourceManager, cont
 
 @pytest.fixture(scope="session")
 def contract_source_manager() -> ContractSourceManager:
-    return ContractSourceManager(contracts_source_path())
+    return ContractSourceManager(contracts_source_path(contracts_version=None))
 
 
 @pytest.fixture(scope="session")

--- a/raiden_contracts/tests/test_contracts_compilation.py
+++ b/raiden_contracts/tests/test_contracts_compilation.py
@@ -42,7 +42,7 @@ def test_nonexistent_precompiled_path() -> None:
 
 def test_verification_overall_checksum() -> None:
     """ Tamper with the overall checksum and see failures in verify_precompiled_checksums() """
-    manager = ContractSourceManager(contracts_source_path())
+    manager = ContractSourceManager(contracts_source_path(contracts_version=None))
     manager.verify_precompiled_checksums(contracts_precompiled_path())
 
     assert manager.overall_checksum
@@ -75,7 +75,7 @@ def test_verification_overall_checksum() -> None:
 
 def test_verification_contracts_checksums() -> None:
     """ Tamper with the contract checksums and see failures in verify_precompiled_checksums() """
-    manager = ContractSourceManager(contracts_source_path())
+    manager = ContractSourceManager(contracts_source_path(contracts_version=None))
     manager.verify_precompiled_checksums(contracts_precompiled_path())
 
     assert manager.contracts_checksums
@@ -119,7 +119,7 @@ def test_current_development_version() -> None:
     assert manager.contracts_version == contracts_version
     check_precompiled_content(manager, contract_names, PRECOMPILED_DATA_FIELDS)
 
-    for _, source_path in contracts_source_path().items():
+    for _, source_path in contracts_source_path(contracts_version=None).items():
         assert source_path.exists()
     assert contracts_precompiled_path().exists()
 
@@ -218,13 +218,15 @@ def test_contract_manager_without_contracts() -> None:
 
 def test_contract_manager_compile() -> None:
     """ Check the ABI in the sources """
-    contract_source_manager_meta(contracts_source_path())
+    contract_source_manager_meta(contracts_source_path(contracts_version=None))
 
 
 def test_contract_manager_json(tmpdir: LocalPath) -> None:
     """ Check the ABI in contracts.json """
     precompiled_path = Path(tmpdir).joinpath("contracts.json")
-    ContractSourceManager(contracts_source_path()).compile_contracts(precompiled_path)
+    ContractSourceManager(contracts_source_path(contracts_version=None)).compile_contracts(
+        precompiled_path
+    )
     # try to load contracts from a precompiled file
     contract_manager_meta(precompiled_path)
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ class VerifyContracts(Command):
             ContractSourceManager,
             contracts_source_path,
         )
-        manager = ContractSourceManager(contracts_source_path())
+        manager = ContractSourceManager(contracts_source_path(contracts_version=None))
         manager.verify_precompiled_checksums(contracts_precompiled_path())
 
 


### PR DESCRIPTION
This fixes #1312.

### What this PR does

* After this PR, the bytecode verification on `CONTRACTS_VERSION` happens against the right source from `data_CONTRACTS_VERSION`, not from `data`.
* `contracts_source_path()` takes a new argument `contracts_version`.

### Why I'm making this PR

Currently, it's impossible to deploy Raiden contracts on a private network so people can test `raiden` #1312.

### What's tricky about this PR (if any)

Nothing.

I've tested that this PR fixes the problem I saw in #1312.

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `python_variable`
    * `PYTHON_CONSTANT`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.