### PR TITLE
`make install-dev`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Documents changes that result in:
 
 ## Unreleased
 
+- [#1318](https://github.com/raiden-network/raiden-contracts/pull/1318) add `make install-dev`.
+
 ## [0.33.3](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.33.3) - 2019-10-24
 
 - [#1313](https://github.com/raiden-network/raiden-contracts/pull/1313) fix deployment using --contracts-version CONTRACT_VERSION, even when ``data`` and ``data_CONTRACTS_VERSION`` contain different sources

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all compile_contracts verify_contracts install lint isort black autopep8 format mypy clean release update_gas_costs
+.PHONY: all compile_contracts verify_contracts install install-dev lint isort black autopep8 format mypy clean release update_gas_costs
 
 all: verify_contracts install
 
@@ -13,6 +13,10 @@ update_gas_costs:
 
 install:
 	pip install -r requirements.txt
+	pip install -e .
+
+install-dev:
+	pip install -r requirements-dev.txt
 	pip install -e .
 
 ISORT_PARAMS = --ignore-whitespace --settings-path ./ --recursive raiden_contracts/

--- a/README.rst
+++ b/README.rst
@@ -109,15 +109,11 @@ If you want to test and further develop outside the officially provided source c
 
 If you want to install the package from source::
 
-    make install
+    make install-dev
 
 To verify that the precompiled ``raiden_contracts/data/contracts.json`` file corresponds to the source code of the contracts::
 
     make verify_contracts
-
-For development and testing, you have to install additional dependencies::
-
-    pip install -r requirements-dev.txt
 
 
 Compile the contracts


### PR DESCRIPTION
### What this PR does

This PR introduces a new `Makefile` goal `make install-dev`.

### Why I'm making this PR

Other repos `raiden` and `raiden-services` have it, and I think it's a good idea.

### What's tricky about this PR (if any)

I updated `.PHONY` variable in the Makefile.

----

Any reviewer can check these:

* [x] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] Squash unnecessary commits
* [ ] Comment commits

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.