### PR TITLE
Pretty print deployment json files

### DIFF
--- a/raiden_contracts/deploy/contract_verifier.py
+++ b/raiden_contracts/deploy/contract_verifier.py
@@ -109,7 +109,7 @@ class ContractVerifier:
             services=services,
         )
         with deployment_file_path.open(mode="w") as target_file:
-            target_file.write(json.dumps(deployment_info, indent=4))
+            target_file.write(json.dumps(deployment_info, indent=2))
 
         print(
             f'Deployment information for chain id = {deployment_info["chain_id"]} '

--- a/raiden_contracts/deploy/contract_verifier.py
+++ b/raiden_contracts/deploy/contract_verifier.py
@@ -109,7 +109,7 @@ class ContractVerifier:
             services=services,
         )
         with deployment_file_path.open(mode="w") as target_file:
-            target_file.write(json.dumps(deployment_info))
+            target_file.write(json.dumps(deployment_info, indent=4))
 
         print(
             f'Deployment information for chain id = {deployment_info["chain_id"]} '


### PR DESCRIPTION
`indent=4` enables the pretty printing of dumps.

This closes #1293.

----

Any reviewer can check these:

* [ ] Comment commits

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.