### PR TITLE
Add an import in README code sample

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,7 @@ If you want to use the officially deployed contracts, please use the ``raiden_co
     from raiden_contracts.contract_manager import (
         ContractManager,
         contracts_precompiled_path,
+        get_contracts_deployment_info,
     )
     from raiden_contracts.constants import (
         CONTRACT_TOKEN_NETWORK_REGISTRY,


### PR DESCRIPTION
`get_contracts_deployment_info` was used below,
but the name was not imported anywhere.

This fixes #1294.

----

Any reviewer can check these:

* [ ] Squash unnecessary commits
* [ ] Comment commits

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.