### PR TITLE
CONTRACT_DEPLOYER_ADDRESS into DEPLOYER_ADDRESS

### DIFF
--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -20,7 +20,7 @@ from raiden_contracts.tests.utils import (
     get_participants_hash,
     get_settlement_amounts,
 )
-from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS, OnchainBalanceProof
+from raiden_contracts.tests.utils.constants import DEPLOYER_ADDRESS, OnchainBalanceProof
 from raiden_contracts.utils.proofs import (
     hash_balance_data,
     sign_balance_proof,
@@ -60,7 +60,7 @@ def create_channel(token_network: Contract, web3: Web3) -> Callable:
 @pytest.fixture()
 def assign_tokens(token_network: Contract, custom_token: Contract) -> Callable:
     def get(participant: HexAddress, deposit: int) -> None:
-        owner = CONTRACT_DEPLOYER_ADDRESS
+        owner = DEPLOYER_ADDRESS
         balance = custom_token.functions.balanceOf(participant).call()
         owner_balance = custom_token.functions.balanceOf(owner).call()
         amount = max(deposit - balance, 0)

--- a/raiden_contracts/tests/fixtures/contracts.py
+++ b/raiden_contracts/tests/fixtures/contracts.py
@@ -8,7 +8,7 @@ from web3 import Web3
 from web3.contract import Contract
 
 from raiden_contracts.contract_manager import ContractManager
-from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
+from raiden_contracts.tests.utils.constants import DEPLOYER_ADDRESS
 
 log = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ def deploy_tester_contract(
     def f(contract_name: str, **kwargs: Dict) -> Contract:
         json_contract = contracts_manager.get_contract(contract_name)
         contract = deploy_contract(
-            web3, CONTRACT_DEPLOYER_ADDRESS, json_contract["abi"], json_contract["bin"], **kwargs
+            web3, DEPLOYER_ADDRESS, json_contract["abi"], json_contract["bin"], **kwargs
         )
         return contract
 
@@ -74,7 +74,7 @@ def deploy_tester_contract_txhash(
     def f(contract_name: str, **kwargs: Dict) -> str:
         json_contract = contracts_manager.get_contract(contract_name)
         txhash = deploy_contract_txhash(
-            web3, CONTRACT_DEPLOYER_ADDRESS, json_contract["abi"], json_contract["bin"], **kwargs
+            web3, DEPLOYER_ADDRESS, json_contract["abi"], json_contract["bin"], **kwargs
         )
         return txhash
 

--- a/raiden_contracts/tests/fixtures/service_registry_fixtures.py
+++ b/raiden_contracts/tests/fixtures/service_registry_fixtures.py
@@ -5,12 +5,12 @@ from web3.contract import Contract
 
 from raiden_contracts.constants import CONTRACT_SERVICE_REGISTRY, EMPTY_ADDRESS
 from raiden_contracts.tests.utils import (
-    CONTRACT_DEPLOYER_ADDRESS,
     DEFAULT_BUMP_DENOMINATOR,
     DEFAULT_BUMP_NUMERATOR,
     DEFAULT_DECAY_CONSTANT,
     DEFAULT_MIN_PRICE,
     DEFAULT_REGISTRATION_DURATION,
+    DEPLOYER_ADDRESS,
 )
 
 
@@ -19,7 +19,7 @@ def service_registry(deploy_tester_contract: Callable, custom_token: Contract) -
     return deploy_tester_contract(
         CONTRACT_SERVICE_REGISTRY,
         _token_for_registration=custom_token.address,
-        _controller=CONTRACT_DEPLOYER_ADDRESS,
+        _controller=DEPLOYER_ADDRESS,
         _initial_price=int(3000e18),
         _price_bump_numerator=DEFAULT_BUMP_NUMERATOR,
         _price_bump_denominator=DEFAULT_BUMP_DENOMINATOR,

--- a/raiden_contracts/tests/fixtures/token_network_fixtures.py
+++ b/raiden_contracts/tests/fixtures/token_network_fixtures.py
@@ -15,7 +15,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MIN,
 )
 from raiden_contracts.contract_manager import ContractManager
-from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
+from raiden_contracts.tests.utils.constants import DEPLOYER_ADDRESS
 
 snapshot_before_token_network = None
 
@@ -43,7 +43,7 @@ def register_token_network(web3: Web3, contracts_manager: ContractManager) -> Ca
     ) -> Contract:
         tx_hash = token_network_registry.functions.createERC20TokenNetwork(
             token_address, channel_participant_deposit_limit, token_network_deposit_limit
-        ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+        ).call_and_transact({"from": DEPLOYER_ADDRESS})
         tx_receipt = web3.eth.getTransactionReceipt(tx_hash)
         event_abi = contracts_manager.get_event_abi(
             CONTRACT_TOKEN_NETWORK_REGISTRY, EVENT_TOKEN_NETWORK_CREATED
@@ -147,7 +147,7 @@ def token_network_external(
         _chain_id=int(web3.version.network),
         _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,
         _settlement_timeout_max=TEST_SETTLE_TIMEOUT_MAX,
-        _deprecation_executor=CONTRACT_DEPLOYER_ADDRESS,
+        _deprecation_executor=DEPLOYER_ADDRESS,
         _channel_participant_deposit_limit=channel_participant_deposit_limit,
         _token_network_deposit_limit=token_network_deposit_limit,
     )

--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -14,7 +14,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MIN,
 )
 from raiden_contracts.contract_manager import ContractManager
-from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS
+from raiden_contracts.tests.utils.constants import DEPLOYER_ADDRESS
 from raiden_contracts.utils.transaction import check_successful_tx
 
 
@@ -82,7 +82,7 @@ def add_and_register_token(
         token_contract = deploy_token_contract(initial_amount, decimals, token_name, token_symbol)
         txid = token_network_registry_contract.functions.createERC20TokenNetwork(
             token_contract.address, channel_participant_deposit_limit, token_network_deposit_limit
-        ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+        ).call_and_transact({"from": DEPLOYER_ADDRESS})
         (tx_receipt, _) = check_successful_tx(web3, txid)
         assert len(tx_receipt["logs"]) == 1
         event_abi = contracts_manager.get_event_abi(

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -55,7 +55,7 @@ from raiden_contracts.deploy.contract_verifier import (
 )
 from raiden_contracts.tests.utils import FAKE_ADDRESS, get_random_privkey
 from raiden_contracts.tests.utils.constants import (
-    CONTRACT_DEPLOYER_ADDRESS,
+    DEPLOYER_ADDRESS,
     FAUCET_PRIVATE_KEY,
     SECONDS_PER_DAY,
     SERVICE_DEPOSIT,
@@ -164,7 +164,7 @@ def deployed_service_info(
     return deployer.deploy_service_contracts(
         token_address=token_address,
         user_deposit_whole_balance_limit=DEPOSIT_LIMIT,
-        service_registry_controller=CONTRACT_DEPLOYER_ADDRESS,
+        service_registry_controller=DEPLOYER_ADDRESS,
         initial_service_deposit_price=SERVICE_DEPOSIT // 2,
         service_deposit_bump_numerator=6,
         service_deposit_bump_denominator=5,
@@ -186,7 +186,7 @@ def test_deploy_service_0_4_0(
         deployer_0_4_0.deploy_service_contracts(
             token_address=token_address,
             user_deposit_whole_balance_limit=DEPOSIT_LIMIT,
-            service_registry_controller=CONTRACT_DEPLOYER_ADDRESS,
+            service_registry_controller=DEPLOYER_ADDRESS,
             initial_service_deposit_price=SERVICE_DEPOSIT // 2,
             service_deposit_bump_numerator=6,
             service_deposit_bump_denominator=5,
@@ -208,7 +208,7 @@ def test_deploy_service_0_21_0(
         deployer_0_21_0.deploy_service_contracts(
             token_address=token_address,
             user_deposit_whole_balance_limit=DEPOSIT_LIMIT,
-            service_registry_controller=CONTRACT_DEPLOYER_ADDRESS,
+            service_registry_controller=DEPLOYER_ADDRESS,
             initial_service_deposit_price=SERVICE_DEPOSIT // 2,
             service_deposit_bump_numerator=6,
             service_deposit_bump_denominator=5,
@@ -345,14 +345,14 @@ def test_deploy_script_raiden(
     deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
     deployed_contracts_info_fail["contracts"][CONTRACT_TOKEN_NETWORK_REGISTRY][
         "constructor_arguments"
-    ][0] = CONTRACT_DEPLOYER_ADDRESS
+    ][0] = DEPLOYER_ADDRESS
     with pytest.raises(RuntimeError):
         deployer.verify_deployment_data(deployed_contracts_info_fail)
 
     deployed_contracts_info_fail = deepcopy(deployed_contracts_info)
     deployed_contracts_info_fail["contracts"][CONTRACT_TOKEN_NETWORK_REGISTRY][
         "constructor_arguments"
-    ][1] = CONTRACT_DEPLOYER_ADDRESS
+    ][1] = DEPLOYER_ADDRESS
     with pytest.raises(RuntimeError):
         deployer.verify_deployment_data(deployed_contracts_info_fail)
 
@@ -848,7 +848,7 @@ def test_validate_address_not_an_address() -> None:
 
 def test_validate_address_happy_path() -> None:
     """ validate_address(x, y, address) should return the same address checksumed """
-    address = CONTRACT_DEPLOYER_ADDRESS
+    address = DEPLOYER_ADDRESS
     assert validate_address(MagicMock(), MagicMock(), address) == to_checksum_address(address)
 
 

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -17,11 +17,7 @@ from raiden_contracts.constants import (
     MessageTypeId,
 )
 from raiden_contracts.contract_manager import gas_measurements
-from raiden_contracts.tests.utils.constants import (
-    CONTRACT_DEPLOYER_ADDRESS,
-    SERVICE_DEPOSIT,
-    UINT256_MAX,
-)
+from raiden_contracts.tests.utils.constants import DEPLOYER_ADDRESS, SERVICE_DEPOSIT, UINT256_MAX
 from raiden_contracts.utils.pending_transfers import get_locked_amount, get_pending_transfers_tree
 from raiden_contracts.utils.proofs import sign_one_to_n_iou, sign_reward_proof
 
@@ -121,7 +117,7 @@ def print_gas_token_network_create(
     registry = get_token_network_registry(**token_network_registry_constructor_args)
     txn_hash = registry.functions.createERC20TokenNetwork(
         custom_token.address, channel_participant_deposit_limit, token_network_deposit_limit
-    ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+    ).call_and_transact({"from": DEPLOYER_ADDRESS})
 
     print_gas(txn_hash, CONTRACT_TOKEN_NETWORK_REGISTRY + " createERC20TokenNetwork")
 

--- a/raiden_contracts/tests/test_service_registry.py
+++ b/raiden_contracts/tests/test_service_registry.py
@@ -15,12 +15,12 @@ from raiden_contracts.constants import (
 )
 from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
 from raiden_contracts.tests.utils.constants import (
-    CONTRACT_DEPLOYER_ADDRESS,
     DEFAULT_BUMP_DENOMINATOR,
     DEFAULT_BUMP_NUMERATOR,
     DEFAULT_DECAY_CONSTANT,
     DEFAULT_MIN_PRICE,
     DEFAULT_REGISTRATION_DURATION,
+    DEPLOYER_ADDRESS,
     SECONDS_PER_DAY,
     SERVICE_DEPOSIT,
     UINT256_MAX,
@@ -180,7 +180,7 @@ def test_changing_duration(
         _decay_constant=DEFAULT_DECAY_CONSTANT,
         _min_price=DEFAULT_MIN_PRICE,
         _registration_duration=new_duration,
-    ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+    ).call_and_transact({"from": DEPLOYER_ADDRESS})
     # make sure that the duration has changed.
     assert service_registry.functions.registration_duration().call() == new_duration
     (A,) = get_accounts(1)
@@ -206,7 +206,7 @@ def test_changing_duration_to_huge_value(
         _decay_constant=DEFAULT_DECAY_CONSTANT,
         _min_price=DEFAULT_MIN_PRICE,
         _registration_duration=new_duration,
-    ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+    ).call_and_transact({"from": DEPLOYER_ADDRESS})
     # make sure that the duration has changed.
     assert service_registry.functions.registration_duration().call() == new_duration
     (A,) = get_accounts(1)
@@ -226,7 +226,7 @@ def test_changing_bump_numerator(service_registry: Contract) -> None:
         _decay_constant=DEFAULT_DECAY_CONSTANT,
         _min_price=DEFAULT_MIN_PRICE,
         _registration_duration=DEFAULT_REGISTRATION_DURATION,
-    ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+    ).call_and_transact({"from": DEPLOYER_ADDRESS})
     assert service_registry.functions.price_bump_numerator().call() == DEFAULT_BUMP_NUMERATOR + 1
 
 
@@ -235,7 +235,7 @@ def test_calling_internal_bump_paramter_change(service_registry: Contract) -> No
     with pytest.raises(MismatchedABI):
         service_registry.functions.setPriceBumpParameters(
             DEFAULT_BUMP_NUMERATOR + 1, DEFAULT_BUMP_DENOMINATOR
-        ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+        ).call_and_transact({"from": DEPLOYER_ADDRESS})
 
 
 def test_too_high_bump_numerator_fail(service_registry: Contract) -> None:
@@ -247,7 +247,7 @@ def test_too_high_bump_numerator_fail(service_registry: Contract) -> None:
             _decay_constant=DEFAULT_DECAY_CONSTANT,
             _min_price=DEFAULT_MIN_PRICE,
             _registration_duration=DEFAULT_REGISTRATION_DURATION,
-        ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+        ).call_and_transact({"from": DEPLOYER_ADDRESS})
 
 
 def test_changing_bump_denominator(service_registry: Contract) -> None:
@@ -258,7 +258,7 @@ def test_changing_bump_denominator(service_registry: Contract) -> None:
         _decay_constant=DEFAULT_DECAY_CONSTANT,
         _min_price=DEFAULT_MIN_PRICE,
         _registration_duration=DEFAULT_REGISTRATION_DURATION,
-    ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+    ).call_and_transact({"from": DEPLOYER_ADDRESS})
     assert (
         service_registry.functions.price_bump_denominator().call() == DEFAULT_BUMP_DENOMINATOR + 1
     )
@@ -273,7 +273,7 @@ def test_changing_too_low_bump_parameter_fail(service_registry: Contract) -> Non
             _decay_constant=DEFAULT_DECAY_CONSTANT,
             _min_price=DEFAULT_MIN_PRICE,
             _registration_duration=DEFAULT_REGISTRATION_DURATION,
-        ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+        ).call_and_transact({"from": DEPLOYER_ADDRESS})
 
 
 def test_zero_numerator_fail(service_registry: Contract) -> None:
@@ -285,7 +285,7 @@ def test_zero_numerator_fail(service_registry: Contract) -> None:
             _decay_constant=DEFAULT_DECAY_CONSTANT,
             _min_price=DEFAULT_MIN_PRICE,
             _registration_duration=DEFAULT_REGISTRATION_DURATION,
-        ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+        ).call_and_transact({"from": DEPLOYER_ADDRESS})
 
 
 def test_changing_decay_constant(service_registry: Contract) -> None:
@@ -296,7 +296,7 @@ def test_changing_decay_constant(service_registry: Contract) -> None:
         _decay_constant=DEFAULT_DECAY_CONSTANT + 100,
         _min_price=DEFAULT_MIN_PRICE,
         _registration_duration=DEFAULT_REGISTRATION_DURATION,
-    ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+    ).call_and_transact({"from": DEPLOYER_ADDRESS})
     assert service_registry.functions.decay_constant().call() == DEFAULT_DECAY_CONSTANT + 100
 
 
@@ -308,7 +308,7 @@ def test_very_small_decay_cosntant(service_registry: Contract) -> None:
         _decay_constant=1,
         _min_price=DEFAULT_MIN_PRICE,
         _registration_duration=DEFAULT_REGISTRATION_DURATION,
-    ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+    ).call_and_transact({"from": DEPLOYER_ADDRESS})
     assert service_registry.functions.decayedPrice(100000, 100).call() == DEFAULT_MIN_PRICE
 
 
@@ -317,7 +317,7 @@ def test_internal_set_decay_constant(service_registry: Contract) -> None:
     with pytest.raises(MismatchedABI):
         service_registry.functions.setDecayConstant(
             DEFAULT_DECAY_CONSTANT + 100
-        ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+        ).call_and_transact({"from": DEPLOYER_ADDRESS})
 
 
 def test_too_high_decay_cosntant_fail(service_registry: Contract) -> None:
@@ -329,7 +329,7 @@ def test_too_high_decay_cosntant_fail(service_registry: Contract) -> None:
             _decay_constant=2 ** 40,
             _min_price=DEFAULT_MIN_PRICE,
             _registration_duration=DEFAULT_REGISTRATION_DURATION,
-        ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+        ).call_and_transact({"from": DEPLOYER_ADDRESS})
 
 
 def test_very_big_decay_cosntant(service_registry: Contract) -> None:
@@ -340,7 +340,7 @@ def test_very_big_decay_cosntant(service_registry: Contract) -> None:
         _decay_constant=2 ** 40 - 1,
         _min_price=DEFAULT_MIN_PRICE,
         _registration_duration=DEFAULT_REGISTRATION_DURATION,
-    ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+    ).call_and_transact({"from": DEPLOYER_ADDRESS})
     assert service_registry.functions.decayedPrice(100000, 11990300).call() == 99998
 
 
@@ -353,7 +353,7 @@ def test_zero_denominator_fail(service_registry: Contract) -> None:
             _decay_constant=DEFAULT_DECAY_CONSTANT,
             _min_price=DEFAULT_MIN_PRICE,
             _registration_duration=DEFAULT_REGISTRATION_DURATION,
-        ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+        ).call_and_transact({"from": DEPLOYER_ADDRESS})
 
 
 def test_changing_min_price(service_registry: Contract) -> None:
@@ -364,7 +364,7 @@ def test_changing_min_price(service_registry: Contract) -> None:
         _decay_constant=DEFAULT_DECAY_CONSTANT,
         _min_price=DEFAULT_MIN_PRICE * 2,
         _registration_duration=DEFAULT_REGISTRATION_DURATION,
-    ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+    ).call_and_transact({"from": DEPLOYER_ADDRESS})
     assert service_registry.functions.min_price().call() == DEFAULT_MIN_PRICE * 2
 
 
@@ -377,7 +377,7 @@ def test_changing_min_price_above_current(service_registry: Contract) -> None:
         _decay_constant=DEFAULT_DECAY_CONSTANT,
         _min_price=current_price + 1,
         _registration_duration=DEFAULT_REGISTRATION_DURATION,
-    ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+    ).call_and_transact({"from": DEPLOYER_ADDRESS})
     assert service_registry.functions.currentPrice().call() == current_price + 1
 
 
@@ -385,7 +385,7 @@ def test_internal_min_price(service_registry: Contract) -> None:
     """Calling the internal setMinPrice() must fail"""
     with pytest.raises(MismatchedABI):
         service_registry.functions.setMinPrice(DEFAULT_MIN_PRICE * 2).call_and_transact(
-            {"from": CONTRACT_DEPLOYER_ADDRESS}
+            {"from": DEPLOYER_ADDRESS}
         )
 
 
@@ -412,7 +412,7 @@ def test_parameter_change_on_no_controller(service_registry_without_controller: 
             _decay_constant=DEFAULT_DECAY_CONSTANT,
             _min_price=DEFAULT_MIN_PRICE * 2,
             _registration_duration=DEFAULT_REGISTRATION_DURATION,
-        ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+        ).call_and_transact({"from": DEPLOYER_ADDRESS})
     assert service_registry_without_controller.functions.min_price().call() == DEFAULT_MIN_PRICE
 
 
@@ -462,9 +462,7 @@ def test_deprecation_switch(
     """The controller turns on the deprecation switch and somebody tries to deposit"""
     # The controller turns on the deprecation switch
     assert not service_registry.functions.deprecated().call()
-    service_registry.functions.setDeprecationSwitch().call_and_transact(
-        {"from": CONTRACT_DEPLOYER_ADDRESS}
-    )
+    service_registry.functions.setDeprecationSwitch().call_and_transact({"from": DEPLOYER_ADDRESS})
     assert service_registry.functions.deprecated().call()
     # A user tries to make a deposit
     (A,) = get_accounts(1)
@@ -497,9 +495,7 @@ def test_deprecation_immediate_payout(
     deposit_abi = contract_manager.get_contract_abi(CONTRACT_DEPOSIT)
     deposit = web3.eth.contract(abi=deposit_abi, address=deposit_address)
     # The controller turns on the deprecation switch
-    service_registry.functions.setDeprecationSwitch().call_and_transact(
-        {"from": CONTRACT_DEPLOYER_ADDRESS}
-    )
+    service_registry.functions.setDeprecationSwitch().call_and_transact({"from": DEPLOYER_ADDRESS})
     # The user successfully withdraws the deposit
     deposit.functions.withdraw(A).call_and_transact({"from": A})
     # The user has all the balance it has minted
@@ -527,7 +523,7 @@ def test_deploying_service_registry_with_denominator_zero(
         deploy_tester_contract(
             CONTRACT_SERVICE_REGISTRY,
             _token_for_registration=custom_token.address,
-            _controller=CONTRACT_DEPLOYER_ADDRESS,
+            _controller=DEPLOYER_ADDRESS,
             _initial_price=int(3000e18),
             _price_bump_numerator=DEFAULT_BUMP_NUMERATOR,
             _price_bump_denominator=0,  # instead of DEFAULT_BUMP_DENOMINATOR

--- a/raiden_contracts/tests/test_token_network_registry.py
+++ b/raiden_contracts/tests/test_token_network_registry.py
@@ -12,7 +12,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MAX,
     TEST_SETTLE_TIMEOUT_MIN,
 )
-from raiden_contracts.tests.utils.constants import CONTRACT_DEPLOYER_ADDRESS, NOT_ADDRESS
+from raiden_contracts.tests.utils.constants import DEPLOYER_ADDRESS, NOT_ADDRESS
 from raiden_contracts.utils.events import check_token_network_created
 
 
@@ -326,24 +326,24 @@ def test_create_erc20_token_network_call(
     with pytest.raises(TransactionFailed):
         token_network_registry_contract.functions.createERC20TokenNetwork(
             custom_token.address, 0, token_network_deposit_limit
-        ).call({"from": CONTRACT_DEPLOYER_ADDRESS})
+        ).call({"from": DEPLOYER_ADDRESS})
 
     with pytest.raises(TransactionFailed):
         token_network_registry_contract.functions.createERC20TokenNetwork(
             custom_token.address, channel_participant_deposit_limit, 0
-        ).call({"from": CONTRACT_DEPLOYER_ADDRESS})
+        ).call({"from": DEPLOYER_ADDRESS})
 
     with pytest.raises(TransactionFailed):
         # fails because token_network_deposit_limit is smaller than
         # channel_participant_deposit_limit.
         token_network_registry_contract.functions.createERC20TokenNetwork(
             custom_token.address, token_network_deposit_limit, channel_participant_deposit_limit
-        ).call({"from": CONTRACT_DEPLOYER_ADDRESS})
+        ).call({"from": DEPLOYER_ADDRESS})
 
     # see a success to make sure above tests were meaningful
     token_network_registry_contract.functions.createERC20TokenNetwork(
         custom_token.address, channel_participant_deposit_limit, token_network_deposit_limit
-    ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+    ).call_and_transact({"from": DEPLOYER_ADDRESS})
 
 
 @pytest.mark.usefixtures("no_token_network")
@@ -402,12 +402,12 @@ def test_create_erc20_token_network_twice_fails(
 
     token_network_registry_contract.functions.createERC20TokenNetwork(
         custom_token.address, channel_participant_deposit_limit, token_network_deposit_limit
-    ).call_and_transact({"from": CONTRACT_DEPLOYER_ADDRESS})
+    ).call_and_transact({"from": DEPLOYER_ADDRESS})
 
     with pytest.raises(TransactionFailed):
         token_network_registry_contract.functions.createERC20TokenNetwork(
             custom_token.address, channel_participant_deposit_limit, token_network_deposit_limit
-        ).call({"from": CONTRACT_DEPLOYER_ADDRESS})
+        ).call({"from": DEPLOYER_ADDRESS})
 
 
 @pytest.mark.usefixtures("no_token_network")

--- a/raiden_contracts/tests/utils/constants.py
+++ b/raiden_contracts/tests/utils/constants.py
@@ -15,7 +15,7 @@ passphrase = "0"
 FAUCET_PRIVATE_KEY = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 FAUCET_ADDRESS = private_key_to_address(FAUCET_PRIVATE_KEY)
 FAUCET_ALLOWANCE = 100 * int(units["ether"])
-CONTRACT_DEPLOYER_ADDRESS = FAUCET_ADDRESS
+DEPLOYER_ADDRESS = FAUCET_ADDRESS
 NONEXISTENT_LOCKSROOT = b"\x00" * 32
 SECONDS_PER_DAY = 60 * 60 * 24
 


### PR DESCRIPTION
This fixes https://github.com/raiden-network/raiden-contracts/issues/1183

### What this PR does

Renames CONTRACT_DEPLOYER_ADDRESS into DEPLOYER_ADDRESS

### Why I'm making this PR

because CONTRACT_* are usually names of contracts.

### What's tricky about this PR (if any)

This is only used in tests, so will not affect other packages.

----

Any reviewer can check these:

* [ ] Comment commits
    * `PYTHON_CONSTANT`
And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.