### PR TITLE
Addresses are at least HexAddress not just str

### DIFF
--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -205,8 +205,8 @@ class ContractDeployer(ContractVerifier):
     def register_token_network(
         self,
         token_registry_abi: List[Dict[str, Any]],
-        token_registry_address: str,
-        token_address: str,
+        token_registry_address: HexAddress,
+        token_address: HexAddress,
         channel_participant_deposit_limit: Optional[int],
         token_network_deposit_limit: Optional[int],
     ) -> HexAddress:
@@ -232,8 +232,8 @@ class ContractDeployer(ContractVerifier):
     def _register_token_network_without_limits(
         self,
         token_registry_abi: List[Dict[str, Any]],
-        token_registry_address: str,
-        token_address: str,
+        token_registry_address: HexAddress,
+        token_address: HexAddress,
         channel_participant_deposit_limit: Optional[int],
         token_network_deposit_limit: Optional[int],
     ) -> HexAddress:
@@ -268,8 +268,8 @@ class ContractDeployer(ContractVerifier):
     def _register_token_network_with_limits(
         self,
         token_registry_abi: List[Dict[str, Any]],
-        token_registry_address: str,
-        token_address: str,
+        token_registry_address: HexAddress,
+        token_address: HexAddress,
         channel_participant_deposit_limit: Optional[int],
         token_network_deposit_limit: Optional[int],
     ) -> HexAddress:


### PR DESCRIPTION
This fixes #1060.

### What this PR does

Replaces some `str` with `HexAddress`.

### Why I'm making this PR

`HexAddress` is a more precise type annotation.

### What's tricky about this PR (if any)

Nothing.

----

Any reviewer can check these:

* [ ] Comment commits

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.