### PR TITLE
Format with newer black (fixes master build failure)

### DIFF
--- a/raiden_contracts/tests/test_deploy_data.py
+++ b/raiden_contracts/tests/test_deploy_data.py
@@ -180,7 +180,7 @@ def test_verify_existent_deployment(token_network_registry_contract: Contract) -
 
 
 def test_verify_existent_deployment_with_wrong_code(
-    token_network_registry_contract: Contract
+    token_network_registry_contract: Contract,
 ) -> None:
     """ Test verify_deployed_contracts_in_filesystem() with an existent deployment data
 

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -1362,7 +1362,7 @@ def test_verify_script(mock_verify: MagicMock) -> None:
 
 
 def test_verify_monitoring_service_deployment_with_wrong_first_constructor_arg(
-    token_network_registry_contract: Contract
+    token_network_registry_contract: Contract,
 ) -> None:
     mock_token = MagicMock()
     mock_token.call.return_value = EMPTY_ADDRESS
@@ -1380,7 +1380,7 @@ def test_verify_monitoring_service_deployment_with_wrong_first_constructor_arg(
 
 
 def test_verify_monitoring_service_deployment_with_wrong_onchain_token_address(
-    token_network_registry_contract: Contract
+    token_network_registry_contract: Contract,
 ) -> None:
     mock_token = MagicMock()
     mock_token.call.return_value = EMPTY_ADDRESS

--- a/raiden_contracts/utils/versions.py
+++ b/raiden_contracts/utils/versions.py
@@ -47,7 +47,7 @@ def contracts_version_has_initial_service_deposit(version: Optional[str]) -> boo
 
 
 def contracts_version_monitoring_service_takes_token_network_registry(
-    version: Optional[str]
+    version: Optional[str],
 ) -> bool:
     """ Returns true if the contracts_version's MonitoringService contracts
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 autopep8>=1.4.3
-black
+black>=19.10b0
 eth-tester[py-evm]<=0.1.0b33
 pytest
 pytest-cov


### PR DESCRIPTION
### What this PR does

* This PR forces pip to install newer versions of `black`.
* This PR formats Python sources using a new version of `black`.

### Why I'm making this PR

I saw a build failure on `master`
https://travis-ci.org/raiden-network/raiden-contracts/builds/604348795?utm_medium=notification&utm_source=email
This happened when the CI used a newer version of black.

Since our codebase should not ban newer versions of black, this codebase has to embrase the newer versions of black.

### What's tricky about this PR (if any)

Nothing.

----

Any reviewer can check these:

* [ ] Comment commits

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.