### PR TITLE
Test MonitoringService constructor with a UDC address without code

### DIFF
--- a/raiden_contracts/tests/test_monitoring_service.py
+++ b/raiden_contracts/tests/test_monitoring_service.py
@@ -490,3 +490,28 @@ def test_monitoring_service_deploy_with_service_registry_without_code(
             _token_network_registry_address=token_network_registry_contract.address,
         )
     # See monitoring_service_external fixture for the success case.
+
+
+def test_monitoring_service_deploy_with_udc_without_code(
+    deploy_tester_contract: Callable,
+    custom_token: Contract,
+    service_registry: Contract,
+    token_network_registry_contract: Contract,
+) -> None:
+    """ Test MonitoringService's constructor with a user_deposit_contract
+
+    address which does not contain code. This is supposed to cause a failure
+    in one of the require() statements in the constructor. """
+    # No good error message is available due to
+    # https://github.com/raiden-network/raiden-contracts/issues/1329
+    # with pytest.raises(TransactionFailed, match="UDC has no code"):
+
+    with pytest.raises(TransactionFailed):
+        deploy_tester_contract(
+            contract_name=CONTRACT_MONITORING_SERVICE,
+            _token_address=custom_token.address,
+            _service_registry_address=service_registry.address,
+            _udc_address=CONTRACT_DEPLOYER_ADDRESS,  # causes error
+            _token_network_registry_address=token_network_registry_contract.address,
+        )
+    # See monitoring_service_external fixture for the success case.


### PR DESCRIPTION
which does not contain code.

This is a part of #572.

### What this PR does

Adds a test that calls MonitoringService's constructor with a UserDepositContract address that does not contain any code.

### What's tricky about this PR (if any)

Nothing.

----

Any reviewer can check these:

* [ ] In Python, use keyword arguments
* [ ] Comment commits
* [ ] Follow naming conventions
    * `python_variable`
    * `PYTHON_CONSTANT`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.