### PR TITLE
Added expanduser to the private key file

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -104,7 +104,7 @@ def setup_ctx(
     web3 = Web3(HTTPProvider(rpc_provider, request_kwargs={"timeout": 60}))
     web3.middleware_stack.inject(geth_poa_middleware, layer=0)
     print("Web3 provider is", web3.providers[0])
-    private_key_string = get_private_key(Path(private_key))
+    private_key_string = get_private_key(Path(private_key).expanduser())
     if not private_key_string:
         raise RuntimeError("Could not access the private key.")
     owner = private_key_to_address(private_key_string)


### PR DESCRIPTION
This allows one to use a path with `~` in it. Which can be important for
scripts that use double quotes to escape variables with space in it,
e.g.:

    python -m raiden_contracts.deploy raiden --private-key "$PRIVATE_KEY"