### PR TITLE
Remove unnecessary `mine` in `create_channel`

### DIFF
--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -31,7 +31,7 @@ from raiden_contracts.utils.proofs import (
 
 
 @pytest.fixture(scope="session")
-def create_channel(token_network: Contract, web3: Web3) -> Callable:
+def create_channel(token_network: Contract) -> Callable:
     def get(A: HexAddress, B: HexAddress, settle_timeout: int = TEST_SETTLE_TIMEOUT_MIN) -> Tuple:
         # Make sure there is no channel existent on chain
         assert token_network.functions.getChannelIdentifier(A, B).call() == 0
@@ -40,7 +40,6 @@ def create_channel(token_network: Contract, web3: Web3) -> Callable:
         txn_hash = token_network.functions.openChannel(
             participant1=A, participant2=B, settle_timeout=settle_timeout
         ).call_and_transact()
-        web3.testing.mine(1)
 
         # Get the channel identifier
         channel_identifier = token_network.functions.getChannelIdentifier(A, B).call()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ semver
 mypy-extensions
 web3<5.0.0
 py_ecc<=1.5.0
+eth-utils==1.8.1


### PR DESCRIPTION
AFAICS it does not serve any purpose and it's slow.

### What this PR does

Removes one call to `mine` after creating a channel.

### Why I'm making this PR

To simplify and speed up tests.

### What's tricky about this PR (if any)

Why has it been added it the first place?

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
    * if the PR adds or removes `require()` or `assert()`
        * [ ] add an entry in Changelog
        * [ ] open an issue in the client, light client, service repos so the change is reflected there
        * Just adding a message in `require()` doesn't require these steps.
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.