### PR TITLE
Require `--service-registry-controller` in deployer

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -20,7 +20,6 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     DEPLOY_SETTLE_TIMEOUT_MAX,
     DEPLOY_SETTLE_TIMEOUT_MIN,
-    EMPTY_ADDRESS,
 )
 from raiden_contracts.deploy.contract_deployer import ContractDeployer
 from raiden_contracts.deploy.contract_verifier import ContractVerifier
@@ -240,7 +239,7 @@ def raiden(
 )
 @click.option(
     "--service-registry-controller",
-    default=EMPTY_ADDRESS,
+    required=True,
     callback=validate_address,
     help="Address of the controller that can modify the parameters of ServiceRegistry",
 )

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -1132,7 +1132,7 @@ def test_deploy_raiden_save_info_false(
 def deploy_services_arguments(
     privkey: str,
     save_info: Optional[bool],
-    service_registry_controller: Optional[HexAddress],
+    service_registry_controller: HexAddress,
     token_network_registry_address: HexAddress,
     contracts_version: Optional[str] = None,
 ) -> List:
@@ -1146,9 +1146,6 @@ def deploy_services_arguments(
     if contracts_version is not None:
         arguments += ["--contracts_version", contracts_version]
 
-    if service_registry_controller:
-        arguments += ["--service-registry-controller", service_registry_controller]
-
     arguments += [
         "--private-key",
         privkey,
@@ -1158,6 +1155,8 @@ def deploy_services_arguments(
         100,
         "--initial-service-deposit-price",
         SERVICE_DEPOSIT // 2,
+        "--service-registry-controller",
+        service_registry_controller,
         "--service-deposit-bump-numerator",
         6,
         "--service-deposit-bump-denominator",
@@ -1195,7 +1194,7 @@ def test_deploy_services(
                 deploy_services_arguments(
                     privkey=privkey_file.name,
                     save_info=None,
-                    service_registry_controller=None,
+                    service_registry_controller=FAKE_ADDRESS,
                     token_network_registry_address=FAKE_ADDRESS,
                 ),
             )
@@ -1219,7 +1218,7 @@ def test_deploy_old_services(get_accounts: Callable, get_private_key: Callable) 
                 deploy_services_arguments(
                     privkey=privkey_file.name,
                     save_info=None,
-                    service_registry_controller=None,
+                    service_registry_controller=FAKE_ADDRESS,
                     token_network_registry_address=FAKE_ADDRESS,
                     contracts_version="0.21.0",
                 ),
@@ -1280,7 +1279,7 @@ def test_deploy_services_save_info_false(
                 deploy_services_arguments(
                     privkey=privkey_file.name,
                     save_info=False,
-                    service_registry_controller=None,
+                    service_registry_controller=FAKE_ADDRESS,
                     token_network_registry_address=FAKE_ADDRESS,
                 ),
             )


### PR DESCRIPTION
Fixes https://github.com/raiden-network/raiden-contracts/issues/1295

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
    * if the PR adds or removes `require()` or `assert()`
        * [ ] add an entry in Changelog
        * [ ] open an issue in the client, light client, service repos so the change is reflected there
        * Just adding a message in `require()` doesn't require these steps.
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.