### PR TITLE
Web3 typing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 
 install:
   - pip install -U pip wheel
-  - pip install -r requirements-dev.txt
+  - pip install -U -r requirements-dev.txt
   - pip install pytest-xdist pytest-sugar codecov coverage pytest-travis-fold
   - pipdeptree --warn fail
   - pip check

--- a/raiden_contracts/constants.py
+++ b/raiden_contracts/constants.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from enum import Enum, IntEnum
 from typing import Dict
 
-from eth_typing import HexAddress, HexStr
+from eth_typing import ChecksumAddress, HexAddress, HexStr
 from eth_utils import keccak
 
 from raiden_contracts.utils.type_aliases import ChainID
@@ -39,7 +39,7 @@ MAX_ETH_TOKEN_NETWORK = int(250 * 10 ** 18)
 
 # Special hashes
 LOCKSROOT_OF_NO_LOCKS = keccak(b"")
-EMPTY_ADDRESS = HexAddress(HexStr("0x0000000000000000000000000000000000000000"))
+EMPTY_ADDRESS = ChecksumAddress(HexAddress(HexStr("0x0000000000000000000000000000000000000000")))
 
 # Event names
 # TokenNetworkRegistry

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -5,8 +5,11 @@ from json import JSONDecodeError
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from eth_typing.evm import HexAddress
+from eth_typing import HexStr
+from eth_typing.evm import ChecksumAddress, HexAddress
+from hexbytes import HexBytes
 from mypy_extensions import TypedDict
+from web3.types import ABIEvent
 
 from raiden_contracts.constants import ID_TO_NETWORKNAME, DeploymentModule
 from raiden_contracts.utils.file_ops import load_json_from_path
@@ -28,8 +31,8 @@ CompiledContract = TypedDict(
 DeployedContract = TypedDict(
     "DeployedContract",
     {
-        "address": HexAddress,
-        "transaction_hash": str,
+        "address": ChecksumAddress,
+        "transaction_hash": HexStr,
         "block_number": int,
         "gas_cost": int,
         "constructor_arguments": List[Any],
@@ -94,7 +97,7 @@ class ContractManager:
         assert self.contracts, "ContractManager should have contracts compiled"
         return self.contracts[contract_name]["abi"]
 
-    def get_event_abi(self, contract_name: str, event_name: str) -> Dict[str, Any]:
+    def get_event_abi(self, contract_name: str, event_name: str) -> ABIEvent:
         """ Returns the ABI for a given event. """
         # Import locally to avoid web3 dependency during installation via `compile_contracts`
         from web3._utils.contracts import find_matching_event_abi

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -9,7 +9,7 @@ from eth_typing import HexStr
 from eth_typing.evm import ChecksumAddress, HexAddress
 from hexbytes import HexBytes
 from mypy_extensions import TypedDict
-from web3.types import ABIEvent
+from web3.types import ABI, ABIEvent
 
 from raiden_contracts.constants import ID_TO_NETWORKNAME, DeploymentModule
 from raiden_contracts.utils.file_ops import load_json_from_path
@@ -23,8 +23,7 @@ _BASE = Path(__file__).parent
 
 
 CompiledContract = TypedDict(
-    "CompiledContract",
-    {"abi": List[Dict[str, Any]], "bin-runtime": str, "bin": str, "metadata": str},
+    "CompiledContract", {"abi": ABI, "bin-runtime": str, "bin": str, "metadata": str},
 )
 
 
@@ -92,7 +91,7 @@ class ContractManager:
     def has_contract(self, contract_name: str) -> bool:
         return contract_name in self.contracts
 
-    def get_contract_abi(self, contract_name: str) -> List[Dict[str, Any]]:
+    def get_contract_abi(self, contract_name: str) -> ABI:
         """ Returns the ABI for a given contract. """
         assert self.contracts, "ContractManager should have contracts compiled"
         return self.contracts[contract_name]["abi"]
@@ -180,11 +179,13 @@ def merge_deployment_data(dict1: DeployedContracts, dict2: DeployedContracts) ->
     if dict2["contracts_version"] != dict1["contracts_version"]:
         raise ValueError("Got dictionaries with different contracts_versions.")
 
-    return {
-        "contracts": common_contracts,
-        "chain_id": dict1["chain_id"],
-        "contracts_version": dict1["contracts_version"],
-    }
+    return DeployedContracts(
+        {
+            "contracts": common_contracts,
+            "chain_id": dict1["chain_id"],
+            "contracts_version": dict1["contracts_version"],
+        }
+    )
 
 
 def get_contracts_deployment_info(

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -6,8 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from eth_typing import HexStr
-from eth_typing.evm import ChecksumAddress, HexAddress
-from hexbytes import HexBytes
+from eth_typing.evm import ChecksumAddress
 from mypy_extensions import TypedDict
 from web3.types import ABI, ABIEvent
 

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 import click
 from click import BadParameter, Context, IntRange, Option, Parameter
+from eth_typing import URI
 from eth_typing.evm import ChecksumAddress, HexAddress
 from eth_utils import is_address, to_checksum_address
 from web3 import HTTPProvider, Web3
@@ -84,7 +85,7 @@ def common_options(func: Callable) -> Callable:
 def setup_ctx(
     ctx: click.Context,
     private_key: str,
-    rpc_provider: str,
+    rpc_provider: URI,
     wait: int,
     gas_price: int,
     gas_limit: int,
@@ -183,7 +184,7 @@ def check_version_dependent_parameters(
 def raiden(
     ctx: click.Context,
     private_key: str,
-    rpc_provider: str,
+    rpc_provider: URI,
     wait: int,
     gas_price: int,
     gas_limit: int,
@@ -291,7 +292,7 @@ def raiden(
 def services(
     ctx: Context,
     private_key: str,
-    rpc_provider: str,
+    rpc_provider: URI,
     wait: int,
     gas_price: int,
     gas_limit: int,
@@ -361,7 +362,7 @@ def services(
 def token(
     ctx: click.Context,
     private_key: str,
-    rpc_provider: str,
+    rpc_provider: URI,
     wait: int,
     gas_price: int,
     gas_limit: int,
@@ -412,7 +413,7 @@ def token(
 def register(
     ctx: Context,
     private_key: str,
-    rpc_provider: str,
+    rpc_provider: URI,
     wait: int,
     gas_price: int,
     gas_limit: int,
@@ -460,7 +461,7 @@ def register(
     help="Contracts version to verify. Current version will be used by default.",
 )
 @click.pass_context
-def verify(_: Any, rpc_provider: str, contracts_version: Optional[str]) -> None:
+def verify(_: Any, rpc_provider: URI, contracts_version: Optional[str]) -> None:
     web3 = Web3(HTTPProvider(rpc_provider, request_kwargs={"timeout": 60}))
     web3.middleware_onion.inject(geth_poa_middleware, layer=0)
     print("Web3 provider is", web3.provider)

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 import semver
 from eth_typing import ChecksumAddress, HexAddress

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from logging import getLogger
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Type
 
 import semver
 from eth_typing import ChecksumAddress, HexAddress
@@ -79,7 +79,6 @@ class ContractDeployer(ContractVerifier):
             abi=contract_interface["abi"], bytecode=contract_interface["bin"]
         )
 
-        assert isinstance(contract, Contract)
         # Get transaction hash from deployed contract
         txhash = self.send_deployment_transaction(contract=contract, args=args)
 
@@ -90,7 +89,7 @@ class ContractDeployer(ContractVerifier):
         )
         receipt, tx = check_successful_tx(web3=self.web3, txid=txhash, timeout=self.wait)
         if not receipt["contractAddress"]:  # happens with Parity
-            receipt["contractAddress"] = tx["creates"]
+            receipt["contractAddress"] = tx["creates"]  # type: ignore
         LOG.info(
             "{0} address: {1}. Gas used: {2}".format(
                 contract_name, receipt["contractAddress"], receipt["gasUsed"]
@@ -105,7 +104,7 @@ class ContractDeployer(ContractVerifier):
         receipt, _ = check_successful_tx(web3=self.web3, txid=txhash, timeout=self.wait)
         return receipt
 
-    def send_deployment_transaction(self, contract: Contract, args: List) -> HexBytes:
+    def send_deployment_transaction(self, contract: Type[Contract], args: List) -> HexBytes:
         txhash = None
         while txhash is None:
             try:

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -7,6 +7,7 @@ import semver
 from eth_typing import HexAddress
 from eth_utils import encode_hex, is_address, to_checksum_address
 from eth_utils.units import units
+from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract import Contract, ContractFunction
 from web3.middleware import construct_sign_and_send_raw_middleware
@@ -98,7 +99,7 @@ class ContractDeployer(ContractVerifier):
         (receipt, _) = check_successful_tx(web3=self.web3, txid=txhash, timeout=self.wait)
         return receipt
 
-    def send_deployment_transaction(self, contract: Contract, args: List) -> str:
+    def send_deployment_transaction(self, contract: Contract, args: List) -> HexBytes:
         txhash = None
         while txhash is None:
             try:

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -11,7 +11,7 @@ from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract import Contract, ContractFunction
 from web3.middleware import construct_sign_and_send_raw_middleware
-from web3.types import TxParams, TxReceipt, Wei
+from web3.types import ABI, TxParams, TxReceipt, Wei
 
 from raiden_contracts.constants import (
     CONTRACT_MONITORING_SERVICE,
@@ -211,7 +211,7 @@ class ContractDeployer(ContractVerifier):
 
     def register_token_network(
         self,
-        token_registry_abi: List[Dict[str, Any]],
+        token_registry_abi: ABI,
         token_registry_address: ChecksumAddress,
         token_address: ChecksumAddress,
         channel_participant_deposit_limit: Optional[int],

--- a/raiden_contracts/deploy/contract_verifier.py
+++ b/raiden_contracts/deploy/contract_verifier.py
@@ -197,7 +197,9 @@ class ContractVerifier:
             )
 
         # Check that the deployed bytecode matches the precompiled data
-        blockchain_bytecode = self.web3.eth.getCode(contract_instance.address)
+        blockchain_bytecode = self.web3.eth.getCode(  # type: ignore
+            contract_instance.address
+        ).hex()
         compiled_bytecode = self.contract_manager.get_runtime_hexcode(contract_name)
         if blockchain_bytecode == compiled_bytecode:
             print(

--- a/raiden_contracts/deploy/contract_verifier.py
+++ b/raiden_contracts/deploy/contract_verifier.py
@@ -197,7 +197,7 @@ class ContractVerifier:
             )
 
         # Check that the deployed bytecode matches the precompiled data
-        blockchain_bytecode = self.web3.eth.getCode(contract_instance.address).hex()
+        blockchain_bytecode = self.web3.eth.getCode(contract_instance.address)
         compiled_bytecode = self.contract_manager.get_runtime_hexcode(contract_name)
         if blockchain_bytecode == compiled_bytecode:
             print(

--- a/raiden_contracts/deploy/contract_verifier.py
+++ b/raiden_contracts/deploy/contract_verifier.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Optional
+from typing import Any, List, Optional, Tuple
 
 from eth_typing.evm import HexAddress
 from eth_utils import to_checksum_address
@@ -161,7 +161,7 @@ class ContractVerifier:
 
     def _verify_deployed_contract(
         self, deployment_data: DeployedContracts, contract_name: str
-    ) -> Contract:
+    ) -> Tuple[Contract, List[Any]]:
         """ Verify deployment info against the chain
 
         Verifies:

--- a/raiden_contracts/tests/deprecation_switch_testnet.py
+++ b/raiden_contracts/tests/deprecation_switch_testnet.py
@@ -2,7 +2,7 @@ from logging import getLogger
 from typing import Optional, Tuple
 
 import click
-from eth_typing import HexAddress, HexStr
+from eth_typing import URI, HexAddress, HexStr
 from eth_utils import encode_hex
 from web3.contract import Contract
 
@@ -35,7 +35,7 @@ log = getLogger(__name__)
 def deprecation_test(
     ctx: click.Context,
     private_key: str,
-    rpc_provider: str,
+    rpc_provider: URI,
     wait: int,
     gas_price: int,
     gas_limit: int,

--- a/raiden_contracts/tests/deprecation_switch_testnet.py
+++ b/raiden_contracts/tests/deprecation_switch_testnet.py
@@ -17,6 +17,7 @@ from raiden_contracts.constants import (
 )
 from raiden_contracts.deploy.__main__ import setup_ctx
 from raiden_contracts.deploy.contract_deployer import ContractDeployer
+from raiden_contracts.tests.utils import call_and_transact
 from raiden_contracts.utils.transaction import check_successful_tx
 
 log = getLogger(__name__)
@@ -127,7 +128,7 @@ def deprecation_test_setup(
     token_contract = deployer.web3.eth.contract(abi=token_abi, address=token_address)
 
     # Mint some tokens for the owner
-    txhash = token_contract.functions.mint(token_amount).call_and_transact(deployer.transaction)
+    txhash = call_and_transact(token_contract.functions.mint(token_amount), deployer.transaction)
 
     log.debug(f"Minting tokens txHash={encode_hex(txhash)}")
     check_successful_tx(deployer.web3, txhash, deployer.wait)
@@ -150,9 +151,9 @@ def deprecation_test_setup(
         f"Registered the token and created a TokenNetwork contract at {token_network_address}."
     )
 
-    txhash = token_contract.functions.approve(
-        token_network.address, token_amount
-    ).call_and_transact(deployer.transaction)
+    txhash = call_and_transact(
+        token_contract.functions.approve(token_network.address, token_amount), deployer.transaction
+    )
     log.debug(f"Approving tokens for the TokenNetwork contract txHash={encode_hex(txhash)}")
     check_successful_tx(deployer.web3, txhash, deployer.wait)
 
@@ -177,9 +178,12 @@ def open_and_deposit(
     txn_success_status: bool = True,
 ) -> int:
     try:
-        txhash = token_network.functions.openChannel(
-            participant1=A, participant2=B, settle_timeout=DEPLOY_SETTLE_TIMEOUT_MIN
-        ).call_and_transact(deployer.transaction)
+        txhash = call_and_transact(
+            token_network.functions.openChannel(
+                participant1=A, participant2=B, settle_timeout=DEPLOY_SETTLE_TIMEOUT_MIN
+            ),
+            deployer.transaction,
+        )
         log.debug(f"Opening a channel between {A} and {B} txHash={encode_hex(txhash)}")
         check_successful_tx(web3=deployer.web3, txid=txhash, timeout=deployer.wait)
 
@@ -196,12 +200,15 @@ def open_and_deposit(
 
     assert channel_identifier is not None
     try:
-        txhash = token_network.functions.setTotalDeposit(
-            channel_identifier=channel_identifier,
-            participant=A,
-            total_deposit=int(MAX_ETH_CHANNEL_PARTICIPANT / 2),
-            partner=B,
-        ).call_and_transact(deployer.transaction)
+        txhash = call_and_transact(
+            token_network.functions.setTotalDeposit(
+                channel_identifier=channel_identifier,
+                participant=A,
+                total_deposit=int(MAX_ETH_CHANNEL_PARTICIPANT / 2),
+                partner=B,
+            ),
+            deployer.transaction,
+        )
         log.debug(
             f"Depositing {MAX_ETH_CHANNEL_PARTICIPANT} tokens for {A} in a channel with "
             f"identifier={channel_identifier} and partner= {B} txHash={encode_hex(txhash)}"
@@ -217,12 +224,15 @@ def open_and_deposit(
     ), f"setTotalDeposit txn status is {success_status} instead of {txn_success_status}"
 
     try:
-        txhash = token_network.functions.setTotalDeposit(
-            channel_identifier=channel_identifier,
-            participant=B,
-            total_deposit=int(MAX_ETH_CHANNEL_PARTICIPANT / 2),
-            partner=A,
-        ).call_and_transact(deployer.transaction)
+        txhash = call_and_transact(
+            token_network.functions.setTotalDeposit(
+                channel_identifier=channel_identifier,
+                participant=B,
+                total_deposit=int(MAX_ETH_CHANNEL_PARTICIPANT / 2),
+                partner=A,
+            ),
+            deployer.transaction,
+        )
         log.debug(
             f"Depositing {MAX_ETH_CHANNEL_PARTICIPANT} tokens for {B} in a channel with "
             f"identifier={channel_identifier} and partner= {A} txHash={encode_hex(txhash)}"

--- a/raiden_contracts/tests/fixtures/base/address.py
+++ b/raiden_contracts/tests/fixtures/base/address.py
@@ -6,6 +6,7 @@ from eth_utils import is_address
 from eth_utils.units import units
 from web3.contract import Contract
 
+from raiden_contracts.tests.utils import call_and_transact
 from raiden_contracts.tests.utils.constants import FAUCET_ADDRESS
 
 
@@ -18,8 +19,8 @@ def send_funds(ethereum_tester: EthereumTester, custom_token: Contract) -> Calla
         ethereum_tester.send_transaction(
             {"from": FAUCET_ADDRESS, "to": target, "gas": 21000, "value": 1 * int(units["ether"])}
         )
-        custom_token.functions.transfer(_to=target, _value=10000).call_and_transact(
-            {"from": FAUCET_ADDRESS}
+        call_and_transact(
+            custom_token.functions.transfer(_to=target, _value=10000), {"from": FAUCET_ADDRESS}
         )
 
     return f

--- a/raiden_contracts/tests/fixtures/base/utils.py
+++ b/raiden_contracts/tests/fixtures/base/utils.py
@@ -11,6 +11,7 @@ from eth_utils.units import units
 from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract import Contract
+from web3.types import ABI, Wei
 
 from raiden_contracts.contract_manager import contracts_gas_path
 from raiden_contracts.tests.utils import call_and_transact, get_random_privkey
@@ -32,7 +33,7 @@ def create_account(web3: Web3, ethereum_tester: EthereumTester) -> Callable:
         for faucet in web3.eth.accounts[:10]:
             try:
                 web3.eth.sendTransaction(
-                    {"from": faucet, "to": address, "value": 1 * int(units["finney"])}
+                    {"from": faucet, "to": address, "value": Wei(1 * int(units["finney"]))}
                 )
                 break
             except TransactionFailed:
@@ -90,7 +91,7 @@ def event_handler(web3: Web3) -> Callable:
     def get(
         contract: Optional[Contract] = None,
         address: Optional[HexAddress] = None,
-        abi: Optional[List] = None,
+        abi: Optional[ABI] = None,
     ) -> LogHandler:
         if contract:
             abi = contract.abi
@@ -114,7 +115,7 @@ def txn_cost(web3: Web3, txn_gas: Callable) -> Callable:
 
 @pytest.fixture
 def txn_gas(web3: Web3) -> Callable:
-    def get(txn_hash: str) -> int:
+    def get(txn_hash: HexBytes) -> int:
         receipt = web3.eth.getTransactionReceipt(txn_hash)
         return receipt["gasUsed"]
 

--- a/raiden_contracts/tests/fixtures/base/utils.py
+++ b/raiden_contracts/tests/fixtures/base/utils.py
@@ -8,11 +8,12 @@ from eth_tester.exceptions import TransactionFailed
 from eth_typing.evm import HexAddress
 from eth_utils import is_same_address
 from eth_utils.units import units
+from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract import Contract
 
 from raiden_contracts.contract_manager import contracts_gas_path
-from raiden_contracts.tests.utils import get_random_privkey
+from raiden_contracts.tests.utils import call_and_transact, get_random_privkey
 from raiden_contracts.utils.logs import LogHandler
 from raiden_contracts.utils.signature import private_key_to_address
 
@@ -59,11 +60,11 @@ def create_service_account(
     def get() -> HexAddress:
         account = create_account()
         deposit = service_registry.functions.currentPrice().call()
-        custom_token.functions.mint(deposit).call_and_transact({"from": account})
-        custom_token.functions.approve(service_registry.address, deposit).call_and_transact(
-            {"from": account}
+        call_and_transact(custom_token.functions.mint(deposit), {"from": account})
+        call_and_transact(
+            custom_token.functions.approve(service_registry.address, deposit), {"from": account}
         )
-        service_registry.functions.deposit(deposit).call_and_transact({"from": account})
+        call_and_transact(service_registry.functions.deposit(deposit), {"from": account})
         assert service_registry.functions.hasValidRegistration(account).call()
         return account
 
@@ -157,7 +158,7 @@ def print_gas(txn_gas: Callable, gas_measurement_results: Dict) -> Callable:
 
 @pytest.fixture()
 def get_block(web3: Web3) -> Callable:
-    def get(txn_hash: str) -> int:
+    def get(txn_hash: HexBytes) -> int:
         receipt = web3.eth.getTransactionReceipt(txn_hash)
         return receipt["blockNumber"]
 

--- a/raiden_contracts/tests/fixtures/base/web3_fixtures.py
+++ b/raiden_contracts/tests/fixtures/base/web3_fixtures.py
@@ -40,7 +40,7 @@ def web3(ethereum_tester: EthereumTester) -> Web3:
     provider = EthereumTesterProvider(ethereum_tester)
     web3 = Web3(provider)
     # Improve test speed by skipping the gas cost estimation.
-    web3.eth.estimateGas = lambda txn: int(5.2e6)  # pylint: disable=E1101
+    web3.eth.estimateGas = lambda txn: int(5.2e6)  # type: ignore  # pylint: disable=E1101
 
     # add faucet account to tester
     ethereum_tester.add_account(FAUCET_PRIVATE_KEY)
@@ -71,6 +71,6 @@ def auto_revert_chain(web3: Web3) -> Generator:
     This is useful especially when using ethereum tester - its log filtering
     is very slow once enough events are present on-chain.
     """
-    snapshot_id = web3.testing.snapshot()
+    snapshot_id = web3.testing.snapshot()  # type: ignore
     yield
-    web3.testing.revert(snapshot_id)
+    web3.testing.revert(snapshot_id)  # type: ignore

--- a/raiden_contracts/tests/fixtures/base/web3_fixtures.py
+++ b/raiden_contracts/tests/fixtures/base/web3_fixtures.py
@@ -1,10 +1,9 @@
 import logging
-from typing import Dict, Generator, Optional
+from typing import Generator
 
 import pytest
 from eth_tester import EthereumTester, PyEVMBackend
 from web3 import Web3
-from web3.contract import ContractFunction
 from web3.providers.eth_tester import EthereumTesterProvider
 
 from raiden_contracts.tests.utils.constants import (
@@ -75,17 +74,3 @@ def auto_revert_chain(web3: Web3) -> Generator:
     snapshot_id = web3.testing.snapshot()
     yield
     web3.testing.revert(snapshot_id)
-
-
-def _call_and_transact(
-    contract_function: ContractFunction, transaction_params: Optional[Dict] = None
-) -> str:
-    """ Executes contract_function.{call, transaction}(transaction_params) and returns txhash """
-    # First 'call' might raise an exception
-    contract_function.call(transaction_params)
-    return contract_function.transact(transaction_params)
-
-
-@pytest.fixture(scope="session", autouse=True)
-def call_and_transact() -> None:
-    ContractFunction.call_and_transact = _call_and_transact

--- a/raiden_contracts/tests/fixtures/base/web3_fixtures.py
+++ b/raiden_contracts/tests/fixtures/base/web3_fixtures.py
@@ -58,7 +58,7 @@ def web3(ethereum_tester: EthereumTester) -> Web3:
     # Enable strict type checks
     web3.enable_strict_bytes_type_checking()
 
-    yield web3
+    return web3
 
 
 @pytest.fixture(autouse=True)

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -3,6 +3,7 @@ from typing import Callable, Collection, List, Optional, Tuple
 import pytest
 from eth_tester.exceptions import TransactionFailed
 from eth_typing import HexAddress
+from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract import Contract
 
@@ -101,7 +102,7 @@ def channel_deposit(token_network: Contract, assign_tokens: Callable) -> Callabl
         deposit: int,
         partner: HexAddress,
         tx_from: Optional[HexAddress] = None,
-    ) -> str:
+    ) -> HexBytes:
         tx_from = tx_from or participant
         assign_tokens(tx_from, deposit)
 
@@ -148,7 +149,7 @@ def withdraw_channel(token_network: Contract, create_withdraw_signatures: Callab
         expiration_block: int,
         partner: HexAddress,
         delegate: Optional[HexAddress] = None,
-    ) -> str:
+    ) -> HexBytes:
         delegate = delegate or participant
         channel_identifier = token_network.functions.getChannelIdentifier(
             participant, partner

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -21,6 +21,7 @@ from raiden_contracts.tests.utils import (
     get_participants_hash,
     get_settlement_amounts,
 )
+from raiden_contracts.tests.utils.blockchain import mine_blocks
 from raiden_contracts.tests.utils.constants import DEPLOYER_ADDRESS, OnchainBalanceProof
 from raiden_contracts.utils.proofs import (
     hash_balance_data,
@@ -300,7 +301,7 @@ def create_settled_channel(
             participant2_values,
         )
 
-        web3.testing.mine(settle_timeout)
+        mine_blocks(web3, settle_timeout)
 
         call_settle(
             token_network,

--- a/raiden_contracts/tests/fixtures/contracts.py
+++ b/raiden_contracts/tests/fixtures/contracts.py
@@ -54,10 +54,10 @@ def deploy_contract(deploy_contract_txhash: Callable) -> Callable:
     ) -> Contract:
         contract = web3.eth.contract(abi=abi, bytecode=bytecode)
         txhash = deploy_contract_txhash(web3, deployer_address, abi, bytecode, **kwargs)
-        contract_address = web3.eth.getTransactionReceipt(txhash).contractAddress
+        contract_address = web3.eth.getTransactionReceipt(txhash)["contractAddress"]
         mine_blocks(web3, 1)
 
-        if web3.eth.getTransactionReceipt(txhash).status != 1:
+        if web3.eth.getTransactionReceipt(txhash)["status"] != 1:
             raise TransactionFailed("deployment failed")
 
         return contract(contract_address)

--- a/raiden_contracts/tests/fixtures/contracts.py
+++ b/raiden_contracts/tests/fixtures/contracts.py
@@ -8,6 +8,7 @@ from web3 import Web3
 from web3.contract import Contract
 
 from raiden_contracts.contract_manager import ContractManager
+from raiden_contracts.tests.utils.blockchain import mine_blocks
 from raiden_contracts.tests.utils.constants import DEPLOYER_ADDRESS
 
 log = logging.getLogger(__name__)
@@ -54,7 +55,7 @@ def deploy_contract(deploy_contract_txhash: Callable) -> Callable:
         contract = web3.eth.contract(abi=abi, bytecode=bytecode)
         txhash = deploy_contract_txhash(web3, deployer_address, abi, bytecode, **kwargs)
         contract_address = web3.eth.getTransactionReceipt(txhash).contractAddress
-        web3.testing.mine(1)
+        mine_blocks(web3, 1)
 
         if web3.eth.getTransactionReceipt(txhash).status != 1:
             raise TransactionFailed("deployment failed")

--- a/raiden_contracts/tests/fixtures/monitoring_service.py
+++ b/raiden_contracts/tests/fixtures/monitoring_service.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 import pytest
 from web3.contract import Contract
 

--- a/raiden_contracts/tests/fixtures/monitoring_service.py
+++ b/raiden_contracts/tests/fixtures/monitoring_service.py
@@ -6,7 +6,7 @@ from raiden_contracts.constants import CONTRACT_MONITORING_SERVICE
 
 @pytest.fixture(scope="session")
 def monitoring_service_external(
-    deploy_tester_contract: Contract,
+    deploy_tester_contract: Callable,
     custom_token: Contract,
     service_registry: Contract,
     uninitialized_user_deposit_contract: Contract,
@@ -26,7 +26,7 @@ def monitoring_service_internals(
     custom_token: Contract,
     service_registry: Contract,
     uninitialized_user_deposit_contract: Contract,
-    deploy_tester_contract: Contract,
+    deploy_tester_contract: Callable,
     token_network_registry_contract: Contract,
 ) -> Contract:
     return deploy_tester_contract(

--- a/raiden_contracts/tests/fixtures/test_contracts.py
+++ b/raiden_contracts/tests/fixtures/test_contracts.py
@@ -28,7 +28,7 @@ def token_network_test_storage(
 
 @pytest.fixture()
 def token_network_test_signatures(
-    deploy_tester_contract: Contract,
+    deploy_tester_contract: Callable,
     web3: Web3,
     custom_token: Contract,
     secret_registry_contract: Contract,
@@ -45,7 +45,7 @@ def token_network_test_signatures(
 
 @pytest.fixture()
 def token_network_test_utils(
-    deploy_tester_contract: Contract,
+    deploy_tester_contract: Callable,
     web3: Web3,
     custom_token: Contract,
     secret_registry_contract: Contract,

--- a/raiden_contracts/tests/fixtures/token.py
+++ b/raiden_contracts/tests/fixtures/token.py
@@ -52,7 +52,7 @@ def human_standard_token(deploy_token_contract: Callable, token_args: Dict) -> C
 
 
 @pytest.fixture
-def deploy_token_contract(deploy_tester_contract: Contract) -> Callable:
+def deploy_token_contract(deploy_tester_contract: Callable) -> Callable:
     """Returns a function that deploys a generic HumanStandardToken contract"""
 
     def f(**args: Dict) -> Contract:

--- a/raiden_contracts/tests/fixtures/token_network_fixtures.py
+++ b/raiden_contracts/tests/fixtures/token_network_fixtures.py
@@ -15,6 +15,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MIN,
 )
 from raiden_contracts.contract_manager import ContractManager
+from raiden_contracts.tests.utils import call_and_transact
 from raiden_contracts.tests.utils.constants import DEPLOYER_ADDRESS
 
 snapshot_before_token_network = None
@@ -41,9 +42,12 @@ def register_token_network(web3: Web3, contracts_manager: ContractManager) -> Ca
         channel_participant_deposit_limit: int,
         token_network_deposit_limit: int,
     ) -> Contract:
-        tx_hash = token_network_registry.functions.createERC20TokenNetwork(
-            token_address, channel_participant_deposit_limit, token_network_deposit_limit
-        ).call_and_transact({"from": DEPLOYER_ADDRESS})
+        tx_hash = call_and_transact(
+            token_network_registry.functions.createERC20TokenNetwork(
+                token_address, channel_participant_deposit_limit, token_network_deposit_limit
+            ),
+            {"from": DEPLOYER_ADDRESS},
+        )
         tx_receipt = web3.eth.getTransactionReceipt(tx_hash)
         event_abi = contracts_manager.get_event_abi(
             CONTRACT_TOKEN_NETWORK_REGISTRY, EVENT_TOKEN_NETWORK_CREATED

--- a/raiden_contracts/tests/fixtures/token_network_fixtures.py
+++ b/raiden_contracts/tests/fixtures/token_network_fixtures.py
@@ -97,7 +97,7 @@ def token_network(
 ) -> Contract:
     """Register a new token network for a custom token"""
     global snapshot_before_token_network
-    snapshot_before_token_network = web3.testing.snapshot()
+    snapshot_before_token_network = web3.testing.snapshot()  # type: ignore
     return register_token_network(
         token_network_registry_contract,
         custom_token.address,
@@ -130,11 +130,11 @@ def token_network_contract(
     deploy_tester_contract: Callable,
     secret_registry_contract: Contract,
     standard_token_contract: Contract,
+    web3: Web3,
 ) -> Contract:
-    network_id = int(secret_registry_contract.web3.version.network)
     return deploy_tester_contract(
         CONTRACT_TOKEN_NETWORK,
-        [standard_token_contract.address, secret_registry_contract.address, network_id],
+        [standard_token_contract.address, secret_registry_contract.address, web3.eth.chainId],
     )
 
 

--- a/raiden_contracts/tests/fixtures/token_network_fixtures.py
+++ b/raiden_contracts/tests/fixtures/token_network_fixtures.py
@@ -123,7 +123,7 @@ def token_network_in_another_token_network_registry(
 
 @pytest.fixture
 def token_network_contract(
-    deploy_tester_contract: Contract,
+    deploy_tester_contract: Callable,
     secret_registry_contract: Contract,
     standard_token_contract: Contract,
 ) -> Contract:

--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -19,7 +19,7 @@ from raiden_contracts.utils.transaction import check_successful_tx
 
 
 @pytest.fixture()
-def get_token_network_registry(deploy_tester_contract: Contract) -> Callable:
+def get_token_network_registry(deploy_tester_contract: Callable) -> Callable:
     def get(**arguments: Dict) -> Contract:
         return deploy_tester_contract(CONTRACT_TOKEN_NETWORK_REGISTRY, **arguments)
 
@@ -71,7 +71,7 @@ def token_network_registry_address(token_network_registry_contract: Contract) ->
 def add_and_register_token(
     web3: Web3,
     token_network_registry_contract: Contract,
-    deploy_token_contract: Contract,
+    deploy_token_contract: Callable,
     contracts_manager: ContractManager,
     channel_participant_deposit_limit: int,
     token_network_deposit_limit: int,

--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -14,6 +14,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MIN,
 )
 from raiden_contracts.contract_manager import ContractManager
+from raiden_contracts.tests.utils import call_and_transact
 from raiden_contracts.tests.utils.constants import DEPLOYER_ADDRESS
 from raiden_contracts.utils.transaction import check_successful_tx
 
@@ -80,9 +81,14 @@ def add_and_register_token(
 
     def f(initial_amount: int, decimals: int, token_name: str, token_symbol: str) -> Contract:
         token_contract = deploy_token_contract(initial_amount, decimals, token_name, token_symbol)
-        txid = token_network_registry_contract.functions.createERC20TokenNetwork(
-            token_contract.address, channel_participant_deposit_limit, token_network_deposit_limit
-        ).call_and_transact({"from": DEPLOYER_ADDRESS})
+        txid = call_and_transact(
+            token_network_registry_contract.functions.createERC20TokenNetwork(
+                token_contract.address,
+                channel_participant_deposit_limit,
+                token_network_deposit_limit,
+            ),
+            {"from": DEPLOYER_ADDRESS},
+        )
         (tx_receipt, _) = check_successful_tx(web3, txid)
         assert len(tx_receipt["logs"]) == 1
         event_abi = contracts_manager.get_event_abi(

--- a/raiden_contracts/tests/fixtures/user_deposit.py
+++ b/raiden_contracts/tests/fixtures/user_deposit.py
@@ -6,6 +6,7 @@ from web3.contract import Contract
 
 from raiden_contracts.constants import CONTRACT_USER_DEPOSIT
 from raiden_contracts.tests.fixtures.token import CUSTOM_TOKEN_TOTAL_SUPPLY
+from raiden_contracts.tests.utils import call_and_transact
 
 
 @pytest.fixture(scope="session")
@@ -30,9 +31,11 @@ def user_deposit_contract(
     monitoring_service_external: Contract,
     one_to_n_contract: Contract,
 ) -> Contract:
-    uninitialized_user_deposit_contract.functions.init(
-        monitoring_service_external.address, one_to_n_contract.address
-    ).call_and_transact()
+    call_and_transact(
+        uninitialized_user_deposit_contract.functions.init(
+            monitoring_service_external.address, one_to_n_contract.address
+        )
+    )
     return uninitialized_user_deposit_contract
 
 
@@ -53,12 +56,13 @@ def deposit_to_udc(user_deposit_contract: Contract, custom_token: Contract) -> C
         If you call it twice, only amount2 - amount1 will be deposited. More
         will be mined and approved to keep the implementation simple, though.
         """
-        custom_token.functions.mint(amount).call_and_transact({"from": receiver})
-        custom_token.functions.approve(user_deposit_contract.address, amount).call_and_transact(
-            {"from": receiver}
+        call_and_transact(custom_token.functions.mint(amount), {"from": receiver})
+        call_and_transact(
+            custom_token.functions.approve(user_deposit_contract.address, amount),
+            {"from": receiver},
         )
-        user_deposit_contract.functions.deposit(receiver, amount).call_and_transact(
-            {"from": receiver}
+        call_and_transact(
+            user_deposit_contract.functions.deposit(receiver, amount), {"from": receiver}
         )
 
     return deposit

--- a/raiden_contracts/tests/test_channel_close.py
+++ b/raiden_contracts/tests/test_channel_close.py
@@ -22,6 +22,7 @@ from raiden_contracts.tests.utils import (
     call_and_transact,
     fake_bytes,
 )
+from raiden_contracts.tests.utils.blockchain import mine_blocks
 from raiden_contracts.utils.events import check_channel_closed
 
 
@@ -79,7 +80,7 @@ def test_close_settled_channel_fail(
         ),
         {"from": A},
     )
-    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
+    mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
     call_and_transact(
         token_network.functions.settleChannel(
             channel_identifier=channel_identifier,
@@ -647,7 +648,7 @@ def test_close_replay_reopened_channel(
         ),
         {"from": A},
     )
-    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
+    mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
     call_and_transact(
         token_network.functions.settleChannel(
             channel_identifier=channel_identifier1,

--- a/raiden_contracts/tests/test_channel_close.py
+++ b/raiden_contracts/tests/test_channel_close.py
@@ -5,6 +5,7 @@ from eth_tester.exceptions import TransactionFailed
 from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract import Contract
+from web3.types import Wei
 
 from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MIN,
@@ -47,7 +48,7 @@ def test_close_nonexistent_channel(token_network: Contract, get_accounts: Callab
             additional_hash=EMPTY_ADDITIONAL_HASH,
             non_closing_signature=EMPTY_SIGNATURE,
             closing_signature=EMPTY_SIGNATURE,
-        ).call({"from": A, "gas": 81000})
+        ).call({"from": A, "gas": Wei(81_000)})
 
 
 def test_close_settled_channel_fail(

--- a/raiden_contracts/tests/test_channel_cooperative_settle.py
+++ b/raiden_contracts/tests/test_channel_cooperative_settle.py
@@ -6,6 +6,7 @@ from web3.contract import Contract
 from web3.exceptions import ValidationError
 
 from raiden_contracts.constants import EMPTY_ADDRESS, ChannelEvent
+from raiden_contracts.tests.utils import call_and_transact
 from raiden_contracts.utils.events import check_channel_settled
 
 
@@ -54,17 +55,38 @@ def test_cooperative_settle_channel_call(
         )
 
     with pytest.raises(TransactionFailed):
-        token_network.functions.cooperativeSettle(
-            channel_identifier, EMPTY_ADDRESS, balance_A, B, balance_B, signature_A, signature_B
-        ).call_and_transact({"from": C})
+        call_and_transact(
+            token_network.functions.cooperativeSettle(
+                channel_identifier,
+                EMPTY_ADDRESS,
+                balance_A,
+                B,
+                balance_B,
+                signature_A,
+                signature_B,
+            ),
+            {"from": C},
+        )
     with pytest.raises(TransactionFailed):
-        token_network.functions.cooperativeSettle(
-            channel_identifier, A, balance_A, EMPTY_ADDRESS, balance_B, signature_A, signature_B
-        ).call_and_transact({"from": C})
+        call_and_transact(
+            token_network.functions.cooperativeSettle(
+                channel_identifier,
+                A,
+                balance_A,
+                EMPTY_ADDRESS,
+                balance_B,
+                signature_A,
+                signature_B,
+            ),
+            {"from": C},
+        )
 
-    token_network.functions.cooperativeSettle(
-        channel_identifier, A, balance_A, B, balance_B, signature_A, signature_B
-    ).call_and_transact({"from": C})
+    call_and_transact(
+        token_network.functions.cooperativeSettle(
+            channel_identifier, A, balance_A, B, balance_B, signature_A, signature_B
+        ),
+        {"from": C},
+    )
 
 
 @pytest.mark.skip(reason="Delayed until another milestone")
@@ -99,9 +121,12 @@ def test_cooperative_settle_channel_signatures(
             channel_identifier, A, balance_B, B, balance_A, signature_A, signature_B
         ).call({"from": C})
 
-    token_network.functions.cooperativeSettle(
-        channel_identifier, A, balance_A, B, balance_B, signature_A, signature_B
-    ).call_and_transact({"from": C})
+    call_and_transact(
+        token_network.functions.cooperativeSettle(
+            channel_identifier, A, balance_A, B, balance_B, signature_A, signature_B
+        ),
+        {"from": C},
+    )
 
 
 @pytest.mark.skip(reason="Delayed until another milestone")
@@ -129,9 +154,12 @@ def test_cooperative_settle_channel_0(
     pre_account_balance_B = custom_token.functions.balanceOf(B).call()
     pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
-    token_network.functions.cooperativeSettle(
-        channel_identifier, A, balance_A, B, balance_B, signature_A, signature_B
-    ).call_and_transact({"from": C})
+    call_and_transact(
+        token_network.functions.cooperativeSettle(
+            channel_identifier, A, balance_A, B, balance_B, signature_A, signature_B
+        ),
+        {"from": C},
+    )
 
     cooperative_settle_state_tests(
         channel_identifier,
@@ -170,9 +198,12 @@ def test_cooperative_settle_channel_00(
     pre_account_balance_B = custom_token.functions.balanceOf(B).call()
     pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
-    token_network.functions.cooperativeSettle(
-        channel_identifier, A, balance_A, B, balance_B, signature_A, signature_B
-    ).call_and_transact({"from": C})
+    call_and_transact(
+        token_network.functions.cooperativeSettle(
+            channel_identifier, A, balance_A, B, balance_B, signature_A, signature_B
+        ),
+        {"from": C},
+    )
 
     cooperative_settle_state_tests(
         channel_identifier,
@@ -212,9 +243,12 @@ def test_cooperative_settle_channel_state(
     pre_account_balance_B = custom_token.functions.balanceOf(B).call()
     pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
-    token_network.functions.cooperativeSettle(
-        channel_identifier, A, balance_A, B, balance_B, signature_A, signature_B
-    ).call_and_transact({"from": C})
+    call_and_transact(
+        token_network.functions.cooperativeSettle(
+            channel_identifier, A, balance_A, B, balance_B, signature_A, signature_B
+        ),
+        {"from": C},
+    )
 
     cooperative_settle_state_tests(
         channel_identifier,
@@ -259,9 +293,12 @@ def test_cooperative_settle_channel_state_withdraw(
     pre_account_balance_B = custom_token.functions.balanceOf(B).call()
     pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
-    token_network.functions.cooperativeSettle(
-        channel_identifier, A, balance_A, B, balance_B, signature_A, signature_B
-    ).call_and_transact({"from": C})
+    call_and_transact(
+        token_network.functions.cooperativeSettle(
+            channel_identifier, A, balance_A, B, balance_B, signature_A, signature_B
+        ),
+        {"from": C},
+    )
 
     cooperative_settle_state_tests(
         channel_identifier,
@@ -357,9 +394,12 @@ def test_cooperative_settle_channel_wrong_balances(
             signature_B_fail2,
         ).call({"from": C})
 
-    token_network.functions.cooperativeSettle(
-        channel_identifier, A, balance_A, B, balance_B, signature_A, signature_B
-    ).call_and_transact({"from": C})
+    call_and_transact(
+        token_network.functions.cooperativeSettle(
+            channel_identifier, A, balance_A, B, balance_B, signature_A, signature_B
+        ),
+        {"from": C},
+    )
 
 
 @pytest.mark.skip(reason="Delayed until another milestone")
@@ -384,9 +424,12 @@ def test_cooperative_close_replay_reopened_channel(
         [A, B], channel_identifier1, B, balance_B, A, balance_A
     )
 
-    token_network.functions.cooperativeSettle(
-        channel_identifier1, B, balance_B, A, balance_A, signature_B, signature_A
-    ).call_and_transact({"from": B})
+    call_and_transact(
+        token_network.functions.cooperativeSettle(
+            channel_identifier1, B, balance_B, A, balance_A, signature_B, signature_A
+        ),
+        {"from": B},
+    )
 
     # Reopen the channel and make sure we cannot use the old balance proof
     channel_identifier2 = create_channel(A, B)[0]
@@ -403,9 +446,12 @@ def test_cooperative_close_replay_reopened_channel(
     (signature_A2, signature_B2) = create_cooperative_settle_signatures(
         [A, B], channel_identifier2, B, balance_B, A, balance_A
     )
-    token_network.functions.cooperativeSettle(
-        channel_identifier2, B, balance_B, A, balance_A, signature_B2, signature_A2
-    ).call_and_transact({"from": B})
+    call_and_transact(
+        token_network.functions.cooperativeSettle(
+            channel_identifier2, B, balance_B, A, balance_A, signature_B2, signature_A2
+        ),
+        {"from": B},
+    )
 
 
 @pytest.mark.skip(reason="Delayed until another milestone")
@@ -429,9 +475,12 @@ def test_cooperative_settle_channel_event(
         [A, B], channel_identifier, B, balance_B, A, balance_A
     )
 
-    txn_hash = token_network.functions.cooperativeSettle(
-        channel_identifier, B, balance_B, A, balance_A, signature_B, signature_A
-    ).call_and_transact({"from": B})
+    txn_hash = call_and_transact(
+        token_network.functions.cooperativeSettle(
+            channel_identifier, B, balance_B, A, balance_A, signature_B, signature_A
+        ),
+        {"from": B},
+    )
 
     ev_handler.add(
         txn_hash,

--- a/raiden_contracts/tests/test_channel_deposit.py
+++ b/raiden_contracts/tests/test_channel_deposit.py
@@ -17,6 +17,7 @@ from raiden_contracts.tests.utils import (
     ChannelValues,
     call_and_transact,
 )
+from raiden_contracts.tests.utils.blockchain import mine_blocks
 from raiden_contracts.utils.events import check_new_deposit
 
 
@@ -106,7 +107,7 @@ def test_deposit_notapproved(
     deposit_A = 1
 
     call_and_transact(custom_token.functions.mint(deposit_A), {"from": A})
-    web3.testing.mine(1)
+    mine_blocks(web3, 1)
     balance = custom_token.functions.balanceOf(A).call()
     assert balance >= deposit_A, f"minted {deposit_A} but the balance is still {balance}"
 
@@ -306,7 +307,7 @@ def test_deposit_wrong_state_fail(
             {"from": B}
         )
 
-    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
+    mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
     call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
     with pytest.raises(TransactionFailed):
         token_network.functions.setTotalDeposit(channel_identifier, A, vals_A.deposit, B).call(

--- a/raiden_contracts/tests/test_channel_open.py
+++ b/raiden_contracts/tests/test_channel_open.py
@@ -28,6 +28,7 @@ from raiden_contracts.tests.utils import (
 from raiden_contracts.utils.events import check_channel_opened
 
 from .utils import get_participants_hash
+from .utils.blockchain import mine_blocks
 
 
 def test_open_channel_call(token_network: Contract, get_accounts: Callable) -> None:
@@ -292,7 +293,7 @@ def test_reopen_channel(
         token_network.functions.openChannel(A, B, settle_timeout).call()
 
     # Settlement window must be over before settling the channel
-    web3.testing.mine(settle_timeout + 1)
+    mine_blocks(web3, settle_timeout + 1)
 
     # Settle channel
     call_and_transact(

--- a/raiden_contracts/tests/test_channel_settle.py
+++ b/raiden_contracts/tests/test_channel_settle.py
@@ -26,6 +26,7 @@ from raiden_contracts.tests.utils import (
     get_onchain_settlement_amounts,
     get_settlement_amounts,
 )
+from raiden_contracts.tests.utils.blockchain import mine_blocks
 from raiden_contracts.utils.events import check_channel_settled
 from raiden_contracts.utils.pending_transfers import (
     get_pending_transfers_tree_with_generated_lists,
@@ -66,7 +67,7 @@ def test_settle_no_bp_success(
     # Do not call updateNonClosingBalanceProof
 
     # Settlement window must be over before settling the channel
-    web3.testing.mine(settle_timeout + 1)
+    mine_blocks(web3, settle_timeout + 1)
 
     # Settling the channel should work with no balance proofs
     call_and_transact(
@@ -131,7 +132,7 @@ def test_settle_channel_state(
     withdraw_channel(channel_identifier, B, vals_B.withdrawn, UINT256_MAX, A)
     close_and_update_channel(channel_identifier, A, vals_A, B, vals_B)
 
-    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
+    mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
 
     pre_balance_A = custom_token.functions.balanceOf(A).call()
     pre_balance_B = custom_token.functions.balanceOf(B).call()
@@ -213,7 +214,7 @@ def test_settle_single_direct_transfer_for_closing_party(
     pre_balance_B = custom_token.functions.balanceOf(B).call()
     pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
-    web3.testing.mine(settle_timeout + 1)
+    mine_blocks(web3, settle_timeout + 1)
     call_and_transact(
         token_network.functions.settleChannel(
             channel_identifier=channel_identifier,
@@ -312,7 +313,7 @@ def test_settle_single_direct_transfer_for_counterparty(
     pre_balance_B = custom_token.functions.balanceOf(B).call()
     pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
-    web3.testing.mine(settle_timeout + 1)
+    mine_blocks(web3, settle_timeout + 1)
     call_and_transact(
         token_network.functions.settleChannel(
             channel_identifier=channel_identifier,
@@ -387,7 +388,7 @@ def test_settlement_with_unauthorized_token_transfer(
         pre_balance_contract + externally_transferred_amount
     )
 
-    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
+    mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
 
     # Compute expected settlement amounts
     settlement = get_settlement_amounts(vals_A, vals_B)
@@ -465,7 +466,7 @@ def test_settle_wrong_state_fail(
     with pytest.raises(TransactionFailed):
         call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
 
-    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
+    mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
     assert web3.eth.blockNumber > settle_block_number
 
     # Channel is settled
@@ -524,7 +525,7 @@ def test_settle_wrong_balance_hash(
 
     close_and_update_channel(channel_identifier, A, vals_A, B, vals_B)
 
-    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
+    mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
 
     with pytest.raises(TransactionFailed):
         call_settle(token_network, channel_identifier, B, vals_A, A, vals_B)
@@ -656,7 +657,7 @@ def test_settle_channel_event(
         {"from": B},
     )
 
-    web3.testing.mine(settle_timeout + 1)
+    mine_blocks(web3, settle_timeout + 1)
     txn_hash = call_and_transact(
         token_network.functions.settleChannel(
             channel_identifier=channel_identifier,

--- a/raiden_contracts/tests/test_channel_settle_unlock_state.py
+++ b/raiden_contracts/tests/test_channel_settle_unlock_state.py
@@ -15,6 +15,7 @@ from raiden_contracts.tests.utils import (
     NONEXISTENT_LOCKSROOT,
     UINT256_MAX,
     are_balance_proofs_valid,
+    call_and_transact,
     get_expected_after_settlement_unlock_amounts,
     get_onchain_settlement_amounts,
     get_settlement_amounts,
@@ -147,9 +148,11 @@ def test_settlement_outcome(
                     channel_identifier, A, B, pending_transfers_tree_B.packed_transfers
                 ).call()
         else:
-            token_network.functions.unlock(
-                channel_identifier, A, B, pending_transfers_tree_B.packed_transfers
-            ).call_and_transact()
+            call_and_transact(
+                token_network.functions.unlock(
+                    channel_identifier, A, B, pending_transfers_tree_B.packed_transfers
+                )
+            )
 
         # The locked amount should have been removed from contract storage
         info_B = token_network.functions.getChannelParticipantInfo(channel_identifier, B, A).call()
@@ -168,9 +171,11 @@ def test_settlement_outcome(
                     channel_identifier, B, A, pending_transfers_tree_A.packed_transfers
                 ).call()
         else:
-            token_network.functions.unlock(
-                channel_identifier, B, A, pending_transfers_tree_A.packed_transfers
-            ).call_and_transact()
+            call_and_transact(
+                token_network.functions.unlock(
+                    channel_identifier, B, A, pending_transfers_tree_A.packed_transfers
+                )
+            )
 
         # The locked amount should have been removed from contract storage
         info_A = token_network.functions.getChannelParticipantInfo(channel_identifier, A, B).call()

--- a/raiden_contracts/tests/test_channel_settle_unlock_state.py
+++ b/raiden_contracts/tests/test_channel_settle_unlock_state.py
@@ -24,6 +24,7 @@ from raiden_contracts.tests.utils import (
     is_balance_proof_old,
     were_balance_proofs_valid,
 )
+from raiden_contracts.tests.utils.blockchain import mine_blocks
 from raiden_contracts.utils.pending_transfers import (
     get_pending_transfers_tree_with_generated_lists,
 )
@@ -82,7 +83,7 @@ def test_settlement_outcome(
 
         close_and_update_channel(channel_identifier, A, vals_A, B, vals_B)
 
-        web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN)
+        mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN)
 
         pre_balance_A = custom_token.functions.balanceOf(A).call()
         pre_balance_B = custom_token.functions.balanceOf(B).call()
@@ -390,7 +391,7 @@ def test_channel_settle_invalid_balance_proof_values(
 
     close_and_update_channel(channel_identifier, A, vals_A, B, vals_B)
 
-    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
+    mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
 
     pre_balance_A = custom_token.functions.balanceOf(A).call()
     pre_balance_B = custom_token.functions.balanceOf(B).call()

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -18,6 +18,7 @@ from raiden_contracts.tests.utils import (
     fake_bytes,
     get_unlocked_amount,
 )
+from raiden_contracts.tests.utils.blockchain import mine_blocks
 from raiden_contracts.utils.events import check_channel_unlocked
 from raiden_contracts.utils.pending_transfers import (
     get_locked_amount,
@@ -298,12 +299,12 @@ def test_lock_data_from_packed_locks(
     assert claimable_amount == claimable(4)
 
     # Register last secret after expiration
-    web3.testing.mine(5)
+    mine_blocks(web3, 5)
     last_lock = pending_transfers_tree.expired[-1]
     # expiration
     assert web3.eth.blockNumber > last_lock[0]
     # register secret
-    secret_registry_contract.functions.registerSecret(last_lock[3]).call_and_transact()
+    call_and_transact(secret_registry_contract.functions.registerSecret(last_lock[3]))
     # ensure registration was done
     assert (
         secret_registry_contract.functions.getSecretRevealBlockHeight(last_lock[2]).call()
@@ -595,7 +596,7 @@ def test_channel_unlock(
     close_and_update_channel(channel_identifier, A, values_A, B, values_B)
 
     # Settlement window must be over before settling the channel
-    web3.testing.mine(settle_timeout)
+    mine_blocks(web3, settle_timeout)
 
     call_settle(token_network, channel_identifier, A, values_A, B, values_B)
 
@@ -766,7 +767,7 @@ def test_channel_unlock_registered_expired_lock_refunds(
     )
 
     # Locks expire
-    web3.testing.mine(max_lock_expiration)
+    mine_blocks(web3, max_lock_expiration)
 
     # Secrets are revealed before settlement window, but after expiration
     for (_, _, secrethash, secret) in pending_transfers_tree.unlockable:
@@ -777,7 +778,7 @@ def test_channel_unlock_registered_expired_lock_refunds(
         )
 
     close_and_update_channel(channel_identifier, A, values_A, B, values_B)
-    web3.testing.mine(settle_timeout)
+    mine_blocks(web3, settle_timeout)
 
     # settle channel
     call_settle(token_network, channel_identifier, A, values_A, B, values_B)
@@ -837,7 +838,7 @@ def test_channel_unlock_unregistered_locks(
     close_and_update_channel(channel_identifier, A, vals_A, B, vals_B)
 
     # Secret hasn't been registered before settlement timeout
-    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
+    mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
     call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
 
     # Someone unlocks A's pending transfers - all tokens should be refunded
@@ -909,7 +910,7 @@ def test_channel_unlock_before_settlement_fails(
         ).call()
 
     # Settlement window must be over before settling the channel
-    web3.testing.mine(settle_timeout)
+    mine_blocks(web3, settle_timeout)
 
     # Unlock fails before settle is called
     with pytest.raises(TransactionFailed):
@@ -1077,7 +1078,7 @@ def test_channel_unlock_both_participants(
     close_and_update_channel(channel_identifier, A, values_A, B, values_B)
 
     # Settle channel
-    web3.testing.mine(settle_timeout)
+    mine_blocks(web3, settle_timeout)
 
     call_settle(token_network, channel_identifier, A, values_A, B, values_B)
 
@@ -1242,7 +1243,7 @@ def test_channel_unlock_with_a_large_expiration(
     close_and_update_channel(channel_identifier, A, values_A, B, values_B)
 
     # Settle channel after a "long" time
-    web3.testing.mine(settle_timeout + 50)
+    mine_blocks(web3, settle_timeout + 50)
 
     call_settle(token_network, channel_identifier, A, values_A, B, values_B)
 
@@ -1448,7 +1449,7 @@ def test_unlock_channel_event(
     close_and_update_channel(channel_identifier, A, values_A, B, values_B)
 
     # Settlement window must be over before settling the channel
-    web3.testing.mine(settle_timeout)
+    mine_blocks(web3, settle_timeout)
 
     call_settle(token_network, channel_identifier, A, values_A, B, values_B)
 

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -14,6 +14,7 @@ from raiden_contracts.tests.utils import (
     ChannelValues,
     LockedAmounts,
     LockIndex,
+    call_and_transact,
     fake_bytes,
     get_unlocked_amount,
 )
@@ -69,9 +70,12 @@ def test_1_item_unlockable(
         web3=web3, unlockable_amounts=[6], expired_amounts=[]
     )
 
-    secret_registry_contract.functions.registerSecret(
-        pending_transfers_tree.unlockable[0][LockIndex.SECRET]
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        secret_registry_contract.functions.registerSecret(
+            pending_transfers_tree.unlockable[0][LockIndex.SECRET]
+        ),
+        {"from": A},
+    )
     assert (
         secret_registry_contract.functions.getSecretRevealBlockHeight(
             pending_transfers_tree.unlockable[0][LockIndex.SECRETHASH]
@@ -102,9 +106,12 @@ def test_get_hash_length_fail(
     A = get_accounts(1)[0]
     pending_transfers_tree = get_pending_transfers_tree(web3, [2, 3, 6], [5])
 
-    secret_registry_contract.functions.registerSecret(
-        pending_transfers_tree.unlockable[0][LockIndex.SECRET]
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        secret_registry_contract.functions.registerSecret(
+            pending_transfers_tree.unlockable[0][LockIndex.SECRET]
+        ),
+        {"from": A},
+    )
     assert (
         secret_registry_contract.functions.getSecretRevealBlockHeight(
             pending_transfers_tree.unlockable[0][LockIndex.SECRETHASH]
@@ -235,9 +242,11 @@ def test_locks_order(
     ).call()
     assert locksroot == pending_transfers_tree.hash_of_packed_transfers
     assert unlocked_amount == 9
-    token_network.functions.unlock(
-        channel_identifier, B, A, pending_transfers_tree.packed_transfers
-    ).call_and_transact()
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, B, A, pending_transfers_tree.packed_transfers
+        )
+    )
 
 
 def test_lock_data_from_packed_locks(
@@ -343,9 +352,11 @@ def test_unlock_wrong_locksroot(
     with pytest.raises(TransactionFailed):
         token_network.functions.unlock(channel_identifier, B, A, b"").call()
 
-    token_network.functions.unlock(
-        channel_identifier, B, A, pending_transfers_tree_A.packed_transfers
-    ).call_and_transact()
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, B, A, pending_transfers_tree_A.packed_transfers
+        )
+    )
 
 
 def test_channel_unlock_bigger_locked_amount(
@@ -392,9 +403,11 @@ def test_channel_unlock_bigger_locked_amount(
 
     # This should pass, even though the locked amount in storage is bigger. The rest of the
     # tokens is sent to A, as tokens corresponding to the locks that could not be unlocked.
-    token_network.functions.unlock(
-        channel_identifier, B, A, pending_transfers_tree_A.packed_transfers
-    ).call_and_transact()
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, B, A, pending_transfers_tree_A.packed_transfers
+        )
+    )
     balance_A = custom_token.functions.balanceOf(A).call()
     balance_B = custom_token.functions.balanceOf(B).call()
     balance_contract = custom_token.functions.balanceOf(token_network.address).call()
@@ -449,9 +462,11 @@ def test_channel_unlock_smaller_locked_amount(
 
     # This should pass, even though the locked amount in storage is smaller.
     # B will receive less tokens.
-    token_network.functions.unlock(
-        channel_identifier, B, A, pending_transfers_tree_A.packed_transfers
-    ).call_and_transact()
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, B, A, pending_transfers_tree_A.packed_transfers
+        )
+    )
 
     balance_A = custom_token.functions.balanceOf(A).call()
     balance_B = custom_token.functions.balanceOf(B).call()
@@ -503,9 +518,11 @@ def test_channel_unlock_bigger_unlocked_amount(
     # This should pass, even though the locked amount in storage is smaller.
     # B will receive the entire locked amount, corresponding to the locks that have been unlocked
     # and A will receive nothing.
-    token_network.functions.unlock(
-        channel_identifier, B, A, pending_transfers_tree_A.packed_transfers
-    ).call_and_transact()
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, B, A, pending_transfers_tree_A.packed_transfers
+        )
+    )
 
     balance_A = custom_token.functions.balanceOf(A).call()
     balance_B = custom_token.functions.balanceOf(B).call()
@@ -591,9 +608,11 @@ def test_channel_unlock(
     assert info_B[ParticipantInfoIndex.LOCKED_AMOUNT] == values_B.locked_amounts.locked
 
     # Unlock the tokens
-    token_network.functions.unlock(
-        channel_identifier, A, B, pending_transfers_tree.packed_transfers
-    ).call_and_transact()
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, A, B, pending_transfers_tree.packed_transfers
+        )
+    )
 
     info_B = token_network.functions.getChannelParticipantInfo(channel_identifier, B, A).call()
     assert info_B[ParticipantInfoIndex.LOCKSROOT] == NONEXISTENT_LOCKSROOT
@@ -633,9 +652,12 @@ def test_channel_settle_and_unlock(
         LOCKSROOT_OF_NO_LOCKS,
         settle_timeout,
     )
-    token_network.functions.unlock(
-        channel_identifier1, B, A, pending_transfers_tree_1.packed_transfers
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier1, B, A, pending_transfers_tree_1.packed_transfers
+        ),
+        {"from": A},
+    )
 
     # Mock pending transfers data for a reopened channel
     pending_transfers_tree_2 = get_pending_transfers_tree(web3, [1, 3, 5], [2, 4], settle_timeout)
@@ -653,9 +675,12 @@ def test_channel_settle_and_unlock(
     )
 
     # 2nd unlocks should go through
-    token_network.functions.unlock(
-        channel_identifier2, B, A, pending_transfers_tree_2.packed_transfers
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier2, B, A, pending_transfers_tree_2.packed_transfers
+        ),
+        {"from": A},
+    )
 
     # Edge channel life-cycle: open -> settle -> open -> settle ->  unlock1 -> unlock2
 
@@ -690,12 +715,18 @@ def test_channel_settle_and_unlock(
     )
 
     # Both old and new unlocks should go through
-    token_network.functions.unlock(
-        channel_identifier4, B, A, pending_transfers_tree_2.packed_transfers
-    ).call_and_transact({"from": A})
-    token_network.functions.unlock(
-        channel_identifier3, B, A, pending_transfers_tree_1.packed_transfers
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier4, B, A, pending_transfers_tree_2.packed_transfers
+        ),
+        {"from": A},
+    )
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier3, B, A, pending_transfers_tree_1.packed_transfers
+        ),
+        {"from": A},
+    )
 
 
 def test_channel_unlock_registered_expired_lock_refunds(
@@ -739,7 +770,7 @@ def test_channel_unlock_registered_expired_lock_refunds(
 
     # Secrets are revealed before settlement window, but after expiration
     for (_, _, secrethash, secret) in pending_transfers_tree.unlockable:
-        secret_registry_contract.functions.registerSecret(secret).call_and_transact({"from": A})
+        call_and_transact(secret_registry_contract.functions.registerSecret(secret), {"from": A})
         assert (
             secret_registry_contract.functions.getSecretRevealBlockHeight(secrethash).call()
             == web3.eth.blockNumber
@@ -756,9 +787,11 @@ def test_channel_unlock_registered_expired_lock_refunds(
     pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
     # Unlock works after channel is settled
-    token_network.functions.unlock(
-        channel_identifier, A, B, pending_transfers_tree.packed_transfers
-    ).call_and_transact()
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, A, B, pending_transfers_tree.packed_transfers
+        )
+    )
 
     balance_A = custom_token.functions.balanceOf(A).call()
     balance_B = custom_token.functions.balanceOf(B).call()
@@ -808,9 +841,12 @@ def test_channel_unlock_unregistered_locks(
     call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
 
     # Someone unlocks A's pending transfers - all tokens should be refunded
-    token_network.functions.unlock(
-        channel_identifier, B, A, pending_transfers_tree.packed_transfers
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, B, A, pending_transfers_tree.packed_transfers
+        ),
+        {"from": A},
+    )
 
     # A gets back locked tokens
     assert (
@@ -889,9 +925,11 @@ def test_channel_unlock_before_settlement_fails(
     pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
     # Unlock works after channel is settled
-    token_network.functions.unlock(
-        channel_identifier, A, B, pending_transfers_tree.packed_transfers
-    ).call_and_transact()
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, A, B, pending_transfers_tree.packed_transfers
+        )
+    )
 
     balance_A = custom_token.functions.balanceOf(A).call()
     balance_B = custom_token.functions.balanceOf(B).call()
@@ -939,9 +977,12 @@ def test_unlock_fails_with_partial_locks(
             ).call({"from": A})
 
     # Unlock with full pending locks does work
-    token_network.functions.unlock(
-        channel_identifier, B, A, pending_transfers_tree.packed_transfers
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, B, A, pending_transfers_tree.packed_transfers
+        ),
+        {"from": A},
+    )
 
 
 def test_unlock_tampered_proof_fails(
@@ -982,9 +1023,12 @@ def test_unlock_tampered_proof_fails(
             ).call({"from": A})
 
     # Unlock with correct pending locks does work
-    token_network.functions.unlock(
-        channel_identifier, B, A, pending_transfers_tree.packed_transfers
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, B, A, pending_transfers_tree.packed_transfers
+        ),
+        {"from": A},
+    )
 
 
 def test_channel_unlock_both_participants(
@@ -1042,14 +1086,18 @@ def test_channel_unlock_both_participants(
     pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
     # A unlock's
-    token_network.functions.unlock(
-        channel_identifier, A, B, pending_transfers_tree_B.packed_transfers
-    ).call_and_transact()
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, A, B, pending_transfers_tree_B.packed_transfers
+        )
+    )
 
     # B unlock's
-    token_network.functions.unlock(
-        channel_identifier, B, A, pending_transfers_tree_A.packed_transfers
-    ).call_and_transact()
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, B, A, pending_transfers_tree_A.packed_transfers
+        )
+    )
 
     balance_A = custom_token.functions.balanceOf(A).call()
     balance_B = custom_token.functions.balanceOf(B).call()
@@ -1104,9 +1152,12 @@ def test_unlock_twice_fails(
         LOCKSROOT_OF_NO_LOCKS,
         settle_timeout,
     )
-    token_network.functions.unlock(
-        channel_identifier, B, A, pending_transfers_tree_1.packed_transfers
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, B, A, pending_transfers_tree_1.packed_transfers
+        ),
+        {"from": A},
+    )
 
     # Calling unlock twice does not work
     with pytest.raises(TransactionFailed):
@@ -1140,9 +1191,12 @@ def test_unlock_no_locks(
         LOCKSROOT_OF_NO_LOCKS,
         settle_timeout,
     )
-    token_network.functions.unlock(
-        channel_identifier, B, A, pending_transfers_tree.packed_transfers
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, B, A, pending_transfers_tree.packed_transfers
+        ),
+        {"from": A},
+    )
 
     # Calling unlock twice does not work
     with pytest.raises(TransactionFailed):
@@ -1197,9 +1251,11 @@ def test_channel_unlock_with_a_large_expiration(
     pre_balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
     # Unlock the tokens must still work
-    token_network.functions.unlock(
-        channel_identifier, A, B, pending_transfers_tree.packed_transfers
-    ).call_and_transact()
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, A, B, pending_transfers_tree.packed_transfers
+        )
+    )
 
     balance_A = custom_token.functions.balanceOf(A).call()
     balance_B = custom_token.functions.balanceOf(B).call()
@@ -1278,14 +1334,20 @@ def test_reverse_participants_unlock(
         ).call({"from": B})
 
     # Someone trying to unlock B's locksroot & locked amount on behalf of A MUST succeed
-    token_network.functions.unlock(
-        channel_identifier, A, B, pending_transfers_tree_B.packed_transfers
-    ).call_and_transact({"from": C})
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, A, B, pending_transfers_tree_B.packed_transfers
+        ),
+        {"from": C},
+    )
 
     # Someone trying to unlock A's locksroot & locked amount on behalf of B MUST succeed
-    token_network.functions.unlock(
-        channel_identifier, B, A, pending_transfers_tree_A.packed_transfers
-    ).call_and_transact({"from": C})
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, B, A, pending_transfers_tree_A.packed_transfers
+        ),
+        {"from": C},
+    )
 
 
 def test_unlock_different_channel_same_participants_fail(
@@ -1334,12 +1396,18 @@ def test_unlock_different_channel_same_participants_fail(
             channel_identifier2, B, A, pending_transfers_tree_1.packed_transfers
         ).call({"from": A})
 
-    token_network.functions.unlock(
-        channel_identifier, B, A, pending_transfers_tree_1.packed_transfers
-    ).call_and_transact({"from": A})
-    token_network.functions.unlock(
-        channel_identifier2, B, A, pending_transfers_tree_2.packed_transfers
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, B, A, pending_transfers_tree_1.packed_transfers
+        ),
+        {"from": A},
+    )
+    call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier2, B, A, pending_transfers_tree_2.packed_transfers
+        ),
+        {"from": A},
+    )
 
 
 def test_unlock_channel_event(
@@ -1387,9 +1455,11 @@ def test_unlock_channel_event(
     ev_handler = event_handler(token_network)
 
     # Unlock the tokens
-    txn_hash = token_network.functions.unlock(
-        channel_identifier, A, B, pending_transfers_tree.packed_transfers
-    ).call_and_transact()
+    txn_hash = call_and_transact(
+        token_network.functions.unlock(
+            channel_identifier, A, B, pending_transfers_tree.packed_transfers
+        )
+    )
 
     unlocked_amount = get_unlocked_amount(
         secret_registry_contract, pending_transfers_tree.packed_transfers

--- a/raiden_contracts/tests/test_channel_update_transfer.py
+++ b/raiden_contracts/tests/test_channel_update_transfer.py
@@ -21,6 +21,7 @@ from raiden_contracts.tests.utils import (
     call_and_transact,
     fake_bytes,
 )
+from raiden_contracts.tests.utils.blockchain import mine_blocks
 from raiden_contracts.utils.events import check_transfer_updated
 
 
@@ -549,7 +550,7 @@ def test_update_not_allowed_after_settlement_period(
         ),
         {"from": A},
     )
-    web3.testing.mine(settle_timeout + 1)
+    mine_blocks(web3, settle_timeout + 1)
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
             channel_identifier,
@@ -1115,7 +1116,7 @@ def test_update_replay_reopened_channel(
         {"from": A},
     )
 
-    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
+    mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
     call_and_transact(
         token_network.functions.settleChannel(
             channel_identifier1,

--- a/raiden_contracts/tests/test_channel_withdraw.py
+++ b/raiden_contracts/tests/test_channel_withdraw.py
@@ -20,6 +20,7 @@ from raiden_contracts.tests.utils import (
     UINT256_MAX,
     call_and_transact,
 )
+from raiden_contracts.tests.utils.blockchain import mine_blocks
 from raiden_contracts.utils.events import check_withdraw
 
 
@@ -210,7 +211,7 @@ def test_withdraw_wrong_state(
     with pytest.raises(TransactionFailed):
         withdraw_channel(channel_identifier, A, withdraw_A, UINT256_MAX, B)
 
-    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
+    mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
     call_and_transact(
         token_network.functions.settleChannel(
             channel_identifier, A, 0, 0, LOCKSROOT_OF_NO_LOCKS, B, 0, 0, LOCKSROOT_OF_NO_LOCKS
@@ -511,7 +512,7 @@ def test_withdraw_replay_reopened_channel(
         ),
         {"from": B},
     )
-    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
+    mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
     call_and_transact(
         token_network.functions.settleChannel(
             channel_identifier1, A, 0, 0, LOCKSROOT_OF_NO_LOCKS, B, 0, 0, LOCKSROOT_OF_NO_LOCKS

--- a/raiden_contracts/tests/test_channel_withdraw.py
+++ b/raiden_contracts/tests/test_channel_withdraw.py
@@ -18,6 +18,7 @@ from raiden_contracts.tests.utils import (
     EMPTY_SIGNATURE,
     LOCKSROOT_OF_NO_LOCKS,
     UINT256_MAX,
+    call_and_transact,
 )
 from raiden_contracts.utils.events import check_withdraw
 
@@ -125,14 +126,17 @@ def test_withdraw_call(
             partner_signature=EMPTY_SIGNATURE,
         ).call({"from": A})
 
-    token_network.functions.setTotalWithdraw(
-        channel_identifier=channel_identifier,
-        participant=A,
-        total_withdraw=withdraw_A,
-        expiration_block=UINT256_MAX,
-        participant_signature=signature_A_for_A,
-        partner_signature=signature_B_for_A,
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.setTotalWithdraw(
+            channel_identifier=channel_identifier,
+            participant=A,
+            total_withdraw=withdraw_A,
+            expiration_block=UINT256_MAX,
+            participant_signature=signature_A_for_A,
+            partner_signature=signature_B_for_A,
+        ),
+        {"from": A},
+    )
 
 
 def test_withdraw_call_near_expiration(
@@ -152,14 +156,17 @@ def test_withdraw_call_near_expiration(
         [A, B], channel_identifier, A, withdraw_A, expiration
     )
 
-    token_network.functions.setTotalWithdraw(
-        channel_identifier=channel_identifier,
-        participant=A,
-        total_withdraw=withdraw_A,
-        expiration_block=expiration,
-        participant_signature=signature_A_for_A,
-        partner_signature=signature_B_for_A,
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.setTotalWithdraw(
+            channel_identifier=channel_identifier,
+            participant=A,
+            total_withdraw=withdraw_A,
+            expiration_block=expiration,
+            participant_signature=signature_A_for_A,
+            partner_signature=signature_B_for_A,
+        ),
+        {"from": A},
+    )
 
 
 def test_withdraw_wrong_state(
@@ -184,16 +191,19 @@ def test_withdraw_wrong_state(
     withdraw_channel(channel_identifier, A, withdraw_A, UINT256_MAX, B)
 
     closing_sig = create_close_signature_for_no_balance_proof(A, channel_identifier)
-    token_network.functions.closeChannel(
-        channel_identifier=channel_identifier,
-        non_closing_participant=B,
-        closing_participant=A,
-        balance_hash=EMPTY_BALANCE_HASH,
-        nonce=0,
-        additional_hash=EMPTY_ADDITIONAL_HASH,
-        non_closing_signature=EMPTY_SIGNATURE,
-        closing_signature=closing_sig,
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.closeChannel(
+            channel_identifier=channel_identifier,
+            non_closing_participant=B,
+            closing_participant=A,
+            balance_hash=EMPTY_BALANCE_HASH,
+            nonce=0,
+            additional_hash=EMPTY_ADDITIONAL_HASH,
+            non_closing_signature=EMPTY_SIGNATURE,
+            closing_signature=closing_sig,
+        ),
+        {"from": A},
+    )
     (_, state) = token_network.functions.getChannelInfo(channel_identifier, A, B).call()
     assert state == ChannelState.CLOSED
 
@@ -201,9 +211,12 @@ def test_withdraw_wrong_state(
         withdraw_channel(channel_identifier, A, withdraw_A, UINT256_MAX, B)
 
     web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
-    token_network.functions.settleChannel(
-        channel_identifier, A, 0, 0, LOCKSROOT_OF_NO_LOCKS, B, 0, 0, LOCKSROOT_OF_NO_LOCKS
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.settleChannel(
+            channel_identifier, A, 0, 0, LOCKSROOT_OF_NO_LOCKS, B, 0, 0, LOCKSROOT_OF_NO_LOCKS
+        ),
+        {"from": A},
+    )
     (_, state) = token_network.functions.getChannelInfo(channel_identifier, A, B).call()
     assert state == ChannelState.REMOVED
 
@@ -259,9 +272,12 @@ def test_withdraw_wrong_signers(
             channel_identifier, A, withdraw_A, UINT256_MAX, signature_A_for_A, signature_C_for_A
         ).call({"from": C})
 
-    token_network.functions.setTotalWithdraw(
-        channel_identifier, A, withdraw_A, UINT256_MAX, signature_A_for_A, signature_B_for_A
-    ).call_and_transact({"from": C})
+    call_and_transact(
+        token_network.functions.setTotalWithdraw(
+            channel_identifier, A, withdraw_A, UINT256_MAX, signature_A_for_A, signature_B_for_A
+        ),
+        {"from": C},
+    )
 
 
 def test_withdraw_wrong_signature_content(
@@ -346,22 +362,31 @@ def test_withdraw_wrong_signature_content(
             signature_B_for_A_fake3,
         ).call({"from": A})
     with pytest.raises(TransactionFailed):
-        token_network.functions.setTotalWithdraw(
-            channel_identifier, A, withdraw_A, 0, signature_A_for_A, signature_B_for_A
-        ).call_and_transact({"from": A})
+        call_and_transact(
+            token_network.functions.setTotalWithdraw(
+                channel_identifier, A, withdraw_A, 0, signature_A_for_A, signature_B_for_A
+            ),
+            {"from": A},
+        )
     with pytest.raises(TransactionFailed):
-        token_network.functions.setTotalWithdraw(
-            channel_identifier,
-            A,
-            withdraw_A,
-            web3.eth.blockNumber,
-            signature_A_for_A,
-            signature_B_for_A,
-        ).call_and_transact({"from": A})
+        call_and_transact(
+            token_network.functions.setTotalWithdraw(
+                channel_identifier,
+                A,
+                withdraw_A,
+                web3.eth.blockNumber,
+                signature_A_for_A,
+                signature_B_for_A,
+            ),
+            {"from": A},
+        )
 
-    token_network.functions.setTotalWithdraw(
-        channel_identifier, A, withdraw_A, UINT256_MAX, signature_A_for_A, signature_B_for_A
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.setTotalWithdraw(
+            channel_identifier, A, withdraw_A, UINT256_MAX, signature_A_for_A, signature_B_for_A
+        ),
+        {"from": A},
+    )
 
 
 def test_withdraw_channel_state(
@@ -465,25 +490,34 @@ def test_withdraw_replay_reopened_channel(
     (signature_A_for_A, signature_B_for_A) = create_withdraw_signatures(
         [A, B], channel_identifier1, A, withdraw_A, UINT256_MAX
     )
-    token_network.functions.setTotalWithdraw(
-        channel_identifier1, A, withdraw_A, UINT256_MAX, signature_A_for_A, signature_B_for_A
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.setTotalWithdraw(
+            channel_identifier1, A, withdraw_A, UINT256_MAX, signature_A_for_A, signature_B_for_A
+        ),
+        {"from": A},
+    )
 
     closing_sig = create_close_signature_for_no_balance_proof(B, channel_identifier1)
-    token_network.functions.closeChannel(
-        channel_identifier=channel_identifier1,
-        non_closing_participant=A,
-        closing_participant=B,
-        balance_hash=EMPTY_BALANCE_HASH,
-        nonce=0,
-        additional_hash=EMPTY_ADDITIONAL_HASH,
-        non_closing_signature=EMPTY_SIGNATURE,
-        closing_signature=closing_sig,
-    ).call_and_transact({"from": B})
+    call_and_transact(
+        token_network.functions.closeChannel(
+            channel_identifier=channel_identifier1,
+            non_closing_participant=A,
+            closing_participant=B,
+            balance_hash=EMPTY_BALANCE_HASH,
+            nonce=0,
+            additional_hash=EMPTY_ADDITIONAL_HASH,
+            non_closing_signature=EMPTY_SIGNATURE,
+            closing_signature=closing_sig,
+        ),
+        {"from": B},
+    )
     web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
-    token_network.functions.settleChannel(
-        channel_identifier1, A, 0, 0, LOCKSROOT_OF_NO_LOCKS, B, 0, 0, LOCKSROOT_OF_NO_LOCKS
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.settleChannel(
+            channel_identifier1, A, 0, 0, LOCKSROOT_OF_NO_LOCKS, B, 0, 0, LOCKSROOT_OF_NO_LOCKS
+        ),
+        {"from": A},
+    )
 
     # Reopen the channel and make sure we cannot use the old withdraw proof
     channel_identifier2 = create_channel(A, B)[0]
@@ -499,9 +533,12 @@ def test_withdraw_replay_reopened_channel(
     (signature_A_for_A2, signature_B_for_A2) = create_withdraw_signatures(
         [A, B], channel_identifier2, A, withdraw_A, UINT256_MAX
     )
-    token_network.functions.setTotalWithdraw(
-        channel_identifier2, A, withdraw_A, UINT256_MAX, signature_A_for_A2, signature_B_for_A2
-    ).call_and_transact({"from": A})
+    call_and_transact(
+        token_network.functions.setTotalWithdraw(
+            channel_identifier2, A, withdraw_A, UINT256_MAX, signature_A_for_A2, signature_B_for_A2
+        ),
+        {"from": A},
+    )
 
 
 def test_withdraw_event(

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -9,7 +9,7 @@ import pytest
 from click import BadParameter, NoSuchOption
 from click.testing import CliRunner
 from eth_typing import HexStr
-from eth_typing.evm import HexAddress
+from eth_typing.evm import ChecksumAddress, HexAddress
 from eth_utils import ValidationError, to_checksum_address
 from pyfakefs.fake_filesystem import FakeFilesystem
 from pyfakefs.fake_filesystem_unittest import Patcher
@@ -440,7 +440,7 @@ def test_deploy_script_register(
     channel_participant_deposit_limit: int,
     token_network_deposit_limit: int,
     deployed_raiden_info: DeployedContracts,
-    token_address: HexAddress,
+    token_address: ChecksumAddress,
 ) -> None:
     """ Run token register function used in the deployment script
 
@@ -476,7 +476,7 @@ def test_deploy_script_register_missing_limits(
     token_network_deposit_limit: int,
     channel_participant_deposit_limit: int,
     deployed_raiden_info: DeployedContracts,
-    token_address: HexAddress,
+    token_address: ChecksumAddress,
     deployer: ContractDeployer,
 ) -> None:
     """ Run token register function used in the deployment script
@@ -519,7 +519,7 @@ def test_deploy_script_register_unexpected_limits(
     web3: Web3,
     token_network_deposit_limit: int,
     channel_participant_deposit_limit: int,
-    token_address: HexAddress,
+    token_address: ChecksumAddress,
     deployed_raiden_info: DeployedContracts,
 ) -> None:
     """ Run token register function used in the deployment script

--- a/raiden_contracts/tests/test_deprecation_switch.py
+++ b/raiden_contracts/tests/test_deprecation_switch.py
@@ -16,6 +16,7 @@ from raiden_contracts.constants import (
 from raiden_contracts.contract_manager import ContractManager
 from raiden_contracts.tests.fixtures.channel import call_settle
 from raiden_contracts.tests.utils import ChannelValues, LockedAmounts, call_and_transact
+from raiden_contracts.tests.utils.blockchain import mine_blocks
 from raiden_contracts.utils.pending_transfers import (
     get_pending_transfers_tree_with_generated_lists,
 )
@@ -211,7 +212,7 @@ def test_deprecation_switch_settle(
 
     # We need to make sure we can still close, settle & unlock the channels
     close_and_update_channel(channel_identifier, A, vals_A, B, vals_B)
-    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
+    mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
 
     call_settle(token_network, channel_identifier, A, vals_A, B, vals_B)
 

--- a/raiden_contracts/tests/test_etherscan_verify.py
+++ b/raiden_contracts/tests/test_etherscan_verify.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List
 
 import requests_mock
 from click.testing import CliRunner
+from web3.types import ABI
 
 from raiden_contracts.constants import (
     CONTRACT_MONITORING_SERVICE,
@@ -13,6 +14,7 @@ from raiden_contracts.constants import (
     DeploymentModule,
 )
 from raiden_contracts.contract_manager import (
+    CompiledContract,
     ContractManager,
     DeployedContracts,
     contracts_precompiled_path,
@@ -36,19 +38,21 @@ def test_get_constructor_args_no_args() -> None:
     assert get_constructor_args(deploy_info, contract_name, contract_manager) == ""  # type: ignore
 
 
-def abi_with_constructor_input_types(types: List[str]) -> List[Dict]:
-    return [{"type": "constructor", "inputs": [{"type": ty} for ty in types]}]
+def abi_with_constructor_input_types(types: List[str]) -> ABI:
+    return [{"type": "constructor", "inputs": [{"type": ty} for ty in types]}]  # type: ignore
 
 
 def test_get_constructor_args_one_arg() -> None:
     """ Test get_constructor_args() on one argument """
     contract_manager = ContractManager(contracts_precompiled_path())
-    contract_manager.contracts[contract_name] = {
-        "abi": abi_with_constructor_input_types(["uint256"]),
-        "bin": "dummy",
-        "bin-runtime": "dummy",
-        "metadata": "dummy",
-    }
+    contract_manager.contracts[contract_name] = CompiledContract(
+        {
+            "abi": abi_with_constructor_input_types(["uint256"]),
+            "bin": "dummy",
+            "bin-runtime": "dummy",
+            "metadata": "dummy",
+        }
+    )
     deploy_info: DeployedContracts = {  # type: ignore
         "contracts": {contract_name: {"constructor_arguments": [16]}}
     }
@@ -61,12 +65,14 @@ def test_get_constructor_args_one_arg() -> None:
 def test_get_constructor_args_two_args() -> None:
     """ Test get_constructor_args() on two arguments """
     contract_manager = ContractManager(contracts_precompiled_path())
-    contract_manager.contracts[contract_name] = {
-        "abi": abi_with_constructor_input_types(["uint256", "bool"]),
-        "bin-runtime": "dummy",
-        "bin": "dummy",
-        "metadata": "dummy",
-    }
+    contract_manager.contracts[contract_name] = CompiledContract(
+        {
+            "abi": abi_with_constructor_input_types(["uint256", "bool"]),
+            "bin-runtime": "dummy",
+            "bin": "dummy",
+            "metadata": "dummy",
+        }
+    )
     deploy_info: DeployedContracts = {  # type: ignore
         "contracts": {contract_name: {"constructor_arguments": [16, True]}}
     }

--- a/raiden_contracts/tests/test_monitoring_service.py
+++ b/raiden_contracts/tests/test_monitoring_service.py
@@ -21,6 +21,7 @@ from raiden_contracts.tests.utils import (
     SERVICE_DEPOSIT,
     call_and_transact,
 )
+from raiden_contracts.tests.utils.blockchain import mine_blocks
 from raiden_contracts.utils.proofs import sign_reward_proof
 
 REWARD_AMOUNT = 10
@@ -151,7 +152,7 @@ def test_claimReward_with_settle_call(
     channel_identifier = monitor_data["channel_identifier"]
 
     # wait until MS is allowed to monitor
-    token_network.web3.testing.mine(monitor_data["first_allowed"] - web3.eth.blockNumber)
+    mine_blocks(web3, monitor_data["first_allowed"] - web3.eth.blockNumber)
 
     # MS updates closed channel on behalf of B
     txn_hash = call_and_transact(
@@ -174,7 +175,7 @@ def test_claimReward_with_settle_call(
         ).call({"from": ms_address})
 
     # Settle channel after settle_timeout elapsed
-    token_network.web3.testing.mine(4)
+    mine_blocks(web3, 4)
     if with_settle:
         call_and_transact(
             token_network.functions.settleChannel(
@@ -256,7 +257,7 @@ def test_monitor(
         )
 
     # wait until MS is allowed to monitor
-    token_network.web3.testing.mine(monitor_data["first_allowed"] - web3.eth.blockNumber)
+    mine_blocks(web3, monitor_data["first_allowed"] - web3.eth.blockNumber)
 
     # successful monitor call
     txn_hash = call_and_transact(
@@ -298,7 +299,7 @@ def test_monitor_by_unregistered_service(
     A, B = monitor_data["participants"]
 
     # wait until MS is allowed to monitor
-    token_network.web3.testing.mine(monitor_data["first_allowed"] - web3.eth.blockNumber)
+    mine_blocks(web3, monitor_data["first_allowed"] - web3.eth.blockNumber)
 
     # only registered service provicers may call `monitor`
     with pytest.raises(TransactionFailed, match="service not registered"):
@@ -337,9 +338,7 @@ def test_monitor_on_wrong_token_network_registry(
     A, B = monitor_data["participants"]
 
     # wait until MS is allowed to monitor
-    token_network_in_another_token_network_registry.web3.testing.mine(
-        monitor_data["first_allowed"] - web3.eth.blockNumber
-    )
+    mine_blocks(web3, monitor_data["first_allowed"] - web3.eth.blockNumber)
 
     # monitor() call fails because the TokenNetwork is not registered on the
     # supposed TokenNetworkRegistry

--- a/raiden_contracts/tests/test_one_to_n.py
+++ b/raiden_contracts/tests/test_one_to_n.py
@@ -2,6 +2,7 @@ from typing import Callable, List
 
 import pytest
 from eth_tester.exceptions import TransactionFailed
+from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract import Contract
 
@@ -86,7 +87,7 @@ def test_bulk_claim_happy_path(
     deposit_to_udc(B, 30)
     C = create_service_account()
 
-    def bulk_claim(ious: List[dict]) -> str:
+    def bulk_claim(ious: List[dict]) -> HexBytes:
         return call_and_transact(
             one_to_n_contract.functions.bulkClaim(
                 senders=[x["sender"] for x in ious],
@@ -130,7 +131,7 @@ def test_bulk_claim_errors(
     with pytest.raises(
         TransactionFailed, match="Same number of elements required for all input parameters"
     ):
-        return call_and_transact(
+        call_and_transact(
             one_to_n_contract.functions.bulkClaim(
                 senders=senders,
                 receivers=receivers,
@@ -147,7 +148,7 @@ def test_bulk_claim_errors(
         with pytest.raises(
             TransactionFailed, match="`signatures` should contain 65 bytes per IOU"
         ):
-            return call_and_transact(
+            call_and_transact(
                 one_to_n_contract.functions.bulkClaim(
                     senders=senders,
                     receivers=receivers,
@@ -161,7 +162,7 @@ def test_bulk_claim_errors(
 
     # Cause a signature mismatch by changing one amount
     with pytest.raises(TransactionFailed, match="Signature mismatch"):
-        return call_and_transact(
+        call_and_transact(
             one_to_n_contract.functions.bulkClaim(
                 senders=senders,
                 receivers=receivers,

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -18,6 +18,7 @@ from raiden_contracts.constants import (
 )
 from raiden_contracts.contract_manager import gas_measurements
 from raiden_contracts.tests.utils import call_and_transact
+from raiden_contracts.tests.utils.blockchain import mine_blocks
 from raiden_contracts.tests.utils.constants import DEPLOYER_ADDRESS, SERVICE_DEPOSIT, UINT256_MAX
 from raiden_contracts.utils.pending_transfers import get_locked_amount, get_pending_transfers_tree
 from raiden_contracts.utils.proofs import sign_one_to_n_iou, sign_reward_proof
@@ -223,7 +224,7 @@ def print_gas_channel_cycle(
     )
     print_gas(txn_hash, CONTRACT_TOKEN_NETWORK + ".updateNonClosingBalanceProof")
 
-    web3.testing.mine(settle_timeout)
+    mine_blocks(web3, settle_timeout)
     txn_hash = call_and_transact(
         token_network.functions.settleChannel(
             channel_identifier, B, 5, locked_amount2, locksroot2, A, 10, locked_amount1, locksroot1
@@ -270,6 +271,7 @@ def print_gas_monitoring_service(
     print_gas: Callable,
     get_private_key: Callable,
     create_service_account: Callable,
+    web3: Web3,
 ) -> None:
     """ Abusing pytest to print gas cost of MonitoringService functions """
     # setup: two parties + MS
@@ -320,7 +322,7 @@ def print_gas_monitoring_service(
         ),
         {"from": A},
     )
-    token_network.web3.testing.mine(4)
+    mine_blocks(web3, 4)
 
     # MS calls `MSC::monitor()` using c1's BP and reward proof
     txn_hash = call_and_transact(
@@ -340,7 +342,7 @@ def print_gas_monitoring_service(
     )
     print_gas(txn_hash, CONTRACT_MONITORING_SERVICE + ".monitor")
 
-    token_network.web3.testing.mine(1)
+    mine_blocks(web3, 1)
 
     # MS claims the reward
     txn_hash = call_and_transact(
@@ -450,7 +452,7 @@ def print_gas_user_deposit(
 
     # withdraw
     withdraw_delay = user_deposit_contract.functions.withdraw_delay().call()
-    web3.testing.mine(withdraw_delay)
+    mine_blocks(web3, withdraw_delay)
     txn_hash = call_and_transact(user_deposit_contract.functions.withdraw(10), {"from": A})
     print_gas(txn_hash, CONTRACT_USER_DEPOSIT + ".withdraw")
 

--- a/raiden_contracts/tests/test_service_registry.py
+++ b/raiden_contracts/tests/test_service_registry.py
@@ -97,8 +97,8 @@ def test_deposit(
     """A service provider can make deposits to ServiceRegistry"""
     (A,) = get_accounts(1)
     call_and_transact(custom_token.functions.mint(SERVICE_DEPOSIT), {"from": A})
-    custom_token.functions.approve(service_registry.address, SERVICE_DEPOSIT).call_and_transact(
-        {"from": A}
+    call_and_transact(
+        custom_token.functions.approve(service_registry.address, SERVICE_DEPOSIT), {"from": A}
     )
 
     # happy path

--- a/raiden_contracts/tests/test_service_registry.py
+++ b/raiden_contracts/tests/test_service_registry.py
@@ -2,7 +2,6 @@ from typing import Callable
 
 import pytest
 from eth_tester.exceptions import TransactionFailed
-from eth_typing import HexStr
 from web3 import Web3
 from web3.contract import Contract, get_event_data
 from web3.exceptions import MismatchedABI
@@ -14,7 +13,7 @@ from raiden_contracts.constants import (
     EVENT_REGISTERED_SERVICE,
 )
 from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
-from raiden_contracts.tests.utils import call_and_transact
+from raiden_contracts.tests.utils import HexBytes, call_and_transact
 from raiden_contracts.tests.utils.constants import (
     DEFAULT_BUMP_DENOMINATOR,
     DEFAULT_BUMP_NUMERATOR,
@@ -562,7 +561,7 @@ def test_deprecation_immediate_payout(
     # The user has all the balance it has minted
     assert minted == custom_token.functions.balanceOf(A).call()
     # The Deposit contract has destroyed itself
-    assert web3.eth.getCode(deposit.address) == HexStr("0x")
+    assert web3.eth.getCode(deposit.address) == HexBytes("0x")  # type: ignore
 
 
 def test_unauthorized_deprecation_switch(

--- a/raiden_contracts/tests/test_service_registry.py
+++ b/raiden_contracts/tests/test_service_registry.py
@@ -2,6 +2,7 @@ from typing import Callable
 
 import pytest
 from eth_tester.exceptions import TransactionFailed
+from eth_typing import HexStr
 from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract import Contract, get_event_data
@@ -490,9 +491,10 @@ def service_registry_with_zero_supply_token(
         )
 
 
+# FIXME: can be removed?
 def service_registry_with_high_numbers(
     deploy_tester_contract: Callable, custom_token: Contract
-) -> Contract:
+) -> None:
     """See if the computation overflows with the highest allowed numbers"""
     contract = deploy_tester_contract(
         CONTRACT_SERVICE_REGISTRY,
@@ -561,7 +563,7 @@ def test_deprecation_immediate_payout(
     # The user has all the balance it has minted
     assert minted == custom_token.functions.balanceOf(A).call()
     # The Deposit contract has destroyed itself
-    assert web3.eth.getCode(deposit.address) == HexBytes("0x")
+    assert web3.eth.getCode(deposit.address) == HexStr("0x")
 
 
 def test_unauthorized_deprecation_switch(

--- a/raiden_contracts/tests/test_service_registry.py
+++ b/raiden_contracts/tests/test_service_registry.py
@@ -3,7 +3,6 @@ from typing import Callable
 import pytest
 from eth_tester.exceptions import TransactionFailed
 from eth_typing import HexStr
-from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract import Contract, get_event_data
 from web3.exceptions import MismatchedABI

--- a/raiden_contracts/tests/test_token.py
+++ b/raiden_contracts/tests/test_token.py
@@ -80,7 +80,7 @@ def test_custom_token(
     """ See custom_token.address contains the expected code """
     blockchain_bytecode = web3.eth.getCode(custom_token.address)
     compiled_bytecode = contracts_manager.get_runtime_hexcode(CONTRACT_CUSTOM_TOKEN)
-    assert blockchain_bytecode == compiled_bytecode
+    assert blockchain_bytecode.hex() == compiled_bytecode  # type: ignore
 
 
 def test_human_standard_token(
@@ -89,4 +89,4 @@ def test_human_standard_token(
     """ See human_standard_token.address contains the expected code """
     blockchain_bytecode = web3.eth.getCode(human_standard_token.address)
     compiled_bytecode = contracts_manager.get_runtime_hexcode(CONTRACT_HUMAN_STANDARD_TOKEN)
-    assert blockchain_bytecode == compiled_bytecode
+    assert blockchain_bytecode.hex() == compiled_bytecode  # type: ignore

--- a/raiden_contracts/tests/test_token.py
+++ b/raiden_contracts/tests/test_token.py
@@ -78,7 +78,7 @@ def test_custom_token(
     custom_token: Contract, web3: Web3, contracts_manager: ContractManager
 ) -> None:
     """ See custom_token.address contains the expected code """
-    blockchain_bytecode = web3.eth.getCode(custom_token.address).hex()
+    blockchain_bytecode = web3.eth.getCode(custom_token.address)
     compiled_bytecode = contracts_manager.get_runtime_hexcode(CONTRACT_CUSTOM_TOKEN)
     assert blockchain_bytecode == compiled_bytecode
 
@@ -87,6 +87,6 @@ def test_human_standard_token(
     human_standard_token: Contract, web3: Web3, contracts_manager: ContractManager
 ) -> None:
     """ See human_standard_token.address contains the expected code """
-    blockchain_bytecode = web3.eth.getCode(human_standard_token.address).hex()
+    blockchain_bytecode = web3.eth.getCode(human_standard_token.address)
     compiled_bytecode = contracts_manager.get_runtime_hexcode(CONTRACT_HUMAN_STANDARD_TOKEN)
     assert blockchain_bytecode == compiled_bytecode

--- a/raiden_contracts/tests/test_token.py
+++ b/raiden_contracts/tests/test_token.py
@@ -7,6 +7,7 @@ from web3.contract import Contract
 
 from raiden_contracts.constants import CONTRACT_CUSTOM_TOKEN, CONTRACT_HUMAN_STANDARD_TOKEN
 from raiden_contracts.contract_manager import ContractManager
+from raiden_contracts.tests.utils import call_and_transact
 
 
 def test_token_mint(web3: Web3, custom_token: Contract, get_accounts: Callable) -> None:
@@ -19,14 +20,14 @@ def test_token_mint(web3: Web3, custom_token: Contract, get_accounts: Callable) 
 
     token_pre_balance = web3.eth.getBalance(token.address)
     tokens_a = 50 * multiplier
-    token.functions.mint(tokens_a).call_and_transact({"from": A})
+    call_and_transact(token.functions.mint(tokens_a), {"from": A})
     assert token.functions.balanceOf(A).call() == tokens_a
     assert token.functions.balanceOf(B).call() == 0
     assert token.functions.totalSupply().call() == supply + tokens_a
     assert web3.eth.getBalance(token.address) == token_pre_balance
 
     tokens_b = 50 * multiplier
-    token.functions.mintFor(tokens_b, B).call_and_transact({"from": A})
+    call_and_transact(token.functions.mintFor(tokens_b, B), {"from": A})
     assert token.functions.balanceOf(A).call() == tokens_a
     assert token.functions.balanceOf(B).call() == tokens_b
     assert token.functions.totalSupply().call() == supply + tokens_a + tokens_b
@@ -38,17 +39,17 @@ def test_approve_transfer(custom_token: Contract, get_accounts: Callable) -> Non
 
     (A, B) = get_accounts(2)
     token = custom_token
-    token.functions.mint(50).call_and_transact({"from": A})
+    call_and_transact(token.functions.mint(50), {"from": A})
     initial_balance_A = token.functions.balanceOf(A).call()
     initial_balance_B = token.functions.balanceOf(B).call()
     to_transfer = 20
-    token.functions.approve(B, to_transfer).call_and_transact({"from": A})
-    token.functions.transferFrom(A, B, to_transfer).call_and_transact({"from": B})
+    call_and_transact(token.functions.approve(B, to_transfer), {"from": A})
+    call_and_transact(token.functions.transferFrom(A, B, to_transfer), {"from": B})
     assert token.functions.balanceOf(B).call() == initial_balance_B + to_transfer
     assert token.functions.balanceOf(A).call() == initial_balance_A - to_transfer
 
     assert custom_token.functions.allowance(_owner=A, _spender=B).call() == 0
-    assert custom_token.functions.approve(_spender=B, _value=25).call_and_transact({"from": A})
+    assert call_and_transact(custom_token.functions.approve(_spender=B, _value=25), {"from": A})
     assert custom_token.functions.allowance(_owner=A, _spender=B).call() == 25
     assert custom_token.functions.allowance(_owner=A, _spender=token.address).call() == 0
 
@@ -69,7 +70,7 @@ def test_token_transfer_funds(web3: Web3, custom_token: Contract, get_accounts: 
     with pytest.raises(TransactionFailed):
         token.functions.transferFunds().call({"from": owner})
 
-    token.functions.mint(50).call_and_transact({"from": A})
+    call_and_transact(token.functions.mint(50), {"from": A})
     assert web3.eth.getBalance(token.address) == 0
 
 

--- a/raiden_contracts/tests/test_token_network.py
+++ b/raiden_contracts/tests/test_token_network.py
@@ -15,7 +15,7 @@ from raiden_contracts.tests.utils.constants import NOT_ADDRESS, UINT256_MAX
 
 def test_constructor_call(
     web3: Web3,
-    get_token_network: Contract,
+    get_token_network: Callable,
     custom_token: Contract,
     secret_registry_contract: Contract,
     get_accounts: Callable,

--- a/raiden_contracts/tests/test_token_network_registry.py
+++ b/raiden_contracts/tests/test_token_network_registry.py
@@ -12,6 +12,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MAX,
     TEST_SETTLE_TIMEOUT_MIN,
 )
+from raiden_contracts.tests.utils import call_and_transact
 from raiden_contracts.tests.utils.constants import DEPLOYER_ADDRESS, NOT_ADDRESS
 from raiden_contracts.utils.events import check_token_network_created
 
@@ -341,9 +342,12 @@ def test_create_erc20_token_network_call(
         ).call({"from": DEPLOYER_ADDRESS})
 
     # see a success to make sure above tests were meaningful
-    token_network_registry_contract.functions.createERC20TokenNetwork(
-        custom_token.address, channel_participant_deposit_limit, token_network_deposit_limit
-    ).call_and_transact({"from": DEPLOYER_ADDRESS})
+    call_and_transact(
+        token_network_registry_contract.functions.createERC20TokenNetwork(
+            custom_token.address, channel_participant_deposit_limit, token_network_deposit_limit
+        ),
+        {"from": DEPLOYER_ADDRESS},
+    )
 
 
 @pytest.mark.usefixtures("no_token_network")
@@ -400,9 +404,12 @@ def test_create_erc20_token_network_twice_fails(
 ) -> None:
     """ Only one TokenNetwork should be creatable from a TokenNetworkRegistry """
 
-    token_network_registry_contract.functions.createERC20TokenNetwork(
-        custom_token.address, channel_participant_deposit_limit, token_network_deposit_limit
-    ).call_and_transact({"from": DEPLOYER_ADDRESS})
+    call_and_transact(
+        token_network_registry_contract.functions.createERC20TokenNetwork(
+            custom_token.address, channel_participant_deposit_limit, token_network_deposit_limit
+        ),
+        {"from": DEPLOYER_ADDRESS},
+    )
 
     with pytest.raises(TransactionFailed):
         token_network_registry_contract.functions.createERC20TokenNetwork(

--- a/raiden_contracts/tests/test_token_network_registry.py
+++ b/raiden_contracts/tests/test_token_network_registry.py
@@ -19,7 +19,7 @@ from raiden_contracts.utils.events import check_token_network_created
 @pytest.mark.usefixtures("no_token_network")
 def test_constructor_call(
     web3: Web3,
-    get_token_network_registry: Contract,
+    get_token_network_registry: Callable,
     secret_registry_contract: Contract,
     get_accounts: Callable,
 ) -> None:
@@ -251,7 +251,7 @@ def test_constructor_call(
 
 @pytest.mark.usefixtures("no_token_network")
 def test_constructor_call_state(
-    web3: Web3, get_token_network_registry: Contract, secret_registry_contract: Contract
+    web3: Web3, get_token_network_registry: Callable, secret_registry_contract: Contract
 ) -> None:
     """ The constructor should set the parameters into the storage of the contract """
 
@@ -412,7 +412,7 @@ def test_create_erc20_token_network_twice_fails(
 
 @pytest.mark.usefixtures("no_token_network")
 def test_events(
-    register_token_network: Contract,
+    register_token_network: Callable,
     token_network_registry_contract: Contract,
     custom_token: Contract,
     event_handler: Callable,

--- a/raiden_contracts/tests/test_transaction.py
+++ b/raiden_contracts/tests/test_transaction.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 from hexbytes import HexBytes
+from web3.types import TxData, TxReceipt, Wei
 
 from raiden_contracts.utils.transaction import check_successful_tx
 
@@ -46,9 +47,9 @@ def test_check_successful_tx_with_gas_completely_used() -> None:
 def test_check_successful_tx_successful_case() -> None:
     web3_mock = Mock()
     gas = 30000
-    receipt = {"blockNumber": 300, "status": 1, "gasUsed": gas - 10}
+    receipt = TxReceipt({"blockNumber": 300, "status": 1, "gasUsed": gas - 10})  # type: ignore
     web3_mock.eth.getTransactionReceipt.return_value = receipt
-    txinfo = {"gas": gas}
+    txinfo = TxData({"gas": Wei(gas)})
     web3_mock.eth.getTransaction.return_value = txinfo
     txid = HexBytes("abcdef")
     assert check_successful_tx(web3=web3_mock, txid=txid) == (receipt, txinfo)

--- a/raiden_contracts/tests/test_transaction.py
+++ b/raiden_contracts/tests/test_transaction.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+from hexbytes import HexBytes
 
 from raiden_contracts.utils.transaction import check_successful_tx
 
@@ -8,7 +9,7 @@ from raiden_contracts.utils.transaction import check_successful_tx
 def test_check_successful_tx_with_status_zero() -> None:
     web3_mock = Mock()
     web3_mock.eth.getTransactionReceipt.return_value = {"blockNumber": 300, "status": 0}
-    txid = "abcdef"
+    txid = HexBytes("abcdef")
     with pytest.raises(ValueError):
         check_successful_tx(web3=web3_mock, txid=txid)
     web3_mock.eth.getTransactionReceipt.assert_called_with(txid)
@@ -19,7 +20,7 @@ def test_check_successful_tx_with_nonexistent_status() -> None:
     """ check_successful_tx() with a receipt without status field should raise a KeyError """
     web3_mock = Mock()
     web3_mock.eth.getTransactionReceipt.return_value = {"blockNumber": 300}
-    txid = "abcdef"
+    txid = HexBytes("abcdef")
     with pytest.raises(KeyError):
         check_successful_tx(web3=web3_mock, txid=txid)
     web3_mock.eth.getTransactionReceipt.assert_called_with(txid)
@@ -35,7 +36,7 @@ def test_check_successful_tx_with_gas_completely_used() -> None:
         "gasUsed": gas,
     }
     web3_mock.eth.getTransaction.return_value = {"gas": gas}
-    txid = "abcdef"
+    txid = HexBytes("abcdef")
     with pytest.raises(ValueError):
         check_successful_tx(web3=web3_mock, txid=txid)
     web3_mock.eth.getTransactionReceipt.assert_called_with(txid)
@@ -49,7 +50,7 @@ def test_check_successful_tx_successful_case() -> None:
     web3_mock.eth.getTransactionReceipt.return_value = receipt
     txinfo = {"gas": gas}
     web3_mock.eth.getTransaction.return_value = txinfo
-    txid = "abcdef"
+    txid = HexBytes("abcdef")
     assert check_successful_tx(web3=web3_mock, txid=txid) == (receipt, txinfo)
     web3_mock.eth.getTransactionReceipt.assert_called_with(txid)
     web3_mock.eth.getTransaction.assert_called_with(txid)

--- a/raiden_contracts/tests/test_user_deposit_contract.py
+++ b/raiden_contracts/tests/test_user_deposit_contract.py
@@ -7,6 +7,7 @@ from web3.contract import Contract
 
 from raiden_contracts.constants import UserDepositEvent
 from raiden_contracts.tests.utils import call_and_transact
+from raiden_contracts.tests.utils.blockchain import mine_blocks
 
 
 def test_deposit(
@@ -161,12 +162,12 @@ def test_withdraw(
 
     # withdraw won't work before withdraw_delay elapsed
     withdraw_delay = user_deposit_contract.functions.withdraw_delay().call()
-    web3.testing.mine(withdraw_delay - 1)
+    mine_blocks(web3, withdraw_delay - 1)
     with pytest.raises(TransactionFailed, match="withdrawing too early"):
         user_deposit_contract.functions.withdraw(18).call({"from": A})
 
     # can't withdraw more then planned
-    web3.testing.mine(1)  # now withdraw_delay is over
+    mine_blocks(web3, 1)  # now withdraw_delay is over
     with pytest.raises(TransactionFailed, match="withdrawing more than planned"):
         user_deposit_contract.functions.withdraw(21).call({"from": A})
 

--- a/raiden_contracts/tests/test_user_deposit_contract.py
+++ b/raiden_contracts/tests/test_user_deposit_contract.py
@@ -6,26 +6,27 @@ from web3 import Web3
 from web3.contract import Contract
 
 from raiden_contracts.constants import UserDepositEvent
+from raiden_contracts.tests.utils import call_and_transact
 
 
 def test_deposit(
     user_deposit_contract: Contract, custom_token: Contract, get_accounts: Callable[[int], Tuple]
 ) -> None:
     (A, B) = get_accounts(2)
-    custom_token.functions.mint(100).call_and_transact({"from": A})
-    custom_token.functions.approve(user_deposit_contract.address, 30).call_and_transact(
-        {"from": A}
+    call_and_transact(custom_token.functions.mint(100), {"from": A})
+    call_and_transact(
+        custom_token.functions.approve(user_deposit_contract.address, 30), {"from": A}
     )
 
     # deposit to A's own balance
-    user_deposit_contract.functions.deposit(A, 10).call_and_transact({"from": A})
+    call_and_transact(user_deposit_contract.functions.deposit(A, 10), {"from": A})
     assert user_deposit_contract.functions.balances(A).call() == 10
     assert user_deposit_contract.functions.total_deposit(A).call() == 10
     assert custom_token.functions.balanceOf(A).call() == 90
     assert custom_token.functions.balanceOf(user_deposit_contract.address).call() == 10
 
     # increase A's deposit
-    user_deposit_contract.functions.deposit(A, 20).call_and_transact({"from": A})
+    call_and_transact(user_deposit_contract.functions.deposit(A, 20), {"from": A})
     assert user_deposit_contract.functions.balances(A).call() == 20
     assert user_deposit_contract.functions.total_deposit(A).call() == 20
     assert custom_token.functions.balanceOf(A).call() == 80
@@ -36,7 +37,7 @@ def test_deposit(
         user_deposit_contract.functions.deposit(A, 19).call({"from": A})
 
     # A deposits to the benefit of B
-    user_deposit_contract.functions.deposit(B, 10).call_and_transact({"from": A})
+    call_and_transact(user_deposit_contract.functions.deposit(B, 10), {"from": A})
     assert user_deposit_contract.functions.balances(B).call() == 10
     assert user_deposit_contract.functions.total_deposit(B).call() == 10
     assert custom_token.functions.balanceOf(A).call() == 70
@@ -49,9 +50,9 @@ def test_deposit(
     # Can't deposit more than the whole_balance_limit
     limit = user_deposit_contract.functions.whole_balance_limit().call()
     assert limit > 0
-    custom_token.functions.mint(limit + 1).call_and_transact({"from": A})
-    custom_token.functions.approve(user_deposit_contract.address, limit + 1).call_and_transact(
-        {"from": A}
+    call_and_transact(custom_token.functions.mint(limit + 1), {"from": A})
+    call_and_transact(
+        custom_token.functions.approve(user_deposit_contract.address, limit + 1), {"from": A}
     )
     with pytest.raises(TransactionFailed, match="too much deposit"):
         user_deposit_contract.functions.deposit(A, limit + 1).call({"from": A})
@@ -67,21 +68,23 @@ def test_transfer(
     user_deposit_contract = uninitialized_user_deposit_contract
     ev_handler = event_handler(user_deposit_contract)
     (A, B) = get_accounts(2)
-    custom_token.functions.mint(10).call_and_transact({"from": A})
-    custom_token.functions.approve(user_deposit_contract.address, 10).call_and_transact(
-        {"from": A}
+    call_and_transact(custom_token.functions.mint(10), {"from": A})
+    call_and_transact(
+        custom_token.functions.approve(user_deposit_contract.address, 10), {"from": A}
     )
-    user_deposit_contract.functions.deposit(A, 10).call_and_transact({"from": A})
+    call_and_transact(user_deposit_contract.functions.deposit(A, 10), {"from": A})
 
     # only trusted contracts can call transfer (init has not been called, yet)
     with pytest.raises(TransactionFailed, match="unknown caller"):
         udc_transfer_contract.functions.transfer(A, B, 10).call()
 
     # happy case
-    user_deposit_contract.functions.init(
-        udc_transfer_contract.address, udc_transfer_contract.address
-    ).call_and_transact()
-    tx_hash = udc_transfer_contract.functions.transfer(A, B, 10).call_and_transact()
+    call_and_transact(
+        user_deposit_contract.functions.init(
+            udc_transfer_contract.address, udc_transfer_contract.address
+        )
+    )
+    tx_hash = call_and_transact(udc_transfer_contract.functions.transfer(A, B, 10))
     ev_handler.assert_event(tx_hash, UserDepositEvent.BALANCE_REDUCED, dict(owner=A, newBalance=0))
     assert user_deposit_contract.functions.balances(A).call() == 0
     assert user_deposit_contract.functions.balances(B).call() == 10
@@ -106,25 +109,27 @@ def test_deposit_after_transfer(
     and we can use another deposit to verify that each is handled correctly.
     """
     user_deposit_contract = uninitialized_user_deposit_contract
-    user_deposit_contract.functions.init(
-        udc_transfer_contract.address, udc_transfer_contract.address
-    ).call_and_transact()
+    call_and_transact(
+        user_deposit_contract.functions.init(
+            udc_transfer_contract.address, udc_transfer_contract.address
+        )
+    )
     (A, B) = get_accounts(2)
-    custom_token.functions.mint(100).call_and_transact({"from": A})
-    custom_token.functions.approve(user_deposit_contract.address, 30).call_and_transact(
-        {"from": A}
+    call_and_transact(custom_token.functions.mint(100), {"from": A})
+    call_and_transact(
+        custom_token.functions.approve(user_deposit_contract.address, 30), {"from": A}
     )
 
     # deposit + transact
-    user_deposit_contract.functions.deposit(A, 10).call_and_transact({"from": A})
-    udc_transfer_contract.functions.transfer(A, B, 10).call_and_transact()
+    call_and_transact(user_deposit_contract.functions.deposit(A, 10), {"from": A})
+    call_and_transact(udc_transfer_contract.functions.transfer(A, B, 10))
     assert user_deposit_contract.functions.balances(A).call() == 0
     assert user_deposit_contract.functions.total_deposit(A).call() == 10
     assert custom_token.functions.balanceOf(A).call() == 90
     assert custom_token.functions.balanceOf(user_deposit_contract.address).call() == 10
 
     # check after another deposit
-    user_deposit_contract.functions.deposit(A, 20).call_and_transact({"from": A})
+    call_and_transact(user_deposit_contract.functions.deposit(A, 20), {"from": A})
     assert user_deposit_contract.functions.balances(A).call() == 10
     assert user_deposit_contract.functions.total_deposit(A).call() == 20
     assert custom_token.functions.balanceOf(A).call() == 80
@@ -147,7 +152,7 @@ def test_withdraw(
     assert user_deposit_contract.functions.effectiveBalance(A).call() == 30
 
     # plan withdraw of 20 tokens
-    tx_hash = user_deposit_contract.functions.planWithdraw(20).call_and_transact({"from": A})
+    tx_hash = call_and_transact(user_deposit_contract.functions.planWithdraw(20), {"from": A})
     ev_handler.assert_event(
         tx_hash, UserDepositEvent.WITHDRAW_PLANNED, dict(withdrawer=A, plannedBalance=10)
     )
@@ -166,6 +171,6 @@ def test_withdraw(
         user_deposit_contract.functions.withdraw(21).call({"from": A})
 
     # actually withdraw 18 tokens
-    user_deposit_contract.functions.withdraw(18).call_and_transact({"from": A})
+    call_and_transact(user_deposit_contract.functions.withdraw(18), {"from": A})
     assert user_deposit_contract.functions.balances(A).call() == 12
     assert user_deposit_contract.functions.effectiveBalance(A).call() == 12

--- a/raiden_contracts/tests/unit/test_recover_from_signature.py
+++ b/raiden_contracts/tests/unit/test_recover_from_signature.py
@@ -13,7 +13,7 @@ from raiden_contracts.utils.signature import sign
 
 
 @pytest.fixture
-def signature_test_contract(deploy_tester_contract: Contract) -> Contract:
+def signature_test_contract(deploy_tester_contract: Callable) -> Contract:
     return deploy_tester_contract("SignatureVerifyTest")
 
 

--- a/raiden_contracts/tests/unit/test_settle_timeout_invariant.py
+++ b/raiden_contracts/tests/unit/test_settle_timeout_invariant.py
@@ -7,6 +7,7 @@ from web3.contract import Contract
 
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MAX, TEST_SETTLE_TIMEOUT_MIN
 from raiden_contracts.tests.utils import LOCKSROOT_OF_NO_LOCKS, call_and_transact, fake_bytes
+from raiden_contracts.tests.utils.blockchain import mine_blocks
 
 
 def test_settle_timeout_inrange(
@@ -54,7 +55,7 @@ def test_settle_timeout_inrange(
         ),
         {"from": A},
     )
-    web3.testing.mine(TEST_SETTLE_TIMEOUT_MIN + 1)
+    mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
     call_and_transact(
         token_network.functions.settleChannel(
             channel_identifier, A, 0, 0, LOCKSROOT_OF_NO_LOCKS, B, 0, 0, LOCKSROOT_OF_NO_LOCKS

--- a/raiden_contracts/tests/unit/test_web3_interaction.py
+++ b/raiden_contracts/tests/unit/test_web3_interaction.py
@@ -1,4 +1,5 @@
 import pytest
+from eth_typing import BlockNumber
 from eth_utils.address import to_checksum_address
 from web3 import Web3
 from web3.contract import Contract
@@ -16,7 +17,7 @@ def test_logfilter_with_nonexistent_event(web3: Web3) -> None:
             abi=[],
             address=to_checksum_address("0xfake"),
             event_name="ev0",
-            from_block=0,
+            from_block=BlockNumber(0),
             to_block="latest",
         )
 

--- a/raiden_contracts/tests/unit/test_web3_interaction.py
+++ b/raiden_contracts/tests/unit/test_web3_interaction.py
@@ -3,6 +3,7 @@ from eth_utils.address import to_checksum_address
 from web3 import Web3
 from web3.contract import Contract
 
+from raiden_contracts.tests.utils import call_and_transact
 from raiden_contracts.utils.logs import LogFilter
 
 
@@ -24,6 +25,6 @@ def test_call_and_transact_does_not_mine(web3: Web3, custom_token: Contract) -> 
     """ See call_and_transact() does not mine a block """
 
     before = web3.eth.blockNumber
-    custom_token.functions.multiplier().call_and_transact()
+    call_and_transact(custom_token.functions.multiplier())
     after = web3.eth.blockNumber
     assert before + 1 == after

--- a/raiden_contracts/tests/utils/blockchain.py
+++ b/raiden_contracts/tests/utils/blockchain.py
@@ -1,0 +1,5 @@
+from web3 import Web3
+
+
+def mine_blocks(web3: Web3, num_blocks: int) -> None:
+    web3.testing.mine(num_blocks)  # type: ignore

--- a/raiden_contracts/tests/utils/contracts.py
+++ b/raiden_contracts/tests/utils/contracts.py
@@ -2,11 +2,12 @@ from typing import Dict, List, Optional, Union
 
 from coincurve import PrivateKey
 from eth_tester import EthereumTester
-from eth_typing.evm import HexAddress
+from eth_typing.evm import ChecksumAddress, HexAddress
 from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract import Contract, ContractConstructor, ContractFunction
 from web3.providers.eth_tester import EthereumTesterProvider
+from web3.types import TxParams
 
 from raiden_contracts.constants import CONTRACT_CUSTOM_TOKEN, CONTRACT_TOKEN_NETWORK
 from raiden_contracts.contract_manager import ContractManager
@@ -45,7 +46,7 @@ def deploy_contract(
     deployer_address = private_key_to_address(deployer_key.to_hex())
     json_contract = contracts_manager.get_contract(contract_name)
     contract = web3.eth.contract(abi=json_contract["abi"], bytecode=json_contract["bin"])
-    tx_hash = call_and_transact(contract.constructor(*args), {"from": deployer_address})
+    tx_hash = call_and_transact(contract.constructor(*args), TxParams({"from": deployer_address}))
     contract_address = web3.eth.getTransactionReceipt(tx_hash)["contractAddress"]
 
     return contract(contract_address)
@@ -64,7 +65,7 @@ def deploy_custom_token(
 
 
 def get_token_network(
-    web3: Web3, address: HexAddress, contracts_manager: ContractManager
+    web3: Web3, address: ChecksumAddress, contracts_manager: ContractManager
 ) -> Contract:
     json_contract = contracts_manager.get_contract(CONTRACT_TOKEN_NETWORK)
 
@@ -73,7 +74,7 @@ def get_token_network(
 
 def call_and_transact(
     contract_function: Union[ContractConstructor, ContractFunction],
-    transaction_params: Optional[Dict] = None,
+    transaction_params: Optional[TxParams] = None,
 ) -> HexBytes:
     """ Executes contract_function.{call, transaction}(transaction_params) and returns txhash """
     # First 'call' might raise an exception

--- a/raiden_contracts/tests/utils/contracts.py
+++ b/raiden_contracts/tests/utils/contracts.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from coincurve import PrivateKey
 from eth_tester import EthereumTester
@@ -41,12 +41,12 @@ def deploy_contract(
     contracts_manager: ContractManager,
     contract_name: str,
     deployer_key: PrivateKey,
-    args: Optional[List] = None,
+    args: List[Any],
 ) -> Contract:
     deployer_address = private_key_to_address(deployer_key.to_hex())
     json_contract = contracts_manager.get_contract(contract_name)
     contract = web3.eth.contract(abi=json_contract["abi"], bytecode=json_contract["bin"])
-    tx_hash = call_and_transact(contract.constructor(*args), TxParams({"from": deployer_address}))
+    tx_hash = contract.constructor(*args).transact(TxParams({"from": deployer_address}))
     contract_address = web3.eth.getTransactionReceipt(tx_hash)["contractAddress"]
 
     return contract(contract_address)
@@ -73,8 +73,7 @@ def get_token_network(
 
 
 def call_and_transact(
-    contract_function: Union[ContractConstructor, ContractFunction],
-    transaction_params: Optional[TxParams] = None,
+    contract_function: ContractFunction, transaction_params: Optional[TxParams] = None,
 ) -> HexBytes:
     """ Executes contract_function.{call, transaction}(transaction_params) and returns txhash """
     # First 'call' might raise an exception

--- a/raiden_contracts/tests/utils/contracts.py
+++ b/raiden_contracts/tests/utils/contracts.py
@@ -1,11 +1,11 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional
 
 from coincurve import PrivateKey
 from eth_tester import EthereumTester
-from eth_typing.evm import ChecksumAddress, HexAddress
+from eth_typing.evm import ChecksumAddress
 from hexbytes import HexBytes
 from web3 import Web3
-from web3.contract import Contract, ContractConstructor, ContractFunction
+from web3.contract import Contract, ContractFunction
 from web3.providers.eth_tester import EthereumTesterProvider
 from web3.types import TxParams
 

--- a/raiden_contracts/tests/utils/contracts.py
+++ b/raiden_contracts/tests/utils/contracts.py
@@ -46,7 +46,7 @@ def deploy_contract(
     json_contract = contracts_manager.get_contract(contract_name)
     contract = web3.eth.contract(abi=json_contract["abi"], bytecode=json_contract["bin"])
     tx_hash = call_and_transact(contract.constructor(*args), {"from": deployer_address})
-    contract_address = web3.eth.getTransactionReceipt(tx_hash).contractAddress
+    contract_address = web3.eth.getTransactionReceipt(tx_hash)["contractAddress"]
 
     return contract(contract_address)
 

--- a/raiden_contracts/utils/logs.py
+++ b/raiden_contracts/utils/logs.py
@@ -11,11 +11,13 @@ from web3._utils.filters import construct_event_filter_params
 from web3._utils.threads import Timeout
 
 # A concrete event added in a transaction.
+from web3.types import ABI, ABIEvent
+
 LogRecorded = namedtuple("LogRecorded", "message callback count")
 
 
 class LogHandler:
-    def __init__(self, web3: Web3, address: HexAddress, abi: List[Any]):
+    def __init__(self, web3: Web3, address: HexAddress, abi: ABI):
         self.web3 = web3
         self.address = address
         self.abi = abi
@@ -136,7 +138,7 @@ class LogFilter:
     def __init__(
         self,
         web3: Web3,
-        abi: List[Any],
+        abi: ABI,
         address: HexAddress,
         event_name: str,
         from_block: int = 0,
@@ -183,6 +185,7 @@ class LogFilter:
             post_callback()
 
     def get_logs(self) -> List[Any]:
+        assert self.filter.filter_id is not None
         logs = self.web3.eth.getFilterLogs(self.filter.filter_id)
         formatted_logs = []
         for log in [dict(log) for log in logs]:
@@ -199,5 +202,6 @@ class LogFilter:
     def uninstall(self) -> None:
         assert self.web3 is not None
         assert self.filter is not None
+        assert self.filter.filter_id is not None
         self.web3.eth.uninstallFilter(self.filter.filter_id)
-        self.filter = None
+        del self.filter

--- a/raiden_contracts/utils/logs.py
+++ b/raiden_contracts/utils/logs.py
@@ -1,7 +1,7 @@
 import functools
 from collections import defaultdict, namedtuple
 from inspect import getframeinfo, stack
-from typing import Any, Callable, Dict, List, Optional, Union, cast
+from typing import Any, Callable, Dict, List, Optional, cast
 
 from click import echo
 from eth_typing.evm import BlockNumber, ChecksumAddress, HexAddress
@@ -15,6 +15,7 @@ from web3._utils.threads import Timeout
 from web3.types import ABI, ABIEvent, BlockIdentifier
 
 LogRecorded = namedtuple("LogRecorded", "message callback count")
+GenesisBlock = BlockNumber(0)
 
 
 class LogHandler:
@@ -142,7 +143,7 @@ class LogFilter:
         abi: ABI,
         address: ChecksumAddress,
         event_name: str,
-        from_block: BlockNumber = BlockNumber(0),
+        from_block: BlockNumber = GenesisBlock,
         to_block: BlockIdentifier = "latest",
         filters: Any = None,
         callback: Optional[Callable[..., Any]] = None,

--- a/raiden_contracts/utils/mint_tokens.py
+++ b/raiden_contracts/utils/mint_tokens.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 import click
-from eth_typing import URI, ChecksumAddress
+from eth_typing import URI, ChecksumAddress, HexStr
 from eth_utils import encode_hex
 from web3 import HTTPProvider, Web3
 from web3.middleware import construct_sign_and_send_raw_middleware
@@ -30,7 +30,7 @@ def main(rpc_url: URI, private_key: Path, token_address: ChecksumAddress, amount
     owner = private_key_to_address(private_key_string)
     web3.middleware_onion.add(construct_sign_and_send_raw_middleware(private_key_string))
     token_code = web3.eth.getCode(token_address, "latest")
-    assert token_code != b""
+    assert token_code != HexStr("")
     token_contract = ContractManager(contracts_precompiled_path()).get_contract(
         CONTRACT_CUSTOM_TOKEN
     )

--- a/raiden_contracts/utils/mint_tokens.py
+++ b/raiden_contracts/utils/mint_tokens.py
@@ -3,8 +3,9 @@ from pathlib import Path
 from typing import Optional
 
 import click
-from eth_typing import URI, ChecksumAddress, HexStr
+from eth_typing import URI, ChecksumAddress
 from eth_utils import encode_hex
+from hexbytes import HexBytes
 from web3 import HTTPProvider, Web3
 from web3.middleware import construct_sign_and_send_raw_middleware
 
@@ -30,7 +31,7 @@ def main(rpc_url: URI, private_key: Path, token_address: ChecksumAddress, amount
     owner = private_key_to_address(private_key_string)
     web3.middleware_onion.add(construct_sign_and_send_raw_middleware(private_key_string))
     token_code = web3.eth.getCode(token_address, "latest")
-    assert token_code != HexStr("")
+    assert token_code != HexBytes("")  # type: ignore
     token_contract = ContractManager(contracts_precompiled_path()).get_contract(
         CONTRACT_CUSTOM_TOKEN
     )

--- a/raiden_contracts/utils/mint_tokens.py
+++ b/raiden_contracts/utils/mint_tokens.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 import click
-from eth_typing import HexAddress
+from eth_typing import URI, HexAddress
 from eth_utils import encode_hex
 from web3 import HTTPProvider, Web3
 from web3.middleware import construct_sign_and_send_raw_middleware
@@ -23,7 +23,7 @@ WEI_TO_ETH = 10 ** 18
 @click.option("--private-key", required=True, type=click.Path(exists=True, dir_okay=False))
 @click.option("--token-address", help="address of the token contract", required=True)
 @click.option("--amount", help="Amount of tokens to mint", required=True, type=click.INT)
-def main(rpc_url: str, private_key: Path, token_address: HexAddress, amount: int) -> None:
+def main(rpc_url: URI, private_key: Path, token_address: HexAddress, amount: int) -> None:
     web3 = Web3(HTTPProvider(rpc_url))
     private_key_string: Optional[str] = get_private_key(private_key)
     assert private_key_string is not None

--- a/raiden_contracts/utils/mint_tokens.py
+++ b/raiden_contracts/utils/mint_tokens.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 import click
-from eth_typing import URI, HexAddress
+from eth_typing import URI, ChecksumAddress
 from eth_utils import encode_hex
 from web3 import HTTPProvider, Web3
 from web3.middleware import construct_sign_and_send_raw_middleware
@@ -23,7 +23,7 @@ WEI_TO_ETH = 10 ** 18
 @click.option("--private-key", required=True, type=click.Path(exists=True, dir_okay=False))
 @click.option("--token-address", help="address of the token contract", required=True)
 @click.option("--amount", help="Amount of tokens to mint", required=True, type=click.INT)
-def main(rpc_url: URI, private_key: Path, token_address: HexAddress, amount: int) -> None:
+def main(rpc_url: URI, private_key: Path, token_address: ChecksumAddress, amount: int) -> None:
     web3 = Web3(HTTPProvider(rpc_url))
     private_key_string: Optional[str] = get_private_key(private_key)
     assert private_key_string is not None

--- a/raiden_contracts/utils/token_ops.py
+++ b/raiden_contracts/utils/token_ops.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 import click
 import requests
+from eth_typing import URI
 from eth_utils import to_checksum_address
 from web3 import HTTPProvider, Web3
 from web3.middleware import construct_sign_and_send_raw_middleware, geth_poa_middleware
@@ -17,7 +18,7 @@ from raiden_contracts.utils.transaction import check_successful_tx
 
 class TokenOperations:
     def __init__(
-        self, rpc_url: str, private_key: Path, password: Optional[Path] = None, wait: int = 10
+        self, rpc_url: URI, private_key: Path, password: Optional[Path] = None, wait: int = 10
     ):
         self.web3 = Web3(HTTPProvider(rpc_url))
         self.private_key = get_private_key(private_key, password)
@@ -129,7 +130,7 @@ def cli() -> None:
 @cli.command()
 @common_options
 def mint(
-    private_key: str, password: str, rpc_url: str, token_address: str, amount: int, wait: int
+    private_key: str, password: str, rpc_url: URI, token_address: str, amount: int, wait: int
 ) -> None:
     password_file = Path(password) if password else None
     token_ops = TokenOperations(rpc_url, Path(private_key), password_file, wait)
@@ -165,7 +166,7 @@ def weth(
 def transfer(
     private_key: str,
     password: str,
-    rpc_url: str,
+    rpc_url: URI,
     token_address: str,
     amount: int,
     wait: int,
@@ -191,7 +192,7 @@ def transfer(
     "--token-address", required=True, help="Address of the token contract", type=click.STRING
 )
 @click.option("--address", help="Address of account to get Balance", type=click.STRING)
-def balance(rpc_url: str, token_address: str, address: str) -> None:
+def balance(rpc_url: URI, token_address: str, address: str) -> None:
     token_address = to_checksum_address(token_address)
     address = to_checksum_address(address)
     web3 = Web3(HTTPProvider(rpc_url))

--- a/raiden_contracts/utils/token_ops.py
+++ b/raiden_contracts/utils/token_ops.py
@@ -4,8 +4,9 @@ from typing import Any, Callable, Dict, List, Optional
 
 import click
 import requests
-from eth_typing import URI, ChecksumAddress, HexStr
+from eth_typing import URI, ChecksumAddress
 from eth_utils import to_checksum_address
+from hexbytes import HexBytes
 from web3 import HTTPProvider, Web3
 from web3.middleware import construct_sign_and_send_raw_middleware, geth_poa_middleware
 from web3.types import TxReceipt, Wei
@@ -31,7 +32,7 @@ class TokenOperations:
         self.web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
     def is_valid_contract(self, token_address: ChecksumAddress) -> bool:
-        return self.web3.eth.getCode(token_address, "latest") != HexStr("")
+        return self.web3.eth.getCode(token_address, "latest") != HexBytes("")  # type: ignore
 
     def mint_tokens(self, token_address: ChecksumAddress, amount: int) -> TxReceipt:
         token_address = to_checksum_address(token_address)

--- a/raiden_contracts/utils/transaction.py
+++ b/raiden_contracts/utils/transaction.py
@@ -1,12 +1,14 @@
 from typing import Any, Dict, Optional, Tuple
 
+from hexbytes import HexBytes
 from web3 import Web3
 from web3._utils.threads import Timeout
+from web3.types import TxData, TxReceipt
 
 
 def check_successful_tx(
-    web3: Web3, txid: str, timeout: int = 180
-) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    web3: Web3, txid: HexBytes, timeout: int = 180
+) -> Tuple[TxReceipt, TxData]:
     """See if transaction went through (Solidity code did not throw).
     :return: Transaction receipt and transaction info
     """
@@ -23,12 +25,12 @@ def check_successful_tx(
         raise ValueError(f"Status 0 indicates failure")
     if txinfo["gas"] == receipt["gasUsed"]:
         raise ValueError(f'Gas is completely used ({txinfo["gas"]}). Failure?')
-    return (receipt, txinfo)
+    return receipt, txinfo
 
 
 def wait_for_transaction_receipt(
-    web3: Web3, txid: str, timeout: int = 180
-) -> Optional[Dict[str, Any]]:
+    web3: Web3, txid: HexBytes, timeout: int = 180
+) -> Optional[TxReceipt]:
     receipt = None
     with Timeout(timeout) as time:
         while not receipt or not receipt["blockNumber"]:  # pylint: disable=E1136

--- a/raiden_contracts/utils/transaction.py
+++ b/raiden_contracts/utils/transaction.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Optional, Tuple
 
 from hexbytes import HexBytes
 from web3 import Web3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ rlp>=1.0.0
 coincurve>=8.0.0
 py-solc>=3.0.0
 semver
-web3<5.6.0,>=5.4.0
+web3<6.0.0,>=5.6.0
 py_ecc<=1.5.0
 eth-abi<3.0.0,>=2.0.0
 eth-utils<2.0.0,>=1.8.4


### PR DESCRIPTION
### What this PR does

Update to `web3` with exported typing information.

I found wrong error in the type annotations. See https://github.com/raiden-network/raiden-contracts/pull/1366/commits/f0a32b5497a0efc975378056e16ed42b82e678a4

### Why I'm making this PR

Better static analysis of the code.

### What's tricky about this PR (if any)

It's big, sorry for that. Otherwise it's quite straight forward.

Besides that we need to decide if we want to use the type from `web3`, `eth-typing` for raiden as well.

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
    * if the PR adds or removes `require()` or `assert()`
        * [ ] add an entry in Changelog
        * [ ] open an issue in the client, light client, service repos so the change is reflected there
        * Just adding a message in `require()` doesn't require these steps.
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.