### PR TITLE
Verify token networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Documents changes that result in:
 - API changes in the package (externally used constants, externally used utilities and scripts)
 - important bug fixes between releases
 
+## Unreleased
+
+- [#1376](https://github.com/raiden-network/raiden-contracts/pull/1376) Support verification of TokenNetworks
+
 ## [0.37.0-beta]
 
 - Practice deployment for next mainnet release

--- a/raiden_contracts/constants.py
+++ b/raiden_contracts/constants.py
@@ -158,6 +158,7 @@ ContractListEntry = namedtuple("ContractListEntry", "module name")
 CONTRACT_LIST = [
     ContractListEntry(module=DeploymentModule.RAIDEN, name=CONTRACT_SECRET_REGISTRY),
     ContractListEntry(module=DeploymentModule.RAIDEN, name=CONTRACT_TOKEN_NETWORK_REGISTRY),
+    ContractListEntry(module=DeploymentModule.RAIDEN, name=CONTRACT_TOKEN_NETWORK),
     ContractListEntry(module=DeploymentModule.SERVICES, name=CONTRACT_SERVICE_REGISTRY),
     ContractListEntry(module=DeploymentModule.SERVICES, name=CONTRACT_MONITORING_SERVICE),
     ContractListEntry(module=DeploymentModule.SERVICES, name=CONTRACT_ONE_TO_N),

--- a/raiden_contracts/contract_manager.py
+++ b/raiden_contracts/contract_manager.py
@@ -38,10 +38,11 @@ DeployedContract = TypedDict(
 )
 
 
-class DeployedContracts(TypedDict):
+class DeployedContracts(TypedDict, total=False):
     chain_id: int
     contracts: Dict[str, DeployedContract]
     contracts_version: str
+    token_networks: List[Dict[str, Any]]
 
 
 class ContractManagerLoadError(RuntimeError):
@@ -218,12 +219,13 @@ def get_contracts_deployment_info(
     if module_chosen(DeploymentModule.SERVICES) and contracts_version_provides_services(version):
         files.append(contracts_deployed_path(chain_id=chain_id, version=version, services=True))
 
-    deployment_data: DeployedContracts = {}  # type: ignore
+    deployment_data: Optional[DeployedContracts] = {}
 
     for f in files:
         j = load_json_from_path(f)
         if j is None:
             continue
+        assert deployment_data is not None
         deployment_data = merge_deployment_data(
             deployment_data,
             DeployedContracts(

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -22,7 +22,7 @@ from raiden_contracts.constants import (
     DEPLOY_SETTLE_TIMEOUT_MAX,
     DEPLOY_SETTLE_TIMEOUT_MIN,
 )
-from raiden_contracts.contract_manager import contracts_deployed_path
+from raiden_contracts.contract_manager import DeployedContracts, contracts_deployed_path
 from raiden_contracts.deploy.contract_deployer import ContractDeployer
 from raiden_contracts.deploy.contract_verifier import ContractVerifier
 from raiden_contracts.utils.private_key import get_private_key
@@ -463,7 +463,7 @@ def _add_token_network_deploy_info(
         chain_id=ChainID(deployer.web3.eth.chainId), version=contracts_version
     )
     with deployment_file_path.open() as f:
-        deployed_contracts_info = json.load(f)
+        deployed_contracts_info: DeployedContracts = json.load(f)
     deployed_contracts_info.setdefault("token_networks", []).append(token_network)
     deployer.store_and_verify_deployment_info_raiden(
         deployed_contracts_info=deployed_contracts_info

--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -452,7 +452,13 @@ def register(
         channel_participant_deposit_limit=channel_participant_deposit_limit,
         token_network_deposit_limit=token_network_deposit_limit,
     )
+    _add_token_network_deploy_info(token_network, deployer, contracts_version)
 
+
+def _add_token_network_deploy_info(
+    token_network: Dict[str, Any], deployer: ContractDeployer, contracts_version: str
+) -> None:
+    """ Add deploy info dict to the deploy_*.json file """
     deployment_file_path = contracts_deployed_path(
         chain_id=ChainID(deployer.web3.eth.chainId), version=contracts_version
     )

--- a/raiden_contracts/tests/deprecation_switch_testnet.py
+++ b/raiden_contracts/tests/deprecation_switch_testnet.py
@@ -141,7 +141,7 @@ def deprecation_test_setup(
         token_address=token_address,
         channel_participant_deposit_limit=channel_participant_deposit_limit,
         token_network_deposit_limit=token_network_deposit_limit,
-    )
+    )["token_network_address"]
 
     token_network_abi = deployer.contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK)
     token_network = deployer.web3.eth.contract(

--- a/raiden_contracts/tests/test_etherscan_verify.py
+++ b/raiden_contracts/tests/test_etherscan_verify.py
@@ -25,7 +25,6 @@ from raiden_contracts.deploy.etherscan_verify import (
     get_constructor_args,
     guid_status,
     join_sources,
-    post_data_for_etherscan_verification,
 )
 
 contract_name = "DummyContract"
@@ -81,32 +80,6 @@ def test_get_constructor_args_two_args() -> None:
         == "0000000000000000000000000000000000000000000000000000000000000010"
         "0000000000000000000000000000000000000000000000000000000000000001"
     )
-
-
-def test_post_data_for_etherscan_verification() -> None:
-    output = post_data_for_etherscan_verification(
-        apikey="jkl;jkl;jkl;",
-        deployment_info={"address": "dummy_address"},  # type: ignore
-        source="dummy_source",
-        contract_name=contract_name,
-        metadata={
-            "compiler": {"version": "1.2.3"},
-            "settings": {"optimizer": {"enabled": False, "runs": "runs"}},
-        },
-        constructor_args="constructor_arguments",
-    )
-    assert output == {
-        "apikey": "jkl;jkl;jkl;",
-        "module": "contract",
-        "action": "verifysourcecode",
-        "contractaddress": "dummy_address",
-        "sourceCode": "dummy_source",
-        "contractname": contract_name,
-        "compilerversion": "v1.2.3",
-        "optimizationUsed": 0,
-        "runs": "runs",
-        "constructorArguements": "constructor_arguments",
-    }
 
 
 def test_run_join_contracts() -> None:

--- a/raiden_contracts/tests/test_etherscan_verify.py
+++ b/raiden_contracts/tests/test_etherscan_verify.py
@@ -52,8 +52,8 @@ def test_get_constructor_args_one_arg() -> None:
             "metadata": "dummy",
         }
     )
-    deploy_info: DeployedContracts = {  # type: ignore
-        "contracts": {contract_name: {"constructor_arguments": [16]}}
+    deploy_info: DeployedContracts = {
+        "contracts": {contract_name: {"constructor_arguments": [16]}}  # type: ignore
     }
     assert (
         get_constructor_args(deploy_info, contract_name, contract_manager)
@@ -72,8 +72,8 @@ def test_get_constructor_args_two_args() -> None:
             "metadata": "dummy",
         }
     )
-    deploy_info: DeployedContracts = {  # type: ignore
-        "contracts": {contract_name: {"constructor_arguments": [16, True]}}
+    deploy_info: DeployedContracts = {
+        "contracts": {contract_name: {"constructor_arguments": [16, True]}}  # type: ignore
     }
     assert (
         get_constructor_args(deploy_info, contract_name, contract_manager)


### PR DESCRIPTION
Add support for verifying TokenNetworks registered via the TokenNetworkRegistry. This is a bit more involved since the TokenNetworks are not deployed by the python code, but by the TokenNetworkRegistry. So we have to reconstruct the argument list.

* [x] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.

TODOs left for the next PR:
- [ ] Allow arbitrary order of deploys and TN registration
- [ ] Add support for passing the password when deploying (currently always has a prompt)