### PR TITLE
Bump version: 0.37.0-beta → 0.37.0b2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,8 @@
 [bumpversion]
-current_version = 0.37.0-beta
+current_version = 0.37.0b2
 commit = True
 tag = True
 
 [bumpversion:file:setup.py]
 serialize = {major}.{minor}.{patch}
+

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import Command
 from setuptools.command.build_py import build_py
 
 DESCRIPTION = "Raiden contracts library and utilities"
-VERSION = "0.37.0-beta"
+VERSION = "0.37.0b2"
 
 
 def read_requirements(path: str) -> List[str]:


### PR DESCRIPTION
### What this PR does
Bump the PyPi version of `raiden-contracts` to `0.37.0b2`.

### Why I'm making this PR
This will allow us to upload a new beta release to PyPi

### What's tricky about this PR (if any)

I used `bump2version --config-file .bumpversion.cfg --new-version '0.37.0-beta2' 0.37.0-beta2`, but still had to
manually adjust the `VERSION` constant in `setup.py`. Maybe there are other places, that I missed?

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
    * if the PR adds or removes `require()` or `assert()`
        * [ ] add an entry in Changelog
        * [ ] open an issue in the client, light client, service repos so the change is reflected there
        * Just adding a message in `require()` doesn't require these steps.
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.