### PR TITLE
Move mypy-extensions into requirements.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,6 @@ attrs>=19.2.0
 bump2version
 requests
 mypy==0.761
-mypy-extensions==0.4.3
 pylint
 pylint-quotes
 requests_mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ py_ecc<=1.5.0
 eth-abi<3.0.0,>=2.0.0
 eth-utils<2.0.0,>=1.8.4
 eth-typing<3.0.0,>=2.2.1
+mypy-extensions==0.4.3


### PR DESCRIPTION
This could be avoided by importing it in an `if TYPING` block, but I'm
afraid people would forget and break the package. Therefore, I am more
comfortable with putting it into the normal requirements, although it is
not strictly necessary.