### PR TITLE
Move basic Raiden types and start using them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,14 @@ ISORT_PARAMS = --ignore-whitespace --settings-path ./ --recursive raiden_contrac
 
 BLACK_PARAMS = --line-length 99 raiden_contracts/
 
-lint:
+lint: mypy
 	black --check --diff $(BLACK_PARAMS)
-	mypy $(LINT_FILES)
 	flake8 $(LINT_FILES)
 	pylint $(LINT_FILES)
 	isort $(ISORT_PARAMS) --check-only
+
+mypy:
+	mypy $(LINT_FILES)
 
 isort:
 	isort $(ISORT_PARAMS)

--- a/raiden_contracts/constants.py
+++ b/raiden_contracts/constants.py
@@ -5,7 +5,7 @@ from typing import Dict
 from eth_typing import ChecksumAddress, HexAddress, HexStr
 from eth_utils import keccak
 
-from raiden_contracts.utils.type_aliases import ChainID
+from raiden_contracts.utils.type_aliases import ChainID, Locksroot
 
 # The last digit is supposed to be zero always. See `RELEASE.rst`.
 CONTRACTS_VERSION = "0.37.0"
@@ -38,7 +38,7 @@ MAX_ETH_CHANNEL_PARTICIPANT = int(0.075 * 10 ** 18)
 MAX_ETH_TOKEN_NETWORK = int(250 * 10 ** 18)
 
 # Special hashes
-LOCKSROOT_OF_NO_LOCKS = keccak(b"")
+LOCKSROOT_OF_NO_LOCKS = Locksroot(keccak(b""))
 EMPTY_ADDRESS = ChecksumAddress(HexAddress(HexStr("0x0000000000000000000000000000000000000000")))
 
 # Event names

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -37,6 +37,7 @@ from raiden_contracts.utils.type_aliases import (
     BalanceHash,
     BlockExpiration,
     ChannelID,
+    Locksroot,
     Signature,
     TokenAmount,
 )
@@ -659,10 +660,10 @@ def create_balance_proof(token_network: Contract, get_private_key: Callable) -> 
     def get(
         channel_identifier: ChannelID,
         participant: HexAddress,
-        transferred_amount: int = 0,
-        locked_amount: int = 0,
+        transferred_amount: TokenAmount = TokenAmount(0),  # noqa
+        locked_amount: TokenAmount = TokenAmount(0),  # noqa
         nonce: Nonce = Nonce(0),  # noqa
-        locksroot: Optional[bytes] = None,
+        locksroot: Optional[Locksroot] = None,
         additional_hash: Optional[AdditionalHash] = None,
         v: int = 27,
         signer: Optional[HexAddress] = None,

--- a/raiden_contracts/tests/test_etherscan_verify.py
+++ b/raiden_contracts/tests/test_etherscan_verify.py
@@ -127,11 +127,11 @@ def test_etherscan_verify_already_verified() -> None:
             """,
         )
         runner = CliRunner()
-        result = runner.invoke(
+        runner.invoke(
             etherscan_verify,
             ["--chain-id", str(chain_id), "--apikey", "API", "--contract-name", "SecretRegistry"],
+            catch_exceptions=False,
         )
-        assert result.exit_code == 0
 
 
 def test_etherscan_verify_unknown_error() -> None:

--- a/raiden_contracts/tests/test_monitoring_service.py
+++ b/raiden_contracts/tests/test_monitoring_service.py
@@ -23,8 +23,9 @@ from raiden_contracts.tests.utils import (
 )
 from raiden_contracts.tests.utils.blockchain import mine_blocks
 from raiden_contracts.utils.proofs import sign_reward_proof
+from raiden_contracts.utils.type_aliases import TokenAmount
 
-REWARD_AMOUNT = 10
+REWARD_AMOUNT = TokenAmount(10)
 
 
 @pytest.fixture

--- a/raiden_contracts/tests/test_one_to_n.py
+++ b/raiden_contracts/tests/test_one_to_n.py
@@ -9,6 +9,7 @@ from web3.contract import Contract
 from raiden_contracts.constants import OneToNEvent
 from raiden_contracts.tests.utils import call_and_transact
 from raiden_contracts.utils.proofs import sign_one_to_n_iou
+from raiden_contracts.utils.type_aliases import BlockExpiration, ChainID, TokenAmount
 
 
 def test_claim(
@@ -202,8 +203,8 @@ def test_claim_by_unregistered_service(
     (A, B) = get_accounts(2)
     deposit_to_udc(A, 30)
 
-    amount = 10
-    expiration = web3.eth.blockNumber + 2
+    amount = TokenAmount(10)
+    expiration = BlockExpiration(web3.eth.blockNumber + 2)
     chain_id = web3.eth.chainId
 
     signature = sign_one_to_n_iou(
@@ -213,7 +214,7 @@ def test_claim_by_unregistered_service(
         amount=amount,
         expiration_block=expiration,
         one_to_n_address=one_to_n_contract.address,
-        chain_id=chain_id,
+        chain_id=ChainID(chain_id),
     )
 
     # Doesn't work because B is not registered
@@ -247,8 +248,8 @@ def test_claim_with_insufficient_deposit(
     deposit_to_udc(A, 6)
     chain_id = web3.eth.chainId
 
-    amount = 10
-    expiration = web3.eth.blockNumber + 1
+    amount = TokenAmount(10)
+    expiration = BlockExpiration(web3.eth.blockNumber + 1)
     signature = sign_one_to_n_iou(
         get_private_key(A),
         sender=A,
@@ -256,7 +257,7 @@ def test_claim_with_insufficient_deposit(
         amount=amount,
         expiration_block=expiration,
         one_to_n_address=one_to_n_contract.address,
-        chain_id=chain_id,
+        chain_id=ChainID(chain_id),
     )
 
     # amount is 10, but only 6 are in deposit
@@ -279,7 +280,7 @@ def test_claim_with_insufficient_deposit(
     assert user_deposit_contract.functions.balances(B).call() == 6
 
     # claim can be retried when transferred amount was 0
-    expiration = web3.eth.blockNumber + 10
+    expiration = BlockExpiration(web3.eth.blockNumber + 10)
     signature = sign_one_to_n_iou(
         get_private_key(A),
         sender=A,
@@ -287,7 +288,7 @@ def test_claim_with_insufficient_deposit(
         amount=amount,
         expiration_block=expiration,
         one_to_n_address=one_to_n_contract.address,
-        chain_id=chain_id,
+        chain_id=ChainID(chain_id),
     )
     call_and_transact(
         one_to_n_contract.functions.claim(

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -22,6 +22,7 @@ from raiden_contracts.tests.utils.blockchain import mine_blocks
 from raiden_contracts.tests.utils.constants import DEPLOYER_ADDRESS, SERVICE_DEPOSIT, UINT256_MAX
 from raiden_contracts.utils.pending_transfers import get_locked_amount, get_pending_transfers_tree
 from raiden_contracts.utils.proofs import sign_one_to_n_iou, sign_reward_proof
+from raiden_contracts.utils.type_aliases import BlockExpiration, ChainID, TokenAmount
 
 
 @pytest.mark.parametrize("version", [None])
@@ -277,7 +278,7 @@ def print_gas_monitoring_service(
     # setup: two parties + MS
     (A, MS) = get_accounts(2)
     B = create_service_account()
-    reward_amount = 10
+    reward_amount = TokenAmount(10)
     deposit_to_udc(B, reward_amount)
 
     # register MS in the ServiceRegistry contract
@@ -372,8 +373,8 @@ def print_gas_one_to_n(
 
     # happy case
     chain_id = web3.eth.chainId
-    amount = 10
-    expiration = web3.eth.blockNumber + 2
+    amount = TokenAmount(10)
+    expiration = BlockExpiration(web3.eth.blockNumber + 2)
     signature = sign_one_to_n_iou(
         get_private_key(A),
         sender=A,
@@ -381,7 +382,7 @@ def print_gas_one_to_n(
         amount=amount,
         expiration_block=expiration,
         one_to_n_address=one_to_n_contract.address,
-        chain_id=chain_id,
+        chain_id=ChainID(chain_id),
     )
     txn_hash = call_and_transact(
         one_to_n_contract.functions.claim(

--- a/raiden_contracts/tests/unit/test_recover_from_signature.py
+++ b/raiden_contracts/tests/unit/test_recover_from_signature.py
@@ -8,6 +8,7 @@ from web3.contract import Contract
 from raiden_contracts.constants import EMPTY_ADDRESS, MessageTypeId
 from raiden_contracts.utils.proofs import eth_sign_hash_message, pack_balance_proof
 from raiden_contracts.utils.signature import sign
+from raiden_contracts.utils.type_aliases import ChainID
 
 # pylint: disable=E1120
 
@@ -37,7 +38,7 @@ def test_verify(
     balance_proof_hash = eth_sign_hash_message(
         pack_balance_proof(
             token_network_address=token_network.address,
-            chain_identifier=web3.eth.chainId,
+            chain_identifier=ChainID(web3.eth.chainId),
             channel_identifier=channel_identifier,
             balance_hash=balance_proof_A.balance_hash,
             nonce=balance_proof_A.nonce,
@@ -53,7 +54,7 @@ def test_verify(
     balance_proof_hash = eth_sign_hash_message(
         pack_balance_proof(
             token_network_address=token_network.address,
-            chain_identifier=web3.eth.chainId,
+            chain_identifier=ChainID(web3.eth.chainId),
             channel_identifier=channel_identifier,
             balance_hash=balance_proof_B.balance_hash,
             nonce=balance_proof_B.nonce,
@@ -106,7 +107,7 @@ def test_ecrecover_output(
     balance_proof_hash = eth_sign_hash_message(
         pack_balance_proof(
             token_network_address=token_network.address,
-            chain_identifier=web3.eth.chainId,
+            chain_identifier=ChainID(web3.eth.chainId),
             channel_identifier=channel_identifier,
             balance_hash=balance_proof_A.balance_hash,
             nonce=balance_proof_A.nonce,
@@ -190,7 +191,7 @@ def test_sign_privatekey_not_string(get_private_key: Callable, get_accounts: Cal
     A = get_accounts(1)[0]
     privatekey = get_private_key(A)
     with pytest.raises(TypeError):
-        sign(bytes(privatekey, "ascii"), bytes("a" * 32, "ascii"), v=27)  # type: ignore
+        sign(bytes(privatekey, "ascii"), bytes("a" * 32, "ascii"), v=27)
 
 
 def test_sign_wrong_v(get_private_key: Callable, get_accounts: Callable) -> None:

--- a/raiden_contracts/tests/utils/constants.py
+++ b/raiden_contracts/tests/utils/constants.py
@@ -5,14 +5,15 @@ from eth_typing import HexAddress, HexStr
 from eth_utils.units import units
 
 from raiden_contracts.utils.signature import private_key_to_address
+from raiden_contracts.utils.type_aliases import AdditionalHash, BalanceHash, Signature
 
 UINT256_MAX = 2 ** 256 - 1
 NOT_ADDRESS = "0xaaa"
 FAKE_ADDRESS = HexAddress(HexStr("0x00112233445566778899aabbccddeeff00112233"))
 EMPTY_HEXADDRESS = "0x0000000000000000000000000000000000000000"
-EMPTY_BALANCE_HASH = b"\x00" * 32
-EMPTY_ADDITIONAL_HASH = b"\x00" * 32
-EMPTY_SIGNATURE = b"\x00" * 65
+EMPTY_BALANCE_HASH = BalanceHash(b"\x00" * 32)
+EMPTY_ADDITIONAL_HASH = AdditionalHash(b"\x00" * 32)
+EMPTY_SIGNATURE = Signature(b"\x00" * 65)
 passphrase = "0"
 FAUCET_PRIVATE_KEY = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 FAUCET_ADDRESS = private_key_to_address(FAUCET_PRIVATE_KEY)

--- a/raiden_contracts/utils/proofs.py
+++ b/raiden_contracts/utils/proofs.py
@@ -10,6 +10,7 @@ from raiden_contracts.utils.type_aliases import (
     BlockExpiration,
     ChainID,
     ChannelID,
+    Locksroot,
     PrivateKey,
     Signature,
     TokenAmount,
@@ -19,7 +20,7 @@ from .signature import sign
 
 
 def hash_balance_data(
-    transferred_amount: int, locked_amount: int, locksroot: bytes
+    transferred_amount: TokenAmount, locked_amount: TokenAmount, locksroot: Locksroot
 ) -> BalanceHash:
     # pylint: disable=E1120
     return Web3.solidityKeccak(

--- a/raiden_contracts/utils/proofs.py
+++ b/raiden_contracts/utils/proofs.py
@@ -1,13 +1,26 @@
 from eth_abi import encode_single
 from eth_typing.evm import HexAddress
 from web3 import Web3
+from web3.types import Nonce
 
 from raiden_contracts.constants import MessageTypeId
+from raiden_contracts.utils.type_aliases import (
+    AdditionalHash,
+    BalanceHash,
+    BlockExpiration,
+    ChainID,
+    ChannelID,
+    PrivateKey,
+    Signature,
+    TokenAmount,
+)
 
 from .signature import sign
 
 
-def hash_balance_data(transferred_amount: int, locked_amount: int, locksroot: bytes) -> bytes:
+def hash_balance_data(
+    transferred_amount: int, locked_amount: int, locksroot: bytes
+) -> BalanceHash:
     # pylint: disable=E1120
     return Web3.solidityKeccak(
         abi_types=["uint256", "uint256", "bytes32"],
@@ -26,11 +39,11 @@ def eth_sign_hash_message(encoded_message: bytes) -> bytes:
 
 def pack_balance_proof(
     token_network_address: HexAddress,
-    chain_identifier: int,
-    channel_identifier: int,
-    balance_hash: bytes,
-    nonce: int,
-    additional_hash: bytes,
+    chain_identifier: ChainID,
+    channel_identifier: ChannelID,
+    balance_hash: BalanceHash,
+    nonce: Nonce,
+    additional_hash: AdditionalHash,
     msg_type: MessageTypeId,
 ) -> bytes:
     return (
@@ -46,13 +59,13 @@ def pack_balance_proof(
 
 def pack_balance_proof_message(
     token_network_address: HexAddress,
-    chain_identifier: int,
-    channel_identifier: int,
+    chain_identifier: ChainID,
+    channel_identifier: ChannelID,
     msg_type: MessageTypeId,
-    balance_hash: bytes,
-    nonce: int,
-    additional_hash: bytes,
-    closing_signature: bytes,
+    balance_hash: BalanceHash,
+    nonce: Nonce,
+    additional_hash: AdditionalHash,
+    closing_signature: Signature,
 ) -> bytes:
     return (
         pack_balance_proof(
@@ -70,12 +83,12 @@ def pack_balance_proof_message(
 
 def pack_cooperative_settle_message(
     token_network_address: HexAddress,
-    chain_identifier: int,
-    channel_identifier: int,
+    chain_identifier: ChainID,
+    channel_identifier: ChannelID,
     participant1_address: HexAddress,
-    participant1_balance: int,
+    participant1_balance: TokenAmount,
     participant2_address: HexAddress,
-    participant2_balance: int,
+    participant2_balance: TokenAmount,
 ) -> bytes:
     return (
         Web3.toBytes(hexstr=token_network_address)
@@ -91,11 +104,11 @@ def pack_cooperative_settle_message(
 
 def pack_withdraw_message(
     token_network_address: HexAddress,
-    chain_identifier: int,
-    channel_identifier: int,
+    chain_identifier: ChainID,
+    channel_identifier: ChannelID,
     participant: HexAddress,
-    amount_to_withdraw: int,
-    expiration_block: int,
+    amount_to_withdraw: TokenAmount,
+    expiration_block: BlockExpiration,
 ) -> bytes:
     return (
         Web3.toBytes(hexstr=token_network_address)
@@ -110,11 +123,11 @@ def pack_withdraw_message(
 
 def pack_reward_proof(
     monitoring_service_contract_address: HexAddress,
-    chain_id: int,
+    chain_id: ChainID,
     token_network_address: HexAddress,
     non_closing_participant: HexAddress,
-    non_closing_signature: bytes,
-    reward_amount: int,
+    non_closing_signature: Signature,
+    reward_amount: TokenAmount,
 ) -> bytes:
     return (
         Web3.toBytes(hexstr=monitoring_service_contract_address)
@@ -128,14 +141,14 @@ def pack_reward_proof(
 
 
 def sign_balance_proof(
-    privatekey: str,
+    privatekey: PrivateKey,
     token_network_address: HexAddress,
-    chain_identifier: int,
-    channel_identifier: int,
+    chain_identifier: ChainID,
+    channel_identifier: ChannelID,
     msg_type: MessageTypeId,
-    balance_hash: bytes,
-    nonce: int,
-    additional_hash: bytes,
+    balance_hash: BalanceHash,
+    nonce: Nonce,
+    additional_hash: AdditionalHash,
     v: int = 27,
 ) -> bytes:
     message_hash = eth_sign_hash_message(
@@ -154,15 +167,15 @@ def sign_balance_proof(
 
 
 def sign_balance_proof_message(
-    privatekey: str,
+    privatekey: PrivateKey,
     token_network_address: HexAddress,
-    chain_identifier: int,
-    channel_identifier: int,
+    chain_identifier: ChainID,
+    channel_identifier: ChannelID,
     msg_type: MessageTypeId,
-    balance_hash: bytes,
-    nonce: int,
-    additional_hash: bytes,
-    closing_signature: bytes,
+    balance_hash: BalanceHash,
+    nonce: Nonce,
+    additional_hash: AdditionalHash,
+    closing_signature: Signature,
     v: int = 27,
 ) -> bytes:
     message_hash = eth_sign_hash_message(
@@ -182,14 +195,14 @@ def sign_balance_proof_message(
 
 
 def sign_cooperative_settle_message(
-    privatekey: str,
+    privatekey: PrivateKey,
     token_network_address: HexAddress,
-    chain_identifier: int,
-    channel_identifier: int,
+    chain_identifier: ChainID,
+    channel_identifier: ChannelID,
     participant1_address: HexAddress,
-    participant1_balance: int,
+    participant1_balance: TokenAmount,
     participant2_address: HexAddress,
-    participant2_balance: int,
+    participant2_balance: TokenAmount,
     v: int = 27,
 ) -> bytes:
     message_hash = eth_sign_hash_message(
@@ -208,13 +221,13 @@ def sign_cooperative_settle_message(
 
 
 def sign_withdraw_message(
-    privatekey: str,
+    privatekey: PrivateKey,
     token_network_address: HexAddress,
-    chain_identifier: int,
-    channel_identifier: int,
+    chain_identifier: ChainID,
+    channel_identifier: ChannelID,
     participant: HexAddress,
-    amount_to_withdraw: int,
-    expiration_block: int,
+    amount_to_withdraw: TokenAmount,
+    expiration_block: BlockExpiration,
     v: int = 27,
 ) -> bytes:
     message_hash = eth_sign_hash_message(
@@ -232,13 +245,13 @@ def sign_withdraw_message(
 
 
 def sign_reward_proof(
-    privatekey: str,
+    privatekey: PrivateKey,
     monitoring_service_contract_address: HexAddress,
-    chain_id: int,
+    chain_id: ChainID,
     token_network_address: HexAddress,
     non_closing_participant: HexAddress,
-    non_closing_signature: bytes,
-    reward_amount: int,
+    non_closing_signature: Signature,
+    reward_amount: TokenAmount,
     v: int = 27,
 ) -> bytes:
     packed_data = pack_reward_proof(
@@ -255,13 +268,13 @@ def sign_reward_proof(
 
 
 def sign_one_to_n_iou(
-    privatekey: str,
+    privatekey: PrivateKey,
     sender: HexAddress,
     receiver: HexAddress,
-    amount: int,
-    expiration_block: int,
-    one_to_n_address: str,
-    chain_id: int,
+    amount: TokenAmount,
+    expiration_block: BlockExpiration,
+    one_to_n_address: HexAddress,
+    chain_id: ChainID,
     v: int = 27,
 ) -> bytes:
     iou_hash = eth_sign_hash_message(

--- a/raiden_contracts/utils/signature.py
+++ b/raiden_contracts/utils/signature.py
@@ -8,7 +8,7 @@ from eth_utils.typing import ChecksumAddress
 sha3 = keccak
 
 
-def sign(privkey: str, msg_hash: bytes, v: int = 0) -> bytes:
+def sign(privkey: PrivateKey, msg_hash: bytes, v: int = 0) -> bytes:
     if not isinstance(msg_hash, bytes):
         raise TypeError("sign(): msg_hash is not an instance of bytes")
     if len(msg_hash) != 32:

--- a/raiden_contracts/utils/type_aliases.py
+++ b/raiden_contracts/utils/type_aliases.py
@@ -1,4 +1,26 @@
 from typing import NewType
 
+T_AdditionalHash = bytes
+AdditionalHash = NewType("AdditionalHash", T_AdditionalHash)
+
+T_BalanceHash = bytes
+BalanceHash = NewType("BalanceHash", T_BalanceHash)
+
+# An absolute number of blocks
+T_BlockExpiration = int
+BlockExpiration = NewType("BlockExpiration", T_BlockExpiration)
+
 T_ChainID = int
 ChainID = NewType("ChainID", T_ChainID)
+
+T_ChannelID = int
+ChannelID = NewType("ChannelID", T_ChannelID)
+
+T_PrivateKey = bytes
+PrivateKey = NewType("PrivateKey", T_PrivateKey)
+
+T_Signature = bytes
+Signature = NewType("Signature", T_Signature)
+
+T_TokenAmount = int
+TokenAmount = NewType("TokenAmount", T_TokenAmount)

--- a/raiden_contracts/utils/type_aliases.py
+++ b/raiden_contracts/utils/type_aliases.py
@@ -16,6 +16,9 @@ ChainID = NewType("ChainID", T_ChainID)
 T_ChannelID = int
 ChannelID = NewType("ChannelID", T_ChannelID)
 
+T_Locksroot = bytes
+Locksroot = NewType("Locksroot", T_Locksroot)
+
 T_PrivateKey = bytes
 PrivateKey = NewType("PrivateKey", T_PrivateKey)
 


### PR DESCRIPTION
These can be imported from Raiden, so that both packages share the same
types for basic Raiden objects.