### PR TITLE
Use byte PrivateKey instead of hex encoded strs

### DIFF
--- a/raiden_contracts/tests/fixtures/base/utils.py
+++ b/raiden_contracts/tests/fixtures/base/utils.py
@@ -17,6 +17,7 @@ from raiden_contracts.contract_manager import contracts_gas_path
 from raiden_contracts.tests.utils import call_and_transact, get_random_privkey
 from raiden_contracts.utils.logs import LogHandler
 from raiden_contracts.utils.signature import private_key_to_address
+from raiden_contracts.utils.type_aliases import PrivateKey
 
 
 @pytest.fixture(scope="session")
@@ -74,9 +75,9 @@ def create_service_account(
 
 @pytest.fixture(scope="session")
 def get_private_key(ethereum_tester: EthereumTester) -> Callable:
-    def get(account_address: HexAddress) -> str:
+    def get(account_address: HexAddress) -> PrivateKey:
         keys = [
-            key.to_hex()
+            key.to_bytes()
             for key in ethereum_tester.backend.account_keys
             if is_same_address(key.public_key.to_address(), account_address)
         ]

--- a/raiden_contracts/tests/fixtures/base/utils.py
+++ b/raiden_contracts/tests/fixtures/base/utils.py
@@ -1,6 +1,7 @@
 import json
 from sys import argv
-from typing import Callable, Dict, Iterable, List, Optional
+from tempfile import NamedTemporaryFile
+from typing import IO, Callable, Dict, Iterable, List, Optional
 
 import pytest
 from eth_tester import EthereumTester
@@ -85,6 +86,16 @@ def get_private_key(ethereum_tester: EthereumTester) -> Callable:
         return keys[0]
 
     return get
+
+
+@pytest.fixture(scope="session")
+def privkey_file(get_private_key: Callable, get_accounts: Callable) -> Iterable[IO]:
+    (signer,) = get_accounts(1)
+    priv_key = get_private_key(signer)
+    with NamedTemporaryFile("w") as privkey_file:
+        privkey_file.write(priv_key.hex())
+        privkey_file.flush()
+        yield privkey_file
 
 
 @pytest.fixture(scope="session")

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -935,8 +935,8 @@ def test_deploy_token_no_balance(get_accounts: Callable, get_private_key: Callab
     """ Call deploy token command with a private key with no balance """
     (signer,) = get_accounts(1)
     priv_key = get_private_key(signer)
-    with NamedTemporaryFile() as privkey_file:
-        privkey_file.write(bytearray(priv_key, "ascii"))
+    with NamedTemporaryFile("w") as privkey_file:
+        privkey_file.write(priv_key.hex())
         privkey_file.flush()
         with patch.object(
             ContractDeployer, "deploy_token_contract", spec=ContractDeployer
@@ -954,8 +954,8 @@ def test_deploy_token_with_balance(get_accounts: Callable, get_private_key: Call
     """ Call deploy token command with a private key with some balance """
     (signer,) = get_accounts(1)
     priv_key = get_private_key(signer)
-    with NamedTemporaryFile() as privkey_file:
-        privkey_file.write(bytearray(priv_key, "ascii"))
+    with NamedTemporaryFile("w") as privkey_file:
+        privkey_file.write(priv_key.hex())
         privkey_file.flush()
         with patch.object(
             ContractDeployer, "deploy_token_contract", spec=ContractDeployer, return_value={}
@@ -1007,8 +1007,8 @@ def test_deploy_raiden(
     """ Calling deploy raiden command """
     (signer,) = get_accounts(1)
     priv_key = get_private_key(signer)
-    with NamedTemporaryFile() as privkey_file:
-        privkey_file.write(bytearray(priv_key, "ascii"))
+    with NamedTemporaryFile("w") as privkey_file:
+        privkey_file.write(priv_key.hex())
         privkey_file.flush()
         with patch.object(Eth, "getBalance", return_value=1):
             runner = CliRunner()
@@ -1037,13 +1037,13 @@ def test_register_script(
     """ Calling deploy raiden command """
     (signer,) = get_accounts(1)
     priv_key = get_private_key(signer)
-    with NamedTemporaryFile() as privkey_file, patch(
+    with NamedTemporaryFile("w") as privkey_file, patch(
         "raiden_contracts.deploy.contract_deployer.get_contracts_deployment_info"
     ) as get_deploy_info_mock, patch(
         "raiden_contracts.deploy.__main__._add_token_network_deploy_info"
     ) as add_tn_info:
         get_deploy_info_mock.return_value = deployed_raiden_info
-        privkey_file.write(bytearray(priv_key, "ascii"))
+        privkey_file.write(priv_key.hex())
         privkey_file.flush()
         with patch.object(Eth, "getBalance", return_value=1), patch.object(Eth, "chainId", 61):
             runner = CliRunner()
@@ -1079,8 +1079,8 @@ def test_register_script_without_token_network(
     """ Calling deploy raiden command """
     (signer,) = get_accounts(1)
     priv_key = get_private_key(signer)
-    with NamedTemporaryFile() as privkey_file:
-        privkey_file.write(bytearray(priv_key, "ascii"))
+    with NamedTemporaryFile("w") as privkey_file:
+        privkey_file.write(priv_key.hex())
         privkey_file.flush()
         with patch.object(Eth, "getBalance", return_value=1):
             runner = CliRunner()
@@ -1121,8 +1121,8 @@ def test_deploy_raiden_save_info_false(
     """ Calling deploy raiden command with --save_info False"""
     (signer,) = get_accounts(1)
     priv_key = get_private_key(signer)
-    with NamedTemporaryFile() as privkey_file:
-        privkey_file.write(bytearray(priv_key, "ascii"))
+    with NamedTemporaryFile("w") as privkey_file:
+        privkey_file.write(priv_key.hex())
         privkey_file.flush()
         with patch.object(Eth, "getBalance", return_value=1):
             runner = CliRunner()
@@ -1196,8 +1196,8 @@ def test_deploy_services(
     """ Calling deploy raiden command """
     (signer,) = get_accounts(1)
     priv_key = get_private_key(signer)
-    with NamedTemporaryFile() as privkey_file:
-        privkey_file.write(bytearray(priv_key, "ascii"))
+    with NamedTemporaryFile("w") as privkey_file:
+        privkey_file.write(priv_key.hex())
         privkey_file.flush()
         with patch.object(Eth, "getBalance", return_value=1):
             runner = CliRunner()
@@ -1220,8 +1220,8 @@ def test_deploy_old_services(get_accounts: Callable, get_private_key: Callable) 
     """ Calling deploy raiden command """
     (signer,) = get_accounts(1)
     priv_key = get_private_key(signer)
-    with NamedTemporaryFile() as privkey_file:
-        privkey_file.write(bytearray(priv_key, "ascii"))
+    with NamedTemporaryFile("w") as privkey_file:
+        privkey_file.write(priv_key.hex())
         privkey_file.flush()
         with patch.object(Eth, "getBalance", return_value=1):
             runner = CliRunner()
@@ -1250,8 +1250,8 @@ def test_deploy_services_with_controller(
     """ Calling deploy raiden command """
     (signer,) = get_accounts(1)
     priv_key = get_private_key(signer)
-    with NamedTemporaryFile() as privkey_file:
-        privkey_file.write(bytearray(priv_key, "ascii"))
+    with NamedTemporaryFile("w") as privkey_file:
+        privkey_file.write(priv_key.hex())
         privkey_file.flush()
         with patch.object(Eth, "getBalance", return_value=1):
             runner = CliRunner()
@@ -1281,8 +1281,8 @@ def test_deploy_services_save_info_false(
     """ Calling deploy raiden command with --save_info False"""
     (signer,) = get_accounts(1)
     priv_key = get_private_key(signer)
-    with NamedTemporaryFile() as privkey_file:
-        privkey_file.write(bytearray(priv_key, "ascii"))
+    with NamedTemporaryFile("w") as privkey_file:
+        privkey_file.write(priv_key.hex())
         privkey_file.flush()
         with patch.object(Eth, "getBalance", return_value=1):
             runner = CliRunner()

--- a/raiden_contracts/utils/signature.py
+++ b/raiden_contracts/utils/signature.py
@@ -1,8 +1,7 @@
 from typing import Union
 
 from coincurve import PrivateKey, PublicKey
-from eth_typing import HexStr
-from eth_utils import keccak, remove_0x_prefix, to_bytes, to_checksum_address
+from eth_utils import keccak, to_bytes, to_checksum_address
 from eth_utils.typing import ChecksumAddress
 
 sha3 = keccak
@@ -13,12 +12,12 @@ def sign(privkey: PrivateKey, msg_hash: bytes, v: int = 0) -> bytes:
         raise TypeError("sign(): msg_hash is not an instance of bytes")
     if len(msg_hash) != 32:
         raise ValueError("sign(): msg_hash has to be exactly 32 bytes")
-    if not isinstance(privkey, str):
-        raise TypeError("sign(): privkey is not an instance of str")
+    if not isinstance(privkey, bytes):
+        raise TypeError("sign(): privkey is not an instance of bytes")
     if v not in {0, 27}:
         raise ValueError(f"sign(): got v = {v} expected 0 or 27.")
 
-    pk = PrivateKey.from_hex(remove_0x_prefix(HexStr(privkey)))
+    pk = PrivateKey(privkey)
     sig: bytes = pk.sign_recoverable(msg_hash, hasher=None)
     assert len(sig) == 65
 


### PR DESCRIPTION
The types are declared as bytes, so the actual runtime code should use bytes, too!

Followup of the type cleanup in https://github.com/raiden-network/raiden-contracts/pull/1394.