### PR TITLE
Use raiddit contracts by default

### DIFF
--- a/raiden_contracts/constants.py
+++ b/raiden_contracts/constants.py
@@ -8,7 +8,7 @@ from eth_utils import keccak
 from raiden_contracts.utils.type_aliases import ChainID, Locksroot
 
 # The last digit is supposed to be zero always. See `RELEASE.rst`.
-CONTRACTS_VERSION = "0.37.0"
+CONTRACTS_VERSION = None
 ALDERAAN_VERSION = "0.37.0"
 
 PRECOMPILED_DATA_FIELDS = ["abi", "bin", "bin-runtime", "metadata"]


### PR DESCRIPTION
### What this PR does
This changes the default CONTRACT_VERSION flag to `None`, so `raiden` will use the latest version by default.


See: https://github.com/raiden-network/raiden/blob/develop/raiden/tests/fixtures/blockchain.py#L11