### PR TITLE
Remove last usage of `deploy_contract` and remove it

### DIFF
--- a/raiden_contracts/tests/test_deprecation_switch.py
+++ b/raiden_contracts/tests/test_deprecation_switch.py
@@ -25,7 +25,7 @@ from raiden_contracts.utils.pending_transfers import (
 def test_deprecation_executor(
     web3: Web3,
     contracts_manager: ContractManager,
-    deploy_contract: Callable,
+    deploy_tester_contract: Callable,
     secret_registry_contract: Contract,
     custom_token: Contract,
     channel_participant_deposit_limit: int,
@@ -42,12 +42,9 @@ def test_deprecation_executor(
     """
     (deprecation_executor, B) = get_accounts(2)
 
-    json_contract = contracts_manager.get_contract(CONTRACT_TOKEN_NETWORK_REGISTRY)
-    token_network_registry = deploy_contract(
-        web3,
+    token_network_registry = deploy_tester_contract(
+        CONTRACT_TOKEN_NETWORK_REGISTRY,
         deprecation_executor,
-        json_contract["abi"],
-        json_contract["bin"],
         _secret_registry_address=secret_registry_contract.address,
         _chain_id=web3.eth.chain_id,
         _settlement_timeout_min=TEST_SETTLE_TIMEOUT_MIN,


### PR DESCRIPTION
### What this PR does

Remove the last usage of the `deploy_contract` fixture and remove it.

### Why I'm making this PR


Preparation for https://github.com/raiden-network/raiden-contracts/issues/401

### What's tricky about this PR (if any)

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
    * if the PR adds or removes `require()` or `assert()`
        * [ ] add an entry in Changelog
        * [ ] open an issue in the client, light client, service repos so the change is reflected there
        * Just adding a message in `require()` doesn't require these steps.
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.