### PR TITLE
Release 0.37.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.37.1
+current_version = 0.37.2
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Documents changes that result in:
 - API changes in the package (externally used constants, externally used utilities and scripts)
 - important bug fixes between releases
 
+## [0.37.2]
+
+- [#1439](https://github.com/raiden-network/raiden-contracts/pull/1439) Provide additional unstable (development) deployment on goerli testnet
+- [#1430](https://github.com/raiden-network/raiden-contracts/pull/1430) Allow reusing the ServiceRegistry when deploying contracts
+
 ## [0.37.0]
 
 - New deployments for both mainnet and testnets (goerli, rinkeby, ropsten)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import Command
 from setuptools.command.build_py import build_py
 
 DESCRIPTION = "Raiden contracts library and utilities"
-VERSION = "0.37.1"
+VERSION = "0.37.2"
 
 
 def read_requirements(path: str) -> List[str]:


### PR DESCRIPTION
This makes the new goerli deployment available for use in https://github.com/raiden-network/raiden/issues/6862.