### PR TITLE
Add `make upload-pypi` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all compile_contracts verify_contracts install install-dev lint isort black autopep8 format mypy clean release update_gas_costs
+.PHONY: all compile_contracts verify_contracts install install-dev lint isort black autopep8 format mypy clean release update_gas_costs dist upload-pypi
 
 all: verify_contracts install
 
@@ -53,3 +53,10 @@ clean:
 
 release: clean verify_contracts
 	python setup.py sdist bdist_wheel upload
+
+dist:
+	python setup.py sdist
+	python setup.py bdist_wheel
+
+upload-pypi: dist
+	twine upload dist/*

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -157,7 +157,7 @@ This command triggers a commit and a local tag is created. A PR must be made wit
 
 .. _release-package:
 
-Trigger Package Release
------------------------
+Upload Package to PyPI
+----------------------
 
-Push the newly created local tag (created at the previous step, e.g. ``v0.9.0``) directly to the ``master`` branch. This will trigger ``travis`` to upload the pypi package automatically, as seen here: https://github.com/raiden-network/raiden-contracts/blob/9fd2124eb648a629aee886f37ade5e502431371f/.travis.yml#L36-L47.
+Use `make upload-pypi` to build the python packages and upload them to PyPI. You will need access to the project at https://pypi.org/project/raiden-contracts/.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,3 +22,5 @@ isort==5.7.0
 pipdeptree
 six~=1.12
 pip>=21
+twine
+wheel


### PR DESCRIPTION
This will build and upload the PyPI package. In the past, this was done
by travis. If we want to automate this again, this make target can be
used.
