### PR TITLE
Fix deprecations (2021.03) and remove semver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ LINT_FILES = raiden_contracts/ setup.py
 
 ISORT_PARAMS = --ignore-whitespace --settings-path ./ raiden_contracts/
 
-BLACK_PARAMS = --line-length 99 raiden_contracts/
+BLACK_PARAMS = raiden_contracts/
 
 lint: mypy solium
 	black --check --diff $(BLACK_PARAMS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.black]
+line-length = 99
+target-version = ['py37']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | build
+  | dist
+)/
+'''

--- a/raiden_contracts/deploy/contract_verifier.py
+++ b/raiden_contracts/deploy/contract_verifier.py
@@ -247,10 +247,13 @@ class ContractVerifier:
         if chain_id != deployed_contracts_info["chain_id"]:
             raise RuntimeError("chain_id mismatch")
 
-        service_registry, service_registry_constructor_arguments = self._verify_deployed_contract(
+        (
+            service_registry,
+            service_registry_constructor_arguments,
+        ) = self._verify_deployed_contract(
             deployment_data=deployed_contracts_info, contract_name=CONTRACT_SERVICE_REGISTRY
         )
-        user_deposit, user_deposit_constructor_arguments = self._verify_deployed_contract(
+        (user_deposit, user_deposit_constructor_arguments,) = self._verify_deployed_contract(
             deployment_data=deployed_contracts_info, contract_name=CONTRACT_USER_DEPOSIT
         )
         one_to_n, one_to_n_constructor_arguments = self._verify_deployed_contract(

--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -42,7 +42,8 @@ def validate_contract_name(_ctx: Context, _param: Any, value: Optional[str]) -> 
 @click.option("--chain-id", default=3, help="Chain id. E.g. --chain-id 3")
 @click.option("--apikey", required=True, help="A valid Etherscan APIKEY is required.")
 @click.option(
-    "--guid", help="GUID from a previous verification attempt. Tries to get the submission status."
+    "--guid",
+    help="GUID from a previous verification attempt. Tries to get the submission status.",
 )
 @click.option(
     "--contract-name",
@@ -138,7 +139,9 @@ def join_sources(source_module: DeploymentModule, contract_name: str) -> str:
 
 
 def get_constructor_args(
-    deployment_info: DeployedContracts, contract_name: str, contract_manager: ContractManager
+    deployment_info: DeployedContracts,
+    contract_name: str,
+    contract_manager: ContractManager,
 ) -> str:
     constructor_arguments = deployment_info["contracts"][contract_name]["constructor_arguments"]
     if constructor_arguments != []:

--- a/raiden_contracts/tests/deprecation_switch_testnet.py
+++ b/raiden_contracts/tests/deprecation_switch_testnet.py
@@ -153,7 +153,8 @@ def deprecation_test_setup(
     )
 
     txhash = call_and_transact(
-        token_contract.functions.approve(token_network.address, token_amount), deployer.transaction
+        token_contract.functions.approve(token_network.address, token_amount),
+        deployer.transaction,
     )
     log.debug(f"Approving tokens for the TokenNetwork contract txHash={encode_hex(txhash)}")
     check_successful_tx(deployer.web3, txhash, deployer.wait)

--- a/raiden_contracts/tests/fixtures/base/address.py
+++ b/raiden_contracts/tests/fixtures/base/address.py
@@ -17,10 +17,16 @@ def send_funds(ethereum_tester: EthereumTester, custom_token: Contract) -> Calla
     def f(target: str) -> None:
         assert is_address(target)
         ethereum_tester.send_transaction(
-            {"from": FAUCET_ADDRESS, "to": target, "gas": 21000, "value": 1 * int(units["ether"])}
+            {
+                "from": FAUCET_ADDRESS,
+                "to": target,
+                "gas": 21000,
+                "value": 1 * int(units["ether"]),
+            }
         )
         call_and_transact(
-            custom_token.functions.transfer(_to=target, _value=10000), {"from": FAUCET_ADDRESS}
+            custom_token.functions.transfer(_to=target, _value=10000),
+            {"from": FAUCET_ADDRESS},
         )
 
     return f

--- a/raiden_contracts/tests/fixtures/base/utils.py
+++ b/raiden_contracts/tests/fixtures/base/utils.py
@@ -34,8 +34,12 @@ def create_account(web3: Web3, ethereum_tester: EthereumTester) -> Callable:
 
         for faucet in web3.eth.accounts[:10]:
             try:
-                web3.eth.sendTransaction(
-                    {"from": faucet, "to": address, "value": Wei(1 * int(units["finney"]))}
+                web3.eth.send_transaction(
+                    {
+                        "from": faucet,
+                        "to": address,
+                        "value": Wei(1 * int(units["finney"])),
+                    }
                 )
                 break
             except TransactionFailed:
@@ -65,7 +69,8 @@ def create_service_account(
         deposit = service_registry.functions.currentPrice().call()
         call_and_transact(custom_token.functions.mint(deposit), {"from": account})
         call_and_transact(
-            custom_token.functions.approve(service_registry.address, deposit), {"from": account}
+            custom_token.functions.approve(service_registry.address, deposit),
+            {"from": account},
         )
         call_and_transact(service_registry.functions.deposit(deposit), {"from": account})
         assert service_registry.functions.hasValidRegistration(account).call()

--- a/raiden_contracts/tests/fixtures/channel.py
+++ b/raiden_contracts/tests/fixtures/channel.py
@@ -60,9 +60,10 @@ def create_channel(token_network: Contract) -> Callable:
         channel_identifier = token_network.functions.getChannelIdentifier(A, B).call()
 
         # Test the channel state on chain
-        (channel_settle_timeout, channel_state) = token_network.functions.getChannelInfo(
-            channel_identifier, A, B
-        ).call()
+        (
+            channel_settle_timeout,
+            channel_state,
+        ) = token_network.functions.getChannelInfo(channel_identifier, A, B).call()
         assert channel_settle_timeout == settle_timeout
         assert channel_state == ChannelState.OPENED
 
@@ -334,7 +335,8 @@ def reveal_secrets(web3: Web3, secret_registry_contract: Contract) -> Callable:
         for (expiration, _, secrethash, secret) in transfers:
             assert web3.eth.block_number < expiration
             call_and_transact(
-                secret_registry_contract.functions.registerSecret(secret), {"from": tx_from}
+                secret_registry_contract.functions.registerSecret(secret),
+                {"from": tx_from},
             )
             assert (
                 secret_registry_contract.functions.getSecretRevealBlockHeight(secrethash).call()

--- a/raiden_contracts/tests/fixtures/token_network_fixtures.py
+++ b/raiden_contracts/tests/fixtures/token_network_fixtures.py
@@ -44,7 +44,9 @@ def register_token_network(web3: Web3, contracts_manager: ContractManager) -> Ca
     ) -> Contract:
         tx_hash = call_and_transact(
             token_network_registry.functions.createERC20TokenNetwork(
-                token_address, channel_participant_deposit_limit, token_network_deposit_limit
+                token_address,
+                channel_participant_deposit_limit,
+                token_network_deposit_limit,
             ),
             {"from": DEPLOYER_ADDRESS},
         )
@@ -134,7 +136,11 @@ def token_network_contract(
 ) -> Contract:
     return deploy_tester_contract(
         CONTRACT_TOKEN_NETWORK,
-        [standard_token_contract.address, secret_registry_contract.address, web3.eth.chain_id],
+        [
+            standard_token_contract.address,
+            secret_registry_contract.address,
+            web3.eth.chain_id,
+        ],
     )
 
 

--- a/raiden_contracts/tests/fixtures/token_network_registry.py
+++ b/raiden_contracts/tests/fixtures/token_network_registry.py
@@ -68,7 +68,7 @@ def token_network_registry_contract(
     return deploy_tester_contract(
         CONTRACT_TOKEN_NETWORK_REGISTRY,
         token_network_libs,
-        **token_network_registry_constructor_args
+        **token_network_registry_constructor_args,
     )
 
 
@@ -83,7 +83,7 @@ def token_network_registry_contract2(
     return deploy_tester_contract(
         CONTRACT_TOKEN_NETWORK_REGISTRY,
         token_network_libs,
-        **token_network_registry_constructor_args
+        **token_network_registry_constructor_args,
     )
 
 

--- a/raiden_contracts/tests/fixtures/user_deposit.py
+++ b/raiden_contracts/tests/fixtures/user_deposit.py
@@ -16,7 +16,9 @@ def user_deposit_whole_balance_limit() -> int:
 
 @pytest.fixture(scope="session")
 def uninitialized_user_deposit_contract(
-    deploy_tester_contract: Callable, custom_token: Contract, user_deposit_whole_balance_limit: int
+    deploy_tester_contract: Callable,
+    custom_token: Contract,
+    user_deposit_whole_balance_limit: int,
 ) -> Contract:
     return deploy_tester_contract(
         CONTRACT_USER_DEPOSIT,
@@ -62,7 +64,8 @@ def deposit_to_udc(user_deposit_contract: Contract, custom_token: Contract) -> C
             {"from": receiver},
         )
         call_and_transact(
-            user_deposit_contract.functions.deposit(receiver, amount), {"from": receiver}
+            user_deposit_contract.functions.deposit(receiver, amount),
+            {"from": receiver},
         )
 
     return deposit

--- a/raiden_contracts/tests/test_channel_close.py
+++ b/raiden_contracts/tests/test_channel_close.py
@@ -33,7 +33,9 @@ def test_close_nonexistent_channel(token_network: Contract, get_accounts: Callab
     non_existent_channel_identifier = 1
 
     (settle_block_number, state) = token_network.functions.getChannelInfo(
-        channel_identifier=non_existent_channel_identifier, participant1=A, participant2=B
+        channel_identifier=non_existent_channel_identifier,
+        participant1=A,
+        participant2=B,
     ).call()
     assert state == ChannelState.NONEXISTENT
     assert settle_block_number == 0
@@ -147,7 +149,11 @@ def test_close_wrong_signature(
 
     with pytest.raises(TransactionFailed):
         token_network.functions.closeChannel(
-            channel_identifier, B, A, *balance_proof._asdict().values(), closing_signature_A
+            channel_identifier,
+            B,
+            A,
+            *balance_proof._asdict().values(),
+            closing_signature_A,
         ).call({"from": A})
 
 
@@ -645,7 +651,11 @@ def test_close_replay_reopened_channel(
     )
     call_and_transact(
         token_network.functions.closeChannel(
-            channel_identifier1, B, A, *balance_proof_B._asdict().values(), closing_sig_A
+            channel_identifier1,
+            B,
+            A,
+            *balance_proof_B._asdict().values(),
+            closing_sig_A,
         ),
         {"from": A},
     )
@@ -672,7 +682,11 @@ def test_close_replay_reopened_channel(
     assert channel_identifier1 != channel_identifier2
     with pytest.raises(TransactionFailed):
         token_network.functions.closeChannel(
-            channel_identifier2, B, A, *balance_proof_B._asdict().values(), closing_sig_A
+            channel_identifier2,
+            B,
+            A,
+            *balance_proof_B._asdict().values(),
+            closing_sig_A,
         ).call({"from": A})
 
     # Balance proof with correct channel_identifier must work
@@ -692,7 +706,11 @@ def test_close_replay_reopened_channel(
     )
     call_and_transact(
         token_network.functions.closeChannel(
-            channel_identifier2, B, A, *balance_proof_B2._asdict().values(), closing_sig_A2
+            channel_identifier2,
+            B,
+            A,
+            *balance_proof_B2._asdict().values(),
+            closing_sig_A2,
         ),
         {"from": A},
     )

--- a/raiden_contracts/tests/test_channel_deposit.py
+++ b/raiden_contracts/tests/test_channel_deposit.py
@@ -83,7 +83,8 @@ def test_deposit_channel_call(
         token_network.functions.setTotalDeposit(channel_identifier, A, 0, B).call({"from": A})
 
     call_and_transact(
-        token_network.functions.setTotalDeposit(channel_identifier, A, deposit_A, B), {"from": A}
+        token_network.functions.setTotalDeposit(channel_identifier, A, deposit_A, B),
+        {"from": A},
     )
     assert (
         deposit_A
@@ -177,7 +178,8 @@ def test_deposit_wrong_channel(
         token_network.functions.setTotalDeposit(channel_identifier, A, 10, C).call({"from": A})
 
     call_and_transact(
-        token_network.functions.setTotalDeposit(channel_identifier, A, 10, B), {"from": A}
+        token_network.functions.setTotalDeposit(channel_identifier, A, 10, B),
+        {"from": A},
     )
     assert (
         10 == token_network.functions.getChannelParticipantInfo(channel_identifier, A, B).call()[0]
@@ -341,12 +343,16 @@ def test_deposit_channel_event(
     )
 
     ev_handler.add(
-        txn_hash, ChannelEvent.DEPOSIT, check_new_deposit(channel_identifier, A, deposit_A)
+        txn_hash,
+        ChannelEvent.DEPOSIT,
+        check_new_deposit(channel_identifier, A, deposit_A),
     )
 
     txn_hash = channel_deposit(channel_identifier, B, deposit_B, A)
     ev_handler.add(
-        txn_hash, ChannelEvent.DEPOSIT, check_new_deposit(channel_identifier, B, deposit_B)
+        txn_hash,
+        ChannelEvent.DEPOSIT,
+        check_new_deposit(channel_identifier, B, deposit_B),
     )
 
     ev_handler.check()

--- a/raiden_contracts/tests/test_channel_open.py
+++ b/raiden_contracts/tests/test_channel_open.py
@@ -298,7 +298,15 @@ def test_reopen_channel(
     # Settle channel
     call_and_transact(
         token_network.functions.settleChannel(
-            channel_identifier1, A, 0, 0, LOCKSROOT_OF_NO_LOCKS, B, 0, 0, LOCKSROOT_OF_NO_LOCKS
+            channel_identifier1,
+            A,
+            0,
+            0,
+            LOCKSROOT_OF_NO_LOCKS,
+            B,
+            0,
+            0,
+            LOCKSROOT_OF_NO_LOCKS,
         ),
         {"from": A},
     )

--- a/raiden_contracts/tests/test_channel_unlock.py
+++ b/raiden_contracts/tests/test_channel_unlock.py
@@ -207,9 +207,10 @@ def test_locks_order(
     wrong_order = pending_transfers_tree.transfers
     wrong_order[1], wrong_order[0] = wrong_order[0], wrong_order[1]
     wrong_order_packed = get_packed_transfers(wrong_order, types)
-    (locksroot, unlocked_amount) = network_utils.functions.getHashAndUnlockedAmountPublic(
-        wrong_order_packed
-    ).call()
+    (
+        locksroot,
+        unlocked_amount,
+    ) = network_utils.functions.getHashAndUnlockedAmountPublic(wrong_order_packed).call()
     # If we change the order, we change the computed hash.
     assert locksroot != pending_transfers_tree.hash_of_packed_transfers
     assert unlocked_amount == 9
@@ -219,9 +220,10 @@ def test_locks_order(
     wrong_order = pending_transfers_tree.transfers
     wrong_order[2], wrong_order[0] = wrong_order[0], wrong_order[2]
     wrong_order_packed = get_packed_transfers(wrong_order, types)
-    (locksroot, unlocked_amount) = network_utils.functions.getHashAndUnlockedAmountPublic(
-        wrong_order_packed
-    ).call()
+    (
+        locksroot,
+        unlocked_amount,
+    ) = network_utils.functions.getHashAndUnlockedAmountPublic(wrong_order_packed).call()
     assert locksroot != pending_transfers_tree.hash_of_packed_transfers
     assert unlocked_amount == 9
     with pytest.raises(TransactionFailed):
@@ -230,15 +232,16 @@ def test_locks_order(
     wrong_order = pending_transfers_tree.transfers
     wrong_order[0], wrong_order[-1] = wrong_order[-1], wrong_order[0]
     wrong_order_packed = get_packed_transfers(wrong_order, types)
-    (locksroot, unlocked_amount) = network_utils.functions.getHashAndUnlockedAmountPublic(
-        wrong_order_packed
-    ).call()
+    (
+        locksroot,
+        unlocked_amount,
+    ) = network_utils.functions.getHashAndUnlockedAmountPublic(wrong_order_packed).call()
     assert locksroot != pending_transfers_tree.hash_of_packed_transfers
     assert unlocked_amount == 9
     with pytest.raises(TransactionFailed):
         token_network.functions.unlock(channel_identifier, B, A, wrong_order_packed).call()
 
-    (locksroot, unlocked_amount) = network_utils.functions.getHashAndUnlockedAmountPublic(
+    (locksroot, unlocked_amount,) = network_utils.functions.getHashAndUnlockedAmountPublic(
         pending_transfers_tree.packed_transfers
     ).call()
     assert locksroot == pending_transfers_tree.hash_of_packed_transfers

--- a/raiden_contracts/tests/test_channel_update_transfer.py
+++ b/raiden_contracts/tests/test_channel_update_transfer.py
@@ -84,7 +84,11 @@ def test_update_call(
     # Failure with the zero signature
     with pytest.raises(TransactionFailed):
         token_network.functions.updateNonClosingBalanceProof(
-            channel_identifier, A, B, *balance_proof_A._asdict().values(), EMPTY_SIGNATURE
+            channel_identifier,
+            A,
+            B,
+            *balance_proof_A._asdict().values(),
+            EMPTY_SIGNATURE,
         ).call({"from": C})
 
     # Failure with the empty balance hash
@@ -300,7 +304,13 @@ def test_update_wrong_nonce_fail(
         ).call({"from": A})
 
     update_state_tests(
-        channel_identifier, A, balance_proof_A, B, balance_proof_B, settle_timeout, txn_hash1
+        channel_identifier,
+        A,
+        balance_proof_A,
+        B,
+        balance_proof_B,
+        settle_timeout,
+        txn_hash1,
     )
 
 
@@ -454,7 +464,13 @@ def test_update_channel_state(
     assert custom_token.functions.balanceOf(token_network.address).call() == pre_balance_contract
 
     update_state_tests(
-        channel_identifier, A, balance_proof_A, B, balance_proof_B, settle_timeout, txn_hash1
+        channel_identifier,
+        A,
+        balance_proof_A,
+        B,
+        balance_proof_B,
+        settle_timeout,
+        txn_hash1,
     )
 
 
@@ -599,7 +615,11 @@ def test_update_not_allowed_for_the_closing_address(
     # A closes with the first balance proof
     call_and_transact(
         token_network.functions.closeChannel(
-            channel_identifier, B, A, *balance_proof_B_0._asdict().values(), closing_sig_A_0
+            channel_identifier,
+            B,
+            A,
+            *balance_proof_B_0._asdict().values(),
+            closing_sig_A_0,
         ),
         {"from": A},
     )

--- a/raiden_contracts/tests/test_channel_withdraw.py
+++ b/raiden_contracts/tests/test_channel_withdraw.py
@@ -214,7 +214,15 @@ def test_withdraw_wrong_state(
     mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
     call_and_transact(
         token_network.functions.settleChannel(
-            channel_identifier, A, 0, 0, LOCKSROOT_OF_NO_LOCKS, B, 0, 0, LOCKSROOT_OF_NO_LOCKS
+            channel_identifier,
+            A,
+            0,
+            0,
+            LOCKSROOT_OF_NO_LOCKS,
+            B,
+            0,
+            0,
+            LOCKSROOT_OF_NO_LOCKS,
         ),
         {"from": A},
     )
@@ -261,21 +269,38 @@ def test_withdraw_wrong_signers(
     withdraw_A = 5
     channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
 
-    (signature_A_for_A, signature_B_for_A, signature_C_for_A) = create_withdraw_signatures(
-        [A, B, C], channel_identifier, A, withdraw_A, UINT256_MAX
-    )
+    (
+        signature_A_for_A,
+        signature_B_for_A,
+        signature_C_for_A,
+    ) = create_withdraw_signatures([A, B, C], channel_identifier, A, withdraw_A, UINT256_MAX)
     with pytest.raises(TransactionFailed):
         token_network.functions.setTotalWithdraw(
-            channel_identifier, A, withdraw_A, UINT256_MAX, signature_C_for_A, signature_B_for_A
+            channel_identifier,
+            A,
+            withdraw_A,
+            UINT256_MAX,
+            signature_C_for_A,
+            signature_B_for_A,
         ).call({"from": C})
     with pytest.raises(TransactionFailed):
         token_network.functions.setTotalWithdraw(
-            channel_identifier, A, withdraw_A, UINT256_MAX, signature_A_for_A, signature_C_for_A
+            channel_identifier,
+            A,
+            withdraw_A,
+            UINT256_MAX,
+            signature_A_for_A,
+            signature_C_for_A,
         ).call({"from": C})
 
     call_and_transact(
         token_network.functions.setTotalWithdraw(
-            channel_identifier, A, withdraw_A, UINT256_MAX, signature_A_for_A, signature_B_for_A
+            channel_identifier,
+            A,
+            withdraw_A,
+            UINT256_MAX,
+            signature_A_for_A,
+            signature_B_for_A,
         ),
         {"from": C},
     )
@@ -365,7 +390,12 @@ def test_withdraw_wrong_signature_content(
     with pytest.raises(TransactionFailed):
         call_and_transact(
             token_network.functions.setTotalWithdraw(
-                channel_identifier, A, withdraw_A, 0, signature_A_for_A, signature_B_for_A
+                channel_identifier,
+                A,
+                withdraw_A,
+                0,
+                signature_A_for_A,
+                signature_B_for_A,
             ),
             {"from": A},
         )
@@ -384,7 +414,12 @@ def test_withdraw_wrong_signature_content(
 
     call_and_transact(
         token_network.functions.setTotalWithdraw(
-            channel_identifier, A, withdraw_A, UINT256_MAX, signature_A_for_A, signature_B_for_A
+            channel_identifier,
+            A,
+            withdraw_A,
+            UINT256_MAX,
+            signature_A_for_A,
+            signature_B_for_A,
         ),
         {"from": A},
     )
@@ -410,9 +445,15 @@ def test_withdraw_channel_state(
     balance_B = custom_token.functions.balanceOf(B).call()
     balance_contract = custom_token.functions.balanceOf(token_network.address).call()
 
-    (_, withdrawn_amount, _, _, _, _, _) = token_network.functions.getChannelParticipantInfo(
-        channel_identifier, A, B
-    ).call()
+    (
+        _,
+        withdrawn_amount,
+        _,
+        _,
+        _,
+        _,
+        _,
+    ) = token_network.functions.getChannelParticipantInfo(channel_identifier, A, B).call()
     assert withdrawn_amount == 0
 
     withdraw_channel(channel_identifier, A, withdraw_A, UINT256_MAX, B, C)
@@ -493,7 +534,12 @@ def test_withdraw_replay_reopened_channel(
     )
     call_and_transact(
         token_network.functions.setTotalWithdraw(
-            channel_identifier1, A, withdraw_A, UINT256_MAX, signature_A_for_A, signature_B_for_A
+            channel_identifier1,
+            A,
+            withdraw_A,
+            UINT256_MAX,
+            signature_A_for_A,
+            signature_B_for_A,
         ),
         {"from": A},
     )
@@ -515,7 +561,15 @@ def test_withdraw_replay_reopened_channel(
     mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
     call_and_transact(
         token_network.functions.settleChannel(
-            channel_identifier1, A, 0, 0, LOCKSROOT_OF_NO_LOCKS, B, 0, 0, LOCKSROOT_OF_NO_LOCKS
+            channel_identifier1,
+            A,
+            0,
+            0,
+            LOCKSROOT_OF_NO_LOCKS,
+            B,
+            0,
+            0,
+            LOCKSROOT_OF_NO_LOCKS,
         ),
         {"from": A},
     )
@@ -527,7 +581,12 @@ def test_withdraw_replay_reopened_channel(
     assert channel_identifier1 != channel_identifier2
     with pytest.raises(TransactionFailed):
         token_network.functions.setTotalWithdraw(
-            channel_identifier2, A, withdraw_A, UINT256_MAX, signature_A_for_A, signature_B_for_A
+            channel_identifier2,
+            A,
+            withdraw_A,
+            UINT256_MAX,
+            signature_A_for_A,
+            signature_B_for_A,
         ).call({"from": A})
 
     # Signed message with correct channel_identifier must work
@@ -536,7 +595,12 @@ def test_withdraw_replay_reopened_channel(
     )
     call_and_transact(
         token_network.functions.setTotalWithdraw(
-            channel_identifier2, A, withdraw_A, UINT256_MAX, signature_A_for_A2, signature_B_for_A2
+            channel_identifier2,
+            A,
+            withdraw_A,
+            UINT256_MAX,
+            signature_A_for_A2,
+            signature_B_for_A2,
         ),
         {"from": A},
     )

--- a/raiden_contracts/tests/test_contract_limits.py
+++ b/raiden_contracts/tests/test_contract_limits.py
@@ -39,22 +39,30 @@ def test_register_three_but_not_four(
     token3 = custom_token_factory()
     call_and_transact(
         token_network_registry.functions.createERC20TokenNetwork(
-            token0.address, channel_participant_deposit_limit, token_network_deposit_limit
+            token0.address,
+            channel_participant_deposit_limit,
+            token_network_deposit_limit,
         )
     )
     call_and_transact(
         token_network_registry.functions.createERC20TokenNetwork(
-            token1.address, channel_participant_deposit_limit, token_network_deposit_limit
+            token1.address,
+            channel_participant_deposit_limit,
+            token_network_deposit_limit,
         )
     )
     call_and_transact(
         token_network_registry.functions.createERC20TokenNetwork(
-            token2.address, channel_participant_deposit_limit, token_network_deposit_limit
+            token2.address,
+            channel_participant_deposit_limit,
+            token_network_deposit_limit,
         )
     )
     with pytest.raises(TransactionFailed, match="registry full"):
         token_network_registry.functions.createERC20TokenNetwork(
-            token3.address, channel_participant_deposit_limit, token_network_deposit_limit
+            token3.address,
+            channel_participant_deposit_limit,
+            token_network_deposit_limit,
         ).call()
 
 
@@ -95,13 +103,15 @@ def test_participant_deposit_limit(
 
     # Deposit some tokens, under the limit
     call_and_transact(
-        token_network.functions.setTotalDeposit(channel_identifier, A, deposit_A, B), {"from": A}
+        token_network.functions.setTotalDeposit(channel_identifier, A, deposit_A, B),
+        {"from": A},
     )
     info_A = token_network.functions.getChannelParticipantInfo(channel_identifier, A, B).call()
     assert info_A[ParticipantInfoIndex.DEPOSIT] == deposit_A
 
     info_B = call_and_transact(
-        token_network.functions.setTotalDeposit(channel_identifier, B, deposit_B, A), {"from": B}
+        token_network.functions.setTotalDeposit(channel_identifier, B, deposit_B, A),
+        {"from": B},
     )
     info_B = token_network.functions.getChannelParticipantInfo(channel_identifier, B, A).call()
     assert info_B[ParticipantInfoIndex.DEPOSIT] == deposit_B

--- a/raiden_contracts/tests/test_deploy_data.py
+++ b/raiden_contracts/tests/test_deploy_data.py
@@ -74,7 +74,12 @@ def test_deploy_data_has_fields_raiden(version: Optional[str], chain_id: ChainID
         reasonable_deployment_of_a_contract(deployed)
 
 
-SERVICE_CONTRACT_NAMES = ("ServiceRegistry", "MonitoringService", "OneToN", "UserDeposit")
+SERVICE_CONTRACT_NAMES = (
+    "ServiceRegistry",
+    "MonitoringService",
+    "OneToN",
+    "UserDeposit",
+)
 
 
 @pytest.mark.parametrize("version", [None])

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -303,7 +303,11 @@ def test_deploy_script_raiden(
 
     # check that it fails if sender has no eth
     deployer = ContractDeployer(
-        web3=web3, private_key=get_random_privkey(), gas_limit=GAS_LIMIT, gas_price=1, wait=10
+        web3=web3,
+        private_key=get_random_privkey(),
+        gas_limit=GAS_LIMIT,
+        gas_price=1,
+        wait=10,
     )
     with pytest.raises(ValidationError):
         deployer.deploy_raiden_contracts(
@@ -381,7 +385,11 @@ def test_deploy_script_token(web3: Web3) -> None:
     token_type = "CustomToken"
     gas_limit = 5860000
     deployer = ContractDeployer(
-        web3=web3, private_key=FAUCET_PRIVATE_KEY, gas_limit=gas_limit, gas_price=1, wait=10
+        web3=web3,
+        private_key=FAUCET_PRIVATE_KEY,
+        gas_limit=gas_limit,
+        gas_price=1,
+        wait=10,
     )
 
     deployed_token = deployer.deploy_token_contract(
@@ -397,7 +405,11 @@ def test_deploy_script_token(web3: Web3) -> None:
 
     # check that it fails if sender has no eth
     deployer = ContractDeployer(
-        web3=web3, private_key=get_random_privkey(), gas_limit=gas_limit, gas_price=1, wait=10
+        web3=web3,
+        private_key=get_random_privkey(),
+        gas_limit=gas_limit,
+        gas_price=1,
+        wait=10,
     )
     with pytest.raises(ValidationError):
         deployer.deploy_token_contract(
@@ -426,7 +438,11 @@ def test_deploy_script_register(
     # normal deployment
     gas_limit = 5860000
     deployer = ContractDeployer(
-        web3=web3, private_key=FAUCET_PRIVATE_KEY, gas_limit=gas_limit, gas_price=1, wait=10
+        web3=web3,
+        private_key=FAUCET_PRIVATE_KEY,
+        gas_limit=gas_limit,
+        gas_price=1,
+        wait=10,
     )
 
     token_registry_abi = deployer.contract_manager.get_contract_abi(
@@ -463,7 +479,11 @@ def test_deploy_script_service(
     """
     gas_limit = 5860000
     deployer = ContractDeployer(
-        web3=web3, private_key=FAUCET_PRIVATE_KEY, gas_limit=gas_limit, gas_price=1, wait=10
+        web3=web3,
+        private_key=FAUCET_PRIVATE_KEY,
+        gas_limit=gas_limit,
+        gas_price=1,
+        wait=10,
     )
 
     token_supply = 10000000
@@ -705,7 +725,10 @@ def test_validate_address_happy_path() -> None:
 @pytest.fixture
 def fs_reload_deployer() -> Generator[FakeFilesystem, None, None]:
     patcher = Patcher(
-        modules_to_reload=[raiden_contracts.contract_manager, raiden_contracts.deploy.__main__]
+        modules_to_reload=[
+            raiden_contracts.contract_manager,
+            raiden_contracts.deploy.__main__,
+        ]
     )
     patcher.setUp()
     yield patcher.fs
@@ -839,7 +862,10 @@ def test_deploy_token_no_balance(privkey_file: IO) -> None:
 def test_deploy_token_with_balance(privkey_file: IO) -> None:
     """ Call deploy token command with a private key with some balance """
     with patch.object(
-        ContractDeployer, "deploy_token_contract", spec=ContractDeployer, return_value={}
+        ContractDeployer,
+        "deploy_token_contract",
+        spec=ContractDeployer,
+        return_value={},
     ) as mock_deployer:
         with patch.object(Eth, "get_balance", return_value=100):
             runner = CliRunner()

--- a/raiden_contracts/tests/test_deprecation_switch.py
+++ b/raiden_contracts/tests/test_deprecation_switch.py
@@ -62,7 +62,9 @@ def test_deprecation_executor(
     # It can be deployed by anyone
     tx_hash = call_and_transact(
         token_network_registry.functions.createERC20TokenNetwork(
-            custom_token.address, channel_participant_deposit_limit, token_network_deposit_limit
+            custom_token.address,
+            channel_participant_deposit_limit,
+            token_network_deposit_limit,
         ),
         {"from": B},
     )
@@ -71,11 +73,15 @@ def test_deprecation_executor(
     # No other TokenNetworks can be deployed now
     with pytest.raises(TransactionFailed):
         token_network_registry.functions.createERC20TokenNetwork(
-            custom_token.address, channel_participant_deposit_limit, token_network_deposit_limit
+            custom_token.address,
+            channel_participant_deposit_limit,
+            token_network_deposit_limit,
         ).call({"from": B})
     with pytest.raises(TransactionFailed):
         token_network_registry.functions.createERC20TokenNetwork(
-            custom_token.address, channel_participant_deposit_limit, token_network_deposit_limit
+            custom_token.address,
+            channel_participant_deposit_limit,
+            token_network_deposit_limit,
         ).call({"from": deprecation_executor})
 
     tx_receipt = web3.eth.getTransactionReceipt(tx_hash)
@@ -93,7 +99,10 @@ def test_deprecation_executor(
 
 
 def test_set_deprecation_switch(
-    get_accounts: Callable, token_network: Contract, web3: Web3, contracts_manager: ContractManager
+    get_accounts: Callable,
+    token_network: Contract,
+    web3: Web3,
+    contracts_manager: ContractManager,
 ) -> None:
     """ The deprecation executor deprecates a TokenNetwork contract """
     (A) = get_accounts(1)[0]

--- a/raiden_contracts/tests/test_etherscan_verify.py
+++ b/raiden_contracts/tests/test_etherscan_verify.py
@@ -129,7 +129,14 @@ def test_etherscan_verify_already_verified() -> None:
         runner = CliRunner()
         runner.invoke(
             etherscan_verify,
-            ["--chain-id", str(chain_id), "--apikey", "API", "--contract-name", "SecretRegistry"],
+            [
+                "--chain-id",
+                str(chain_id),
+                "--apikey",
+                "API",
+                "--contract-name",
+                "SecretRegistry",
+            ],
             catch_exceptions=False,
         )
 
@@ -151,7 +158,14 @@ def test_etherscan_verify_unknown_error() -> None:
         runner = CliRunner()
         result = runner.invoke(
             etherscan_verify,
-            ["--chain-id", str(chain_id), "--apikey", "API", "--contract-name", "SecretRegistry"],
+            [
+                "--chain-id",
+                str(chain_id),
+                "--apikey",
+                "API",
+                "--contract-name",
+                "SecretRegistry",
+            ],
         )
         assert result.exit_code != 0
 
@@ -183,7 +197,14 @@ def test_etherscan_verify_unable_to_verify() -> None:
         runner = CliRunner()
         result = runner.invoke(
             etherscan_verify,
-            ["--chain-id", str(chain_id), "--apikey", "API", "--contract-name", "SecretRegistry"],
+            [
+                "--chain-id",
+                str(chain_id),
+                "--apikey",
+                "API",
+                "--contract-name",
+                "SecretRegistry",
+            ],
         )
         assert result.exit_code != 0
 
@@ -206,7 +227,14 @@ def test_etherscan_verify_success() -> None:
         runner = CliRunner()
         result = runner.invoke(
             etherscan_verify,
-            ["--chain-id", str(chain_id), "--apikey", "API", "--contract-name", "SecretRegistry"],
+            [
+                "--chain-id",
+                str(chain_id),
+                "--apikey",
+                "API",
+                "--contract-name",
+                "SecretRegistry",
+            ],
         )
         assert result.exit_code == 0
 
@@ -232,7 +260,14 @@ def test_etherscan_verify_success_after_a_loop() -> None:
         runner = CliRunner()
         result = runner.invoke(
             etherscan_verify,
-            ["--chain-id", str(chain_id), "--apikey", "API", "--contract-name", "SecretRegistry"],
+            [
+                "--chain-id",
+                str(chain_id),
+                "--apikey",
+                "API",
+                "--contract-name",
+                "SecretRegistry",
+            ],
         )
         assert result.exit_code == 0
 

--- a/raiden_contracts/tests/test_monitoring_service.py
+++ b/raiden_contracts/tests/test_monitoring_service.py
@@ -36,7 +36,8 @@ def ms_address(
     # register MS in the ServiceRegistry contract
     call_and_transact(custom_token.functions.mint(2 * SERVICE_DEPOSIT), {"from": ms})
     call_and_transact(
-        custom_token.functions.approve(service_registry.address, SERVICE_DEPOSIT), {"from": ms}
+        custom_token.functions.approve(service_registry.address, SERVICE_DEPOSIT),
+        {"from": ms},
     )
     call_and_transact(service_registry.functions.deposit(SERVICE_DEPOSIT), {"from": ms})
 
@@ -94,7 +95,11 @@ def setup_monitor_data(
         # close channel
         call_and_transact(
             token_network.functions.closeChannel(
-                channel_identifier, B, A, *balance_proof_A._asdict().values(), closing_signature_A
+                channel_identifier,
+                B,
+                A,
+                *balance_proof_A._asdict().values(),
+                closing_signature_A,
             ),
             {"from": A},
         )
@@ -204,7 +209,11 @@ def test_claimReward_with_settle_call(
     ms_ev_handler.assert_event(
         txn_hash,
         MonitoringServiceEvent.REWARD_CLAIMED,
-        dict(ms_address=ms_address, amount=REWARD_AMOUNT, reward_identifier=reward_identifier),
+        dict(
+            ms_address=ms_address,
+            amount=REWARD_AMOUNT,
+            reward_identifier=reward_identifier,
+        ),
     )
 
     # Check that MS balance has increased by claiming the reward

--- a/raiden_contracts/tests/test_one_to_n.py
+++ b/raiden_contracts/tests/test_one_to_n.py
@@ -130,7 +130,8 @@ def test_bulk_claim_errors(
 
     # One value too many to `amounts`
     with pytest.raises(
-        TransactionFailed, match="Same number of elements required for all input parameters"
+        TransactionFailed,
+        match="Same number of elements required for all input parameters",
     ):
         call_and_transact(
             one_to_n_contract.functions.bulkClaim(

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -139,7 +139,9 @@ def print_gas_token_network_create(
     registry = get_token_network_registry(**token_network_registry_constructor_args)
     txn_hash = call_and_transact(
         registry.functions.createERC20TokenNetwork(
-            custom_token.address, channel_participant_deposit_limit, token_network_deposit_limit
+            custom_token.address,
+            channel_participant_deposit_limit,
+            token_network_deposit_limit,
         ),
         {"from": DEPLOYER_ADDRESS},
     )
@@ -252,7 +254,15 @@ def print_gas_channel_cycle(
     mine_blocks(web3, settle_timeout)
     txn_hash = call_and_transact(
         token_network.functions.settleChannel(
-            channel_identifier, B, 5, locked_amount2, locksroot2, A, 10, locked_amount1, locksroot1
+            channel_identifier,
+            B,
+            5,
+            locked_amount2,
+            locksroot2,
+            A,
+            10,
+            locked_amount1,
+            locksroot1,
         )
     )
     print_gas(txn_hash, CONTRACT_TOKEN_NETWORK + ".settleChannel")
@@ -308,7 +318,8 @@ def print_gas_monitoring_service(
     # register MS in the ServiceRegistry contract
     call_and_transact(custom_token.functions.mint(SERVICE_DEPOSIT * 2), {"from": MS})
     call_and_transact(
-        custom_token.functions.approve(service_registry.address, SERVICE_DEPOSIT), {"from": MS}
+        custom_token.functions.approve(service_registry.address, SERVICE_DEPOSIT),
+        {"from": MS},
     )
     call_and_transact(service_registry.functions.deposit(SERVICE_DEPOSIT), {"from": MS})
 

--- a/raiden_contracts/tests/test_secret_registry.py
+++ b/raiden_contracts/tests/test_secret_registry.py
@@ -135,6 +135,9 @@ def test_register_secret_batch_events(
     txn_hash = call_and_transact(secret_registry_contract.functions.registerSecretBatch(secrets))
 
     ev_handler.add(
-        txn_hash, EVENT_SECRET_REVEALED, check_secrets_revealed(secret_hashes, secrets), 3
+        txn_hash,
+        EVENT_SECRET_REVEALED,
+        check_secrets_revealed(secret_hashes, secrets),
+        3,
     )
     ev_handler.check()

--- a/raiden_contracts/tests/test_service_registry.py
+++ b/raiden_contracts/tests/test_service_registry.py
@@ -51,7 +51,10 @@ def test_deposit_contract_without_service_registry_code(
     (A,) = get_accounts(1)
     call_and_transact(custom_token.functions.mint(100), {"from": A})
     depo = get_deposit_contract(
-        _token=custom_token.address, _release_at=UINT256_MAX, _withdrawer=A, _service_registry=A
+        _token=custom_token.address,
+        _release_at=UINT256_MAX,
+        _withdrawer=A,
+        _service_registry=A,
     )
     call_and_transact(custom_token.functions.transfer(depo.address, 100), {"from": A})
     assert custom_token.functions.balanceOf(A).call() == 0
@@ -97,7 +100,8 @@ def test_deposit(
     (A,) = get_accounts(1)
     call_and_transact(custom_token.functions.mint(SERVICE_DEPOSIT), {"from": A})
     call_and_transact(
-        custom_token.functions.approve(service_registry.address, SERVICE_DEPOSIT), {"from": A}
+        custom_token.functions.approve(service_registry.address, SERVICE_DEPOSIT),
+        {"from": A},
     )
 
     # happy path
@@ -119,7 +123,8 @@ def test_deposit(
     # More minting and approving before extending the registration
     call_and_transact(custom_token.functions.mint(SERVICE_DEPOSIT), {"from": A})
     call_and_transact(
-        custom_token.functions.approve(service_registry.address, SERVICE_DEPOSIT), {"from": A}
+        custom_token.functions.approve(service_registry.address, SERVICE_DEPOSIT),
+        {"from": A},
     )
 
     # Extending the registration
@@ -141,7 +146,8 @@ def test_setURL(
 
     call_and_transact(custom_token.functions.mint(SERVICE_DEPOSIT), {"from": A})
     call_and_transact(
-        custom_token.functions.approve(service_registry.address, SERVICE_DEPOSIT), {"from": A}
+        custom_token.functions.approve(service_registry.address, SERVICE_DEPOSIT),
+        {"from": A},
     )
     tx = call_and_transact(service_registry.functions.deposit(SERVICE_DEPOSIT), {"from": A})
     tx_receipt = web3.eth.getTransactionReceipt(tx)
@@ -189,7 +195,8 @@ def test_changing_duration(
     (A,) = get_accounts(1)
     call_and_transact(custom_token.functions.mint(2 * SERVICE_DEPOSIT), {"from": A})
     call_and_transact(
-        custom_token.functions.approve(service_registry.address, 2 * SERVICE_DEPOSIT), {"from": A}
+        custom_token.functions.approve(service_registry.address, 2 * SERVICE_DEPOSIT),
+        {"from": A},
     )
     call_and_transact(service_registry.functions.deposit(SERVICE_DEPOSIT), {"from": A})
     first_expiration = service_registry.functions.service_valid_till(A).call()
@@ -218,7 +225,8 @@ def test_changing_duration_to_huge_value(
     (A,) = get_accounts(1)
     call_and_transact(custom_token.functions.mint(2 * SERVICE_DEPOSIT), {"from": A})
     call_and_transact(
-        custom_token.functions.approve(service_registry.address, 2 * SERVICE_DEPOSIT), {"from": A}
+        custom_token.functions.approve(service_registry.address, 2 * SERVICE_DEPOSIT),
+        {"from": A},
     )
     with pytest.raises(TransactionFailed, match="overflow during extending the registration"):
         call_and_transact(service_registry.functions.deposit(SERVICE_DEPOSIT), {"from": A})
@@ -525,7 +533,8 @@ def test_deprecation_switch(
     minted_amount = service_registry.functions.currentPrice().call()
     call_and_transact(custom_token.functions.mint(minted_amount), {"from": A})
     call_and_transact(
-        custom_token.functions.approve(service_registry.address, minted_amount), {"from": A}
+        custom_token.functions.approve(service_registry.address, minted_amount),
+        {"from": A},
     )
     with pytest.raises(TransactionFailed, match="this contract was deprecated"):
         call_and_transact(service_registry.functions.deposit(minted_amount), {"from": A})

--- a/raiden_contracts/tests/test_token_network_registry.py
+++ b/raiden_contracts/tests/test_token_network_registry.py
@@ -312,7 +312,9 @@ def test_create_erc20_token_network_call(
     # failures with addresses where no Token contract can be found
     with pytest.raises(TransactionFailed):
         token_network_registry_contract.functions.createERC20TokenNetwork(
-            EMPTY_ADDRESS, channel_participant_deposit_limit, token_network_deposit_limit
+            EMPTY_ADDRESS,
+            channel_participant_deposit_limit,
+            token_network_deposit_limit,
         ).call()
     with pytest.raises(TransactionFailed):
         token_network_registry_contract.functions.createERC20TokenNetwork(
@@ -320,7 +322,9 @@ def test_create_erc20_token_network_call(
         ).call()
     with pytest.raises(TransactionFailed):
         token_network_registry_contract.functions.createERC20TokenNetwork(
-            fake_token_contract, channel_participant_deposit_limit, token_network_deposit_limit
+            fake_token_contract,
+            channel_participant_deposit_limit,
+            token_network_deposit_limit,
         ).call()
 
     # failures with invalid deposit limits
@@ -338,13 +342,17 @@ def test_create_erc20_token_network_call(
         # fails because token_network_deposit_limit is smaller than
         # channel_participant_deposit_limit.
         token_network_registry_contract.functions.createERC20TokenNetwork(
-            custom_token.address, token_network_deposit_limit, channel_participant_deposit_limit
+            custom_token.address,
+            token_network_deposit_limit,
+            channel_participant_deposit_limit,
         ).call({"from": DEPLOYER_ADDRESS})
 
     # see a success to make sure above tests were meaningful
     call_and_transact(
         token_network_registry_contract.functions.createERC20TokenNetwork(
-            custom_token.address, channel_participant_deposit_limit, token_network_deposit_limit
+            custom_token.address,
+            channel_participant_deposit_limit,
+            token_network_deposit_limit,
         ),
         {"from": DEPLOYER_ADDRESS},
     )
@@ -406,14 +414,18 @@ def test_create_erc20_token_network_twice_fails(
 
     call_and_transact(
         token_network_registry_contract.functions.createERC20TokenNetwork(
-            custom_token.address, channel_participant_deposit_limit, token_network_deposit_limit
+            custom_token.address,
+            channel_participant_deposit_limit,
+            token_network_deposit_limit,
         ),
         {"from": DEPLOYER_ADDRESS},
     )
 
     with pytest.raises(TransactionFailed):
         token_network_registry_contract.functions.createERC20TokenNetwork(
-            custom_token.address, channel_participant_deposit_limit, token_network_deposit_limit
+            custom_token.address,
+            channel_participant_deposit_limit,
+            token_network_deposit_limit,
         ).call({"from": DEPLOYER_ADDRESS})
 
 

--- a/raiden_contracts/tests/test_user_deposit_contract.py
+++ b/raiden_contracts/tests/test_user_deposit_contract.py
@@ -53,7 +53,8 @@ def test_deposit(
     assert limit > 0
     call_and_transact(custom_token.functions.mint(limit + 1), {"from": A})
     call_and_transact(
-        custom_token.functions.approve(user_deposit_contract.address, limit + 1), {"from": A}
+        custom_token.functions.approve(user_deposit_contract.address, limit + 1),
+        {"from": A},
     )
     with pytest.raises(TransactionFailed, match="too much deposit"):
         user_deposit_contract.functions.deposit(A, limit + 1).call({"from": A})
@@ -154,7 +155,9 @@ def test_withdraw(
     # plan withdraw of 20 tokens
     tx_hash = call_and_transact(user_deposit_contract.functions.planWithdraw(20), {"from": A})
     ev_handler.assert_event(
-        tx_hash, UserDepositEvent.WITHDRAW_PLANNED, dict(withdrawer=A, plannedBalance=10)
+        tx_hash,
+        UserDepositEvent.WITHDRAW_PLANNED,
+        dict(withdrawer=A, plannedBalance=10),
     )
     assert user_deposit_contract.functions.balances(A).call() == 30
     assert user_deposit_contract.functions.effectiveBalance(A).call() == 10

--- a/raiden_contracts/tests/unit/test_merge_dict.py
+++ b/raiden_contracts/tests/unit/test_merge_dict.py
@@ -7,7 +7,10 @@ from raiden_contracts.contract_manager import merge_deployment_data
 
 def test_merge_deployment_data_identical() -> None:
     """ merge_deployment_data() throws ValueError when identical two dictionaries are given """
-    deployment = {"contract_version": "0.12.0", "contracts": {"TokenNetworkRegistry": "something"}}
+    deployment = {
+        "contract_version": "0.12.0",
+        "contracts": {"TokenNetworkRegistry": "something"},
+    }
     with pytest.raises(ValueError):
         merge_deployment_data(deployment, deployment)  # type: ignore
 

--- a/raiden_contracts/tests/unit/test_settle_timeout_invariant.py
+++ b/raiden_contracts/tests/unit/test_settle_timeout_invariant.py
@@ -58,7 +58,15 @@ def test_settle_timeout_inrange(
     mine_blocks(web3, TEST_SETTLE_TIMEOUT_MIN + 1)
     call_and_transact(
         token_network.functions.settleChannel(
-            channel_identifier, A, 0, 0, LOCKSROOT_OF_NO_LOCKS, B, 0, 0, LOCKSROOT_OF_NO_LOCKS
+            channel_identifier,
+            A,
+            0,
+            0,
+            LOCKSROOT_OF_NO_LOCKS,
+            B,
+            0,
+            0,
+            LOCKSROOT_OF_NO_LOCKS,
         ),
         {"from": A},
     )

--- a/raiden_contracts/tests/unit/test_unit_signatures.py
+++ b/raiden_contracts/tests/unit/test_unit_signatures.py
@@ -23,7 +23,12 @@ def test_recover_address_from_withdraw_message(
     expiration_block = 492889
     channel_identifier = create_channel_and_deposit(A, B, deposit_A, deposit_B)
     (signature_A, signature_B) = create_withdraw_signatures(
-        [A, B], channel_identifier, A, withdraw_A, expiration_block, token_network.address
+        [A, B],
+        channel_identifier,
+        A,
+        withdraw_A,
+        expiration_block,
+        token_network.address,
     )
 
     recovered_address_A = token_network.functions.recoverAddressFromWithdrawMessagePublic(
@@ -66,7 +71,9 @@ def test_recover_address_from_withdraw_message(
 
 
 def test_recover_address_from_balance_proof(
-    token_network_test_signatures: Contract, create_balance_proof: Callable, get_accounts: Callable
+    token_network_test_signatures: Contract,
+    create_balance_proof: Callable,
+    get_accounts: Callable,
 ) -> None:
     """TokenNetwork can recover the signer's address from a balance proof
 
@@ -85,7 +92,10 @@ def test_recover_address_from_balance_proof(
     balance_proof_wrong_token_network = create_balance_proof(channel_identifier, A)
 
     balance_proof_other_signer = create_balance_proof(
-        channel_identifier, A, signer=B, other_token_network=token_network_test_signatures
+        channel_identifier,
+        A,
+        signer=B,
+        other_token_network=token_network_test_signatures,
     )
 
     assert (

--- a/raiden_contracts/tests/utils/channel.py
+++ b/raiden_contracts/tests/utils/channel.py
@@ -11,7 +11,12 @@ from raiden_contracts.tests.utils.constants import EMPTY_ADDITIONAL_HASH, UINT25
 
 SettlementValues = namedtuple(
     "SettlementValues",
-    ["participant1_balance", "participant2_balance", "participant1_locked", "participant2_locked"],
+    [
+        "participant1_balance",
+        "participant2_balance",
+        "participant1_locked",
+        "participant2_locked",
+    ],
 )
 
 
@@ -120,9 +125,10 @@ def is_balance_proof_old(participant1: ChannelValues, participant2: ChannelValue
 
     total_available_deposit = get_total_available_deposit(participant1, participant2)
 
-    (participant1_balance, participant2_balance) = get_expected_after_settlement_unlock_amounts(
-        participant1, participant2
-    )
+    (
+        participant1_balance,
+        participant2_balance,
+    ) = get_expected_after_settlement_unlock_amounts(participant1, participant2)
 
     # Valid last balance proofs should ensure the following equality:
     if participant1_balance + participant2_balance == total_available_deposit:

--- a/raiden_contracts/utils/token_ops.py
+++ b/raiden_contracts/utils/token_ops.py
@@ -28,7 +28,8 @@ class TokenOperations:
         self.owner = private_key_to_address(self.private_key)
         self.wait = wait
         self.web3.middleware_onion.add(construct_sign_and_send_raw_middleware(self.private_key))
-        self.web3.eth.defaultAccount = self.owner
+        self.web3.eth.default_account = self.owner
+
         self.web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
     def is_valid_contract(self, token_address: ChecksumAddress) -> bool:
@@ -198,7 +199,10 @@ def transfer(
     type=click.STRING,
 )
 @click.option(
-    "--token-address", required=True, help="Address of the token contract", type=click.STRING
+    "--token-address",
+    required=True,
+    help="Address of the token contract",
+    type=click.STRING,
 )
 @click.option("--address", help="Address of account to get Balance", type=click.STRING)
 def balance(rpc_url: URI, token_address: str, address: str) -> None:

--- a/raiden_contracts/utils/versions.py
+++ b/raiden_contracts/utils/versions.py
@@ -1,37 +1,47 @@
+from enum import Enum
 from typing import Optional
 
-from semver import VersionInfo
+from semantic_version import SimpleSpec, Version
+
+
+class ContractFeature(Enum):
+    SERVICES = "services"
+    MAX_TOKEN_NETWORKS = "max_token_networks"
+    INITIAL_SERVICE_DEPOSIT = "initial_service_deposit"
+    MS_NEEDS_TOKENNETWORK_REGISTRY = "ms_needs_tokennetwork_registry"
+
+
+CONTRACT_FEATURE_VERSIONS = {
+    ContractFeature.SERVICES: SimpleSpec(">=0.8.0"),
+    ContractFeature.MAX_TOKEN_NETWORKS: SimpleSpec(">=0.9.0"),
+    ContractFeature.INITIAL_SERVICE_DEPOSIT: SimpleSpec(">=0.18.0"),
+    ContractFeature.MS_NEEDS_TOKENNETWORK_REGISTRY: SimpleSpec(">=0.22.0"),
+}
+
+
+def _matches_feature(feature: ContractFeature, version: Optional[str]) -> bool:
+    """Returns a bool indicating whether the passed version matches the minimum required
+    version for the given feature."""
+
+    if version is None:
+        # contracts_version == None means the stock version in development.
+        return True
+    return CONTRACT_FEATURE_VERSIONS[feature].match(Version(version))
 
 
 def contracts_version_with_max_token_networks(version: Optional[str]) -> bool:
-    if version is None:
-        # contracts_version == None means the stock version in development.
-        return True
-    return VersionInfo.parse(version).compare("0.9.0") >= 0
+    return _matches_feature(ContractFeature.MAX_TOKEN_NETWORKS, version)
 
 
 def contracts_version_provides_services(version: Optional[str]) -> bool:
-    if version is None:
-        # contracts_version == None means the stock version in development.
-        return True
-    return VersionInfo.parse(version).compare("0.8.0") >= 0
+    return _matches_feature(ContractFeature.SERVICES, version)
 
 
 def contracts_version_has_initial_service_deposit(version: Optional[str]) -> bool:
-    if version is None:
-        # contracts_versoin == None means the stock version in development.
-        return True
-    return VersionInfo.parse(version).compare("0.18.0") > 0
+    return _matches_feature(ContractFeature.INITIAL_SERVICE_DEPOSIT, version)
 
 
 def contracts_version_monitoring_service_takes_token_network_registry(
     version: Optional[str],
 ) -> bool:
-    """Returns true if the contracts_version's MonitoringService contracts
-
-    expects a TokenNetworkRegistry address as a constructor argument.
-    """
-    if version is None:
-        # stock version in `data`
-        return True
-    return VersionInfo.parse(version).compare("0.22.0") > 0
+    return _matches_feature(ContractFeature.MS_NEEDS_TOKENNETWORK_REGISTRY, version)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ click>=7.0
 rlp>=1.0.0
 coincurve>=8.0.0
 py-solc-x
-semver
+semantic_version>=2.8
 web3<6.0.0,>=5.7.0
 eth-abi<3.0.0,>=2.0.0
 eth-utils<2.0.0,>=1.8.4


### PR DESCRIPTION
### What this PR does

Fixes various deprecation warnings and removes `semver` in favor of `semantic_version` (which was already required through dependencies).

For some reason black decided to reformat some files.

### Why I'm making this PR

To fix warnings

### What's tricky about this PR (if any)

Nothing particular

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
    * if the PR adds or removes `require()` or `assert()`
        * [ ] add an entry in Changelog
        * [ ] open an issue in the client, light client, service repos so the change is reflected there
        * Just adding a message in `require()` doesn't require these steps.
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.