### PR TITLE
Remove the need for local solc install for users

### DIFF
--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -8,7 +8,6 @@ from eth_typing import ChecksumAddress, HexAddress
 from eth_utils import encode_hex, is_address, to_checksum_address
 from eth_utils.units import units
 from hexbytes import HexBytes
-from solcx import link_code
 from web3 import Web3
 from web3.contract import Contract, ContractFunction
 from web3.middleware import construct_sign_and_send_raw_middleware
@@ -35,6 +34,7 @@ from raiden_contracts.contract_manager import (
 from raiden_contracts.contract_source_manager import ContractSourceManager, contracts_source_path
 from raiden_contracts.deploy.contract_verifier import ContractVerifier
 from raiden_contracts.utils.file_ops import load_json_from_path
+from raiden_contracts.utils.linking import link_code
 from raiden_contracts.utils.signature import private_key_to_address
 from raiden_contracts.utils.transaction import check_successful_tx
 from raiden_contracts.utils.type_aliases import ChainID, PrivateKey

--- a/raiden_contracts/tests/fixtures/contracts.py
+++ b/raiden_contracts/tests/fixtures/contracts.py
@@ -4,13 +4,13 @@ from typing import Any, Callable, Dict, Tuple
 import pytest
 from eth_tester.exceptions import TransactionFailed
 from eth_typing import HexAddress
-from solcx import link_code
 from web3 import Web3
 from web3.contract import Contract
 
 from raiden_contracts.contract_manager import ContractManager
 from raiden_contracts.tests.utils.blockchain import mine_blocks
 from raiden_contracts.tests.utils.constants import DEPLOYER_ADDRESS
+from raiden_contracts.utils.linking import link_code
 
 log = logging.getLogger(__name__)
 

--- a/raiden_contracts/utils/linking.py
+++ b/raiden_contracts/utils/linking.py
@@ -22,3 +22,14 @@ def link_bytecode(
         get_placeholder_for_library_identifier(library_identifier),
         normalized_address,
     )
+
+
+def link_code(unlinked_bytecode: str, libs: dict) -> str:
+    """Drop-in replacement for solcx.link_code based on link_code
+
+    The advantage is that no install solc is required.
+    """
+    for lib, address in libs.items():
+        unlinked_bytecode = link_bytecode(unlinked_bytecode, lib, address)
+
+    return unlinked_bytecode


### PR DESCRIPTION
Packages that use raiden-contracts' fixtures don't need a solc
installation, anymore. This is achieved by doing the linking step in
pure python.