### PR TITLE
Fix setuptools setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ config = {
     "license": "MIT",
     "keywords": "raiden ethereum blockchain",
     "install_requires": requirements,
-    "setup_requires": _get_single_requirement(requirements, "py-solc"),
+    "setup_requires": requirements,
     "packages": find_packages(),
     "include_package_data": True,
     "classifiers": [


### PR DESCRIPTION
This PR will fix the `setup.py` installation method by providing the necessary dependencies for the verify_contracts command that is employed during setup.
(see https://github.com/raiden-network/raiden-services/pull/951#issuecomment-814959179)