### PR TITLE
Fix deployment check for old deployments

### DIFF
--- a/raiden_contracts/deploy/contract_verifier.py
+++ b/raiden_contracts/deploy/contract_verifier.py
@@ -203,7 +203,10 @@ class ContractVerifier:
         blockchain_bytecode = self.web3.eth.get_code(contract_instance.address).hex()
         compiled_bytecode = self.contract_manager.get_runtime_hexcode(contract_name)
 
-        if contract_name == CONTRACT_TOKEN_NETWORK_REGISTRY:
+        if (
+            contract_name == CONTRACT_TOKEN_NETWORK_REGISTRY
+            and LIBRARY_TOKEN_NETWORK_UTILS in contracts
+        ):
             # We need to link the libs into the contract bytecode.
             # As this is run in the tests in fake file systems, do poor mans linking here
             compiled_bytecode = link_bytecode(

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -318,6 +318,21 @@ def test_deploy_script_raiden(
         )
 
 
+@pytest.mark.slow
+def test_deploy_script_raiden_0_37_0(
+    deployer_0_37_0: ContractDeployer,
+) -> None:
+    """Checks that `verify_deployment_data` works fine with older contracts."""
+    data = deployer_0_37_0.deploy_raiden_contracts(
+        max_num_of_token_networks=1,
+        reuse_secret_registry_from_deploy_file=None,
+        settle_timeout_min=DEPLOY_SETTLE_TIMEOUT_MIN,
+        settle_timeout_max=DEPLOY_SETTLE_TIMEOUT_MAX,
+    )
+
+    deployer_0_37_0.verify_deployment_data(deployment_data=data)
+
+
 def test_deploy_raiden_reuse_secret_registry(
     deployer: ContractDeployer, deployed_raiden_info: DeployedContracts
 ) -> None:


### PR DESCRIPTION
### What this PR does

Fix deployment check for old deployments

### Why I'm making this PR

I ran into this while working on https://github.com/raiden-network/light-client/issues/2699

### What's tricky about this PR (if any)

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
    * if the PR adds or removes `require()` or `assert()`
        * [ ] add an entry in Changelog
        * [ ] open an issue in the client, light client, service repos so the change is reflected there
        * Just adding a message in `require()` doesn't require these steps.
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.