### PR TITLE
Add support for python 3.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
     - name: Test
       run: |
         source ./venv/bin/activate
-        pytest --cov=./ raiden_contracts/tests/ -v -n 4 --cov-config setup.cfg
+        pytest --cov=./ raiden_contracts/tests/ -v -n 2 --cov-config setup.cfg
     - name: Codecov
       run: |
         source ./venv/bin/activate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Documents changes that result in:
 - API changes in the package (externally used constants, externally used utilities and scripts)
 - important bug fixes between releases
 
+- [#1456](https://github.com/raiden-network/raiden-contracts/pull/1456) Add Python 3.9 support
+
 ## [0.37.5]
 - Add missing deployment files for the unstable deployment done in 0.37.2.
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Raiden Network Smart Contracts
 Prerequisites
 -------------
 
--  Python 3.7 or 3.8
+-  Python 3.7, 3.8 or 3.9
 -  https://pip.pypa.io/en/stable/
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ config = {
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     "entry_points": {"console_scripts": ["deploy = raiden_contracts.deploy.__main__:main"]},
     "cmdclass": {


### PR DESCRIPTION
### What this PR does

Signal support for Python 3.9

### Why I'm making this PR

### What's tricky about this PR (if any)

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
    * if the PR adds or removes `require()` or `assert()`
        * [ ] add an entry in Changelog
        * [ ] open an issue in the client, light client, service repos so the change is reflected there
        * Just adding a message in `require()` doesn't require these steps.
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.