### PR TITLE
Use RDN as default token for service payments

### DIFF
--- a/raiden_contracts/deploy/__main__.py
+++ b/raiden_contracts/deploy/__main__.py
@@ -250,7 +250,7 @@ def raiden(
 @common_options
 @click.option(
     "--token-address",
-    default=None,
+    default="0x255Aa6DF07540Cb5d3d297f0D0D4D84cb52bc8e6",
     callback=validate_address,
     help="Address of token used to pay for the services (MS, PFS).",
 )


### PR DESCRIPTION
We promised to use RDN during the token sale. We can't prevent anyone
from deploying the contracts with a different token selected, but we can
at least choose RDN as default.

Closes https://github.com/raiden-network/raiden-contracts/issues/1463.