### PR TITLE
raiden_contracts: change CONTRACTS_VERSION to 0.38.0

### DIFF
--- a/raiden_contracts/constants.py
+++ b/raiden_contracts/constants.py
@@ -9,6 +9,7 @@ from raiden_contracts.utils.type_aliases import ChainID, Locksroot
 
 # The last digit is supposed to be zero always. See `RELEASE.rst`.
 CONTRACTS_VERSION = "0.38.0"
+BESPIN_VERSION = "0.37.0"
 ALDERAAN_VERSION = "0.37.0"
 
 PRECOMPILED_DATA_FIELDS = ["abi", "bin", "bin-runtime", "metadata"]

--- a/raiden_contracts/constants.py
+++ b/raiden_contracts/constants.py
@@ -8,7 +8,7 @@ from eth_utils import keccak
 from raiden_contracts.utils.type_aliases import ChainID, Locksroot
 
 # The last digit is supposed to be zero always. See `RELEASE.rst`.
-CONTRACTS_VERSION = "0.37.0"
+CONTRACTS_VERSION = "0.38.0"
 ALDERAAN_VERSION = "0.37.0"
 
 PRECOMPILED_DATA_FIELDS = ["abi", "bin", "bin-runtime", "metadata"]


### PR DESCRIPTION
### What this PR does
Change the CONTRACTS_VERSION to 0.38.0.

### Why I'm making this PR
So that raiden uses the latest released contract code.

:warning: This PR should not be merged until we are reasonably sure that the newer contracts will not break tests in the `raiden` repository.