### PR TITLE
Arbitrum adaptations

### DIFF
--- a/raiden_contracts/constants.py
+++ b/raiden_contracts/constants.py
@@ -150,13 +150,13 @@ ID_TO_CHAINNAME: Dict[ChainID, str] = {
     ChainID(5): "goerli",
     ChainID(42): "kovan",
     ChainID(627): "smoketest",
+    ChainID(42161): "arbitrum-one",
+    ChainID(421611): "arbitrum-rinkeby",
 }
 
 CHAINNAME_TO_ID: Dict[str, ChainID] = {name: id for id, name in ID_TO_CHAINNAME.items()}
 
 # ContractNames
-
-
 ContractListEntry = namedtuple("ContractListEntry", "module name")
 
 CONTRACT_LIST = [

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -72,9 +72,8 @@ class ContractDeployer(ContractVerifier):
             gas_limit = Wei(1_000_000_000)
             gas_price = Wei(int(units["gwei"]))
             LOG.info(
-                "Adapting transaction parameters for arbitrum",
-                gas_limit=gas_limit,
-                gas_price=gas_price,
+                "Adapting transaction parameters for arbitrum. "
+                f"gas limit: {gas_limit}, gas_price: {gas_price}"
             )
             self.transaction["gas"] = gas_limit
             self.transaction["gasPrice"] = gas_price
@@ -294,6 +293,7 @@ class ContractDeployer(ContractVerifier):
                 token_address
             ).call()
             time.sleep(2)
+
         LOG.debug(f"TokenNetwork address: {token_network_address}")
         return dict(
             token_network_address=token_network_address,

--- a/raiden_contracts/deploy/contract_verifier.py
+++ b/raiden_contracts/deploy/contract_verifier.py
@@ -173,9 +173,10 @@ class ContractVerifier:
         contracts = deployment_data["contracts"]
 
         # Check blockchain transaction hash & block information
-        receipt = self.web3.eth.get_transaction_receipt(
+        receipt = self.web3.eth.wait_for_transaction_receipt(
             contracts[contract_name]["transaction_hash"]
         )
+
         if receipt["blockNumber"] != contracts[contract_name]["block_number"]:
             raise RuntimeError(
                 f'We have block_number {contracts[contract_name]["block_number"]} in the '

--- a/raiden_contracts/tests/test_deploy_script.py
+++ b/raiden_contracts/tests/test_deploy_script.py
@@ -830,7 +830,8 @@ def test_deploy_token_no_balance(privkey_file: IO) -> None:
             mock_deployer.assert_not_called()
 
 
-def test_deploy_token_with_balance(privkey_file: IO) -> None:
+@patch.object(ContractDeployer, "_maybe_set_arbitrum_settings")
+def test_deploy_token_with_balance(mock_arb_config: MagicMock, privkey_file: IO) -> None:
     """Call deploy token command with a private key with some balance"""
     with patch.object(
         ContractDeployer,
@@ -843,6 +844,7 @@ def test_deploy_token_with_balance(privkey_file: IO) -> None:
             result = runner.invoke(token, deploy_token_arguments(privkey=privkey_file.name))
             assert result.exit_code == 0
             mock_deployer.assert_called_once()
+            mock_arb_config.assert_called_once()
 
 
 def deploy_raiden_arguments(
@@ -871,12 +873,14 @@ def deploy_raiden_arguments(
 
 
 @patch.object(ContractDeployer, "deploy_raiden_contracts")
+@patch.object(ContractDeployer, "_maybe_set_arbitrum_settings")
 @patch.object(ContractVerifier, "store_and_verify_deployment_info_raiden")
 @pytest.mark.parametrize("contracts_version", [None, ALDERAAN_VERSION])
 @pytest.mark.parametrize("reuse_secret_registry", [False, True])
 def test_deploy_raiden(
     mock_deploy: MagicMock,
     mock_verify: MagicMock,
+    mock_arb_config: MagicMock,
     contracts_version: Optional[str],
     reuse_secret_registry: bool,
     privkey_file: IO,
@@ -897,10 +901,13 @@ def test_deploy_raiden(
         assert result.exit_code == 0
         mock_deploy.assert_called_once()
         mock_verify.assert_called_once()
+        mock_arb_config.assert_called_once()
 
 
 @patch.object(ContractDeployer, "register_token_network")
+@patch.object(ContractDeployer, "_maybe_set_arbitrum_settings")
 def test_register_script(
+    mock_arb_config: MagicMock,
     mock_deploy: MagicMock,
     deployed_raiden_info: DeployedContracts,
     privkey_file: IO,
@@ -936,11 +943,17 @@ def test_register_script(
             )
             assert result.exit_code == 0
             mock_deploy.assert_called_once()
+            mock_arb_config.assert_called_once()
             add_tn_info.assert_called_once()
 
 
 @patch.object(ContractDeployer, "register_token_network")
-def test_register_script_without_token_network(mock_deploy: MagicMock, privkey_file: IO) -> None:
+@patch.object(ContractDeployer, "_maybe_set_arbitrum_settings")
+def test_register_script_without_token_network(
+    mock_arb_config: MagicMock,
+    mock_deploy: MagicMock,
+    privkey_file: IO,
+) -> None:
     """Calling deploy raiden command"""
     with patch.object(Eth, "get_balance", return_value=1):
         runner = CliRunner()
@@ -969,12 +982,14 @@ def test_register_script_without_token_network(mock_deploy: MagicMock, privkey_f
             "Add --token-network-registry-address <address>.",
         )
         mock_deploy.assert_not_called()
+        mock_arb_config.assert_called_once()
 
 
 @patch.object(ContractDeployer, "deploy_raiden_contracts")
+@patch.object(ContractDeployer, "_maybe_set_arbitrum_settings")
 @patch.object(ContractDeployer, "verify_deployment_data")
 def test_deploy_raiden_save_info_false(
-    mock_deploy: MagicMock, mock_verify: MagicMock, privkey_file: IO
+    mock_deploy: MagicMock, mock_arb_config: MagicMock, mock_verify: MagicMock, privkey_file: IO
 ) -> None:
     """Calling deploy raiden command with --save_info False"""
     with patch.object(Eth, "get_balance", return_value=1):
@@ -992,6 +1007,7 @@ def test_deploy_raiden_save_info_false(
         assert result.exit_code == 0
         mock_deploy.assert_called_once()
         mock_verify.assert_called_once()
+        mock_arb_config.assert_called_once()
 
 
 def deploy_services_arguments(
@@ -1039,8 +1055,11 @@ def deploy_services_arguments(
 
 
 @patch.object(ContractDeployer, "deploy_service_contracts")
+@patch.object(ContractDeployer, "_maybe_set_arbitrum_settings")
 @patch.object(ContractVerifier, "store_and_verify_deployment_info_services")
-def test_deploy_services(mock_deploy: MagicMock, mock_verify: MagicMock, privkey_file: IO) -> None:
+def test_deploy_services(
+    mock_deploy: MagicMock, mock_arb_config: MagicMock, mock_verify: MagicMock, privkey_file: IO
+) -> None:
     """Calling deploy raiden command"""
     with patch.object(Eth, "get_balance", return_value=1):
         runner = CliRunner()
@@ -1057,6 +1076,7 @@ def test_deploy_services(mock_deploy: MagicMock, mock_verify: MagicMock, privkey
         assert result.exit_code == 0
         mock_deploy.assert_called_once()
         mock_verify.assert_called_once()
+        mock_arb_config.assert_called_once()
 
 
 def test_deploy_old_services(privkey_file: IO) -> None:
@@ -1078,9 +1098,10 @@ def test_deploy_old_services(privkey_file: IO) -> None:
 
 
 @patch.object(ContractDeployer, "deploy_service_contracts")
+@patch.object(ContractDeployer, "_maybe_set_arbitrum_settings")
 @patch.object(ContractVerifier, "store_and_verify_deployment_info_services")
 def test_deploy_services_with_controller(
-    mock_deploy: MagicMock, mock_verify: MagicMock, privkey_file: IO
+    mock_deploy: MagicMock, mock_arb_config: MagicMock, mock_verify: MagicMock, privkey_file: IO
 ) -> None:
     """Calling deploy raiden command"""
     with patch.object(Eth, "get_balance", return_value=1):
@@ -1098,12 +1119,14 @@ def test_deploy_services_with_controller(
         assert result.exit_code == 0
         mock_deploy.assert_called_once()
         mock_verify.assert_called_once()
+        mock_arb_config.assert_called_once()
 
 
 @patch.object(ContractDeployer, "deploy_service_contracts")
+@patch.object(ContractDeployer, "_maybe_set_arbitrum_settings")
 @patch.object(ContractDeployer, "verify_service_contracts_deployment_data")
 def test_deploy_services_save_info_false(
-    mock_deploy: MagicMock, mock_verify: MagicMock, privkey_file: IO
+    mock_deploy: MagicMock, mock_arb_config: MagicMock, mock_verify: MagicMock, privkey_file: IO
 ) -> None:
     """Calling deploy raiden command with --save_info False"""
     with patch.object(Eth, "get_balance", return_value=1):
@@ -1121,6 +1144,7 @@ def test_deploy_services_save_info_false(
         assert result.exit_code == 0
         mock_deploy.assert_called_once()
         mock_verify.assert_called_once()
+        mock_arb_config.assert_called_once()
 
 
 @patch.object(ContractVerifier, "verify_deployed_contracts_in_filesystem")

--- a/raiden_contracts/tests/test_transaction.py
+++ b/raiden_contracts/tests/test_transaction.py
@@ -9,29 +9,29 @@ from raiden_contracts.utils.transaction import check_successful_tx
 
 def test_check_successful_tx_with_status_zero() -> None:
     web3_mock = Mock()
-    web3_mock.eth.get_transaction_receipt.return_value = {"blockNumber": 300, "status": 0}
+    web3_mock.eth.wait_for_transaction_receipt.return_value = {"blockNumber": 300, "status": 0}
     txid = HexBytes("abcdef")
     with pytest.raises(ValueError):
         check_successful_tx(web3=web3_mock, txid=txid)
-    web3_mock.eth.get_transaction_receipt.assert_called_with(txid)
+    web3_mock.eth.wait_for_transaction_receipt.assert_called_with(txid, timeout=180)
     web3_mock.eth.get_transaction.assert_called_with(txid)
 
 
 def test_check_successful_tx_with_nonexistent_status() -> None:
     """check_successful_tx() with a receipt without status field should raise a KeyError"""
     web3_mock = Mock()
-    web3_mock.eth.get_transaction_receipt.return_value = {"blockNumber": 300}
+    web3_mock.eth.wait_for_transaction_receipt.return_value = {"blockNumber": 300}
     txid = HexBytes("abcdef")
     with pytest.raises(KeyError):
         check_successful_tx(web3=web3_mock, txid=txid)
-    web3_mock.eth.get_transaction_receipt.assert_called_with(txid)
+    web3_mock.eth.wait_for_transaction_receipt.assert_called_with(txid, timeout=180)
     web3_mock.eth.get_transaction.assert_called_with(txid)
 
 
 def test_check_successful_tx_with_gas_completely_used() -> None:
     web3_mock = Mock()
     gas = 30000
-    web3_mock.eth.get_transaction_receipt.return_value = {
+    web3_mock.eth.wait_for_transaction_receipt.return_value = {
         "blockNumber": 300,
         "status": 1,
         "gasUsed": gas,
@@ -40,7 +40,7 @@ def test_check_successful_tx_with_gas_completely_used() -> None:
     txid = HexBytes("abcdef")
     with pytest.raises(ValueError):
         check_successful_tx(web3=web3_mock, txid=txid)
-    web3_mock.eth.get_transaction_receipt.assert_called_with(txid)
+    web3_mock.eth.wait_for_transaction_receipt.assert_called_with(txid, timeout=180)
     web3_mock.eth.get_transaction.assert_called_with(txid)
 
 
@@ -48,10 +48,10 @@ def test_check_successful_tx_successful_case() -> None:
     web3_mock = Mock()
     gas = 30000
     receipt = TxReceipt({"blockNumber": 300, "status": 1, "gasUsed": gas - 10})  # type: ignore
-    web3_mock.eth.get_transaction_receipt.return_value = receipt
+    web3_mock.eth.wait_for_transaction_receipt.return_value = receipt
     txinfo = TxData({"gas": Wei(gas)})
     web3_mock.eth.get_transaction.return_value = txinfo
     txid = HexBytes("abcdef")
     assert check_successful_tx(web3=web3_mock, txid=txid) == (receipt, txinfo)
-    web3_mock.eth.get_transaction_receipt.assert_called_with(txid)
+    web3_mock.eth.wait_for_transaction_receipt.assert_called_with(txid, timeout=180)
     web3_mock.eth.get_transaction.assert_called_with(txid)

--- a/raiden_contracts/utils/transaction.py
+++ b/raiden_contracts/utils/transaction.py
@@ -1,9 +1,7 @@
-from typing import Optional, Tuple
+from typing import Tuple
 
 from hexbytes import HexBytes
 from web3 import Web3
-from web3._utils.threads import Timeout
-from web3.exceptions import TransactionNotFound
 from web3.types import TxData, TxReceipt
 
 
@@ -13,7 +11,7 @@ def check_successful_tx(
     """See if transaction went through (Solidity code did not throw).
     :return: Transaction receipt and transaction info
     """
-    receipt = wait_for_transaction_receipt(web3=web3, txid=txid, timeout=timeout)
+    receipt = web3.eth.wait_for_transaction_receipt(txid, timeout=timeout)
     if receipt is None:
         raise RuntimeError("Could not obtain a transaction receipt.")
     txinfo = web3.eth.get_transaction(txid)
@@ -27,17 +25,3 @@ def check_successful_tx(
     if txinfo["gas"] == receipt["gasUsed"]:
         raise ValueError(f'Gas is completely used ({txinfo["gas"]}). Failure?')
     return receipt, txinfo
-
-
-def wait_for_transaction_receipt(
-    web3: Web3, txid: HexBytes, timeout: int = 180
-) -> Optional[TxReceipt]:
-    receipt = None
-    with Timeout(timeout) as time:
-        while not receipt or not receipt["blockNumber"]:  # pylint: disable=E1136
-            try:
-                receipt = web3.eth.get_transaction_receipt(txid)
-            except TransactionNotFound:
-                time.sleep(5)
-
-    return receipt


### PR DESCRIPTION
### What this PR does

Part of #1539 

Adapt the contracts repo to work with Arbitrum based rollups.

So far:
- Add Arbitrum test and mainnet chain ids
- Adapt the transaction parameters when deploying contracts on arbitrum

### Why I'm making this PR

### What's tricky about this PR (if any)

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
    * if the PR adds or removes `require()` or `assert()`
        * [ ] add an entry in Changelog
        * [ ] open an issue in the client, light client, service repos so the change is reflected there
        * Just adding a message in `require()` doesn't require these steps.
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.