### PR TITLE
Revert

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         if [ ! -x venv ]; then python3 -m venv venv; fi
         source ./venv/bin/activate
-        python -m pip install --upgrade pip=="21.2.3" wheel codecov
+        python -m pip install --upgrade pip wheel codecov
         make install-dev
         make verify_contracts
     - name: Lint

--- a/raiden_contracts/tests/test_print_gas.py
+++ b/raiden_contracts/tests/test_print_gas.py
@@ -374,7 +374,7 @@ def print_gas_monitoring_service(
         ),
         {"from": A},
     )
-    mine_blocks(web3, 4)
+    mine_blocks(web3, 6)
 
     # MS calls `MSC::monitor()` using c1's BP and reward proof
     txn_hash = call_and_transact(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,6 +21,5 @@ requests_mock
 isort==5.10.1
 pipdeptree
 six~=1.16
-pip==21.2.4
 twine
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ rlp>=1.0.0
 coincurve>=8.0.0
 py-solc-x
 semantic_version>=2.8
-web3~=5.24
+web3==5.24
 eth-abi<3.0.0,>=2.0.0
 eth-utils>=1.8.4,<3.0.0
 eth-typing>=2.2.1,<4.0.0


### PR DESCRIPTION
### What this PR does

Revert e5b6837f and 76101f5f.

### Why I'm making this PR

Even though the PRs were green, CI wasn't happen with them. So let's revert and find out why.

### What's tricky about this PR (if any)

----

Any reviewer can check these:

* [ ] If the PR is fixing a bug or adding a feature, add an entry to CHANGELOG.md.
* [ ] If the PR changed a Solidity source, run `make compile_contracts` and add the resulting `raiden_contracts/data/contracts.json` in the PR.
* [ ] If the PR is changing documentation only, add `[skip ci]` in the commit message so Travis does not waste time.
    * [ ] But, if the PR changes comments in a Solidity source, do not add `[skip ci]` and let Travis check the hash of the source.
* [ ] In Python, use keyword arguments
* [ ] Squash unnecessary commits
* [ ] Comment commits
* [ ] Follow naming conventions
    * `solidityFunction`
    * `_solidity_argument`
    * `solidity_variable`
    * `python_variable`
    * `PYTHON_CONSTANT`
* [ ] Follow the Signature Convention in [CONTRIBUTING.md](./CONTRIBUTING.md)
* For each new contract
    * [ ] The deployment script deploys the new contract.
    * [ ] `etherscan_verify.py` runs on the new contract.
* Bookkeep
    * [ ] The gas cost of new functions are stored in `gas.json`.
* Solidity specific conventions
    * [ ] Document arguments of functions in natspec
    * [ ] Care reentrancy problems
    * if the PR adds or removes `require()` or `assert()`
        * [ ] add an entry in Changelog
        * [ ] open an issue in the client, light client, service repos so the change is reflected there
        * Just adding a message in `require()` doesn't require these steps.
* [ ] When you catch a require() failure in Solidity, look for a specific error message like `pytest.raises(TransactionFailed, match="error message"):`

And before "merge" all checkboxes have to be checked.  If you find redundant points, remove them.