### PR TITLE
Add missing `mypy_extensions`  requirement

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.40.0
+current_version = 0.40.1
 commit = True
 tag = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Documents changes that result in:
 - API changes in the package (externally used constants, externally used utilities and scripts)
 - important bug fixes between releases
 
+## [0.40.1]
+
+- [#1576](https://github.com/raiden-network/raiden-contracts/pull/1576) Add missing `mypy_extensions` requirement
+
 ## [0.40.0]
 
 - [#1517](https://github.com/raiden-network/raiden-contracts/pull/1517), [#1522](https://github.com/raiden-network/raiden-contracts/pull/1522) Upgrade to solidity 0.8 series

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ web3==5.24
 eth-abi<3.0.0,>=2.0.0
 eth-utils>=1.8.4,<3.0.0
 eth-typing>=2.2.1,<4.0.0
+mypy_extensions<0.5.0,>0.4.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import Command
 from setuptools.command.build_py import build_py
 
 DESCRIPTION = "Raiden contracts library and utilities"
-VERSION = "0.40.0"
+VERSION = "0.40.1"
 
 
 def read_requirements(path: str) -> List[str]:


### PR DESCRIPTION
### What this PR does

While working on the raiden-service-bundle I ran into this>:
```
synapse_1            |   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
synapse_1            |   File "/synapse-venv/lib/python3.9/site-packages/raiden_synapse_modules/presence_router/pfs.py", line 21, in <module>
synapse_1            |     from raiden_contracts.contract_manager import get_contracts_deployment_info
synapse_1            |   File "/synapse-venv/lib/python3.9/site-packages/raiden_contracts/contract_manager.py", line 11, in <module>
synapse_1            |     from mypy_extensions import TypedDict
synapse_1            | ModuleNotFoundError: No module named 'mypy_extensions'
````
