### PR TITLE
chore: Prepare 0.40.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.40.1
+current_version = 0.40.2
 commit = True
 tag = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Documents changes that result in:
 - API changes in the package (externally used constants, externally used utilities and scripts)
 - important bug fixes between releases
 
+## [0.40.2]
+
+- [#1584](https://github.com/raiden-network/raiden-contracts/pull/1584) Upgrade `web3` and `eth-tester` dependencies
+
 ## [0.40.1]
 
 - [#1576](https://github.com/raiden-network/raiden-contracts/pull/1576) Add missing `mypy_extensions` requirement

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import Command
 from setuptools.command.build_py import build_py
 
 DESCRIPTION = "Raiden contracts library and utilities"
-VERSION = "0.40.1"
+VERSION = "0.40.2"
 
 
 def read_requirements(path: str) -> List[str]:


### PR DESCRIPTION
https://github.com/raiden-network/raiden-services/pull/1131 is blocked by these deps, so lets create a new release.