### PR TITLE
improve gas handling for Arbitrum based networks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -231,6 +231,11 @@ Deployment information is stored in a ``deployment_[CHAIN_NAME].json`` file corr
     # Based on the network id, the script verifies the corresponding deployment_[CHAIN_NAME].json file
     # using the chain name-id mapping from constants.py
 
+Deployment on an Arbitrum based network
+-----------------------
+
+In case the target network is based on Arbitrum, it needs some extra care in terms of the gas. Gas works differently here and therefore the associated commandline parameter require different values. First of all the ``--gas-limit`` parameter should not be set. This gets done automatically and in adaption to Arbitrum. Second, the ``--gas-price`` parameter has a different effect. On Arbitrum this defines the highest price the transactor is willed to pay. This means up-on execution the Arbitrum node will reduce the price automatically to the current price and no more. So this can be seen as ``--max-gas-price``. The amount has no impact on how fast the transaction gets through. The default `5 Gwei` should be enough for most cases. To be sure, just check the current gas price on an offical Arbitrum block explorer. In case the value is too low, the Arbitrum node will just reject the transaction with a respective error message.
+
 
 Verification with Etherscan
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/raiden_contracts/deploy/contract_deployer.py
+++ b/raiden_contracts/deploy/contract_deployer.py
@@ -88,15 +88,8 @@ class ContractDeployer(ContractVerifier):
         # Gas usage on Arbitrum is different that EVM gas usage, so increase the limit here
         if self.is_connected_to_arbitrum_chain:
             gas_limit = Wei(1_000_000_000)
-            gas_price = Wei(int(units["gwei"]))
-
             self.transaction["gas"] = gas_limit
-            self.transaction["gasPrice"] = gas_price
-
-            LOG.info(
-                "Adapting transaction parameters for arbitrum. "
-                f"gas limit: {gas_limit}, gas_price: {gas_price}"
-            )
+            LOG.info(f"Adapting transaction parameters for Arbitrum: gas_limit = {gas_limit}")
 
     def deploy(self, contract_name: str, args: Optional[List] = None) -> TxReceipt:
         if args is None:


### PR DESCRIPTION
Closes #1608 

First of all, it is not necessary to programmatically set a fixed gas price value when detecting an Arbitrum network. The gas price gets already set by a commandline parameter and does not need any further doing. The default 5 Gwei
are enough for the current prices (test network). Else the user can/must set the value higher.

As the deployment tools are meant to run by hand and usually a developer of the team, it is not necessary to add any special gas price strategies as we do for the Raiden services. But to support the correct/better usage, the deployment documentation got extended for Arbitrum.