### PR TITLE
add API endpoint to verify Arbitrum One deployment

### DIFF
--- a/raiden_contracts/deploy/etherscan_verify.py
+++ b/raiden_contracts/deploy/etherscan_verify.py
@@ -103,6 +103,7 @@ api_of_chain_id = {
     4: "https://api-rinkeby.etherscan.io/api",
     5: "https://api-goerli.etherscan.io/api",
     42: "https://api-kovan.etherscan.io/api",
+    42161: "https://api.arbiscan.io/api",
 }
 
 


### PR DESCRIPTION
Add API endpoint to verify Arbitrum One deployment.

I used it already and it works in practice. You can check the latest Arbitrum One contract addresses in `data/` on Arbiscan.